### PR TITLE
Link siren to light controls

### DIFF
--- a/src/objects/PoliceCar.js
+++ b/src/objects/PoliceCar.js
@@ -20,7 +20,7 @@ export class PoliceCar extends Phaser.GameObjects.Container {
 
     // Lights & siren
     this.lightsOn = false;
-    this.sirenOn = false;
+    this.sirenOn = false; // tracks audio state
     this._lightTimer = 0;
     this._lightPhase = 0; // 0 = blue, 1 = red
 
@@ -50,16 +50,18 @@ export class PoliceCar extends Phaser.GameObjects.Container {
     this.lightsOn = forceState === null ? !this.lightsOn : !!forceState;
     if (this.lightsOn) {
       this.headlights.forEach(l => l.setIntensity(1));
+      this._setSiren(true);
     } else {
       this.sprite.setTexture('police-off');
       this.headlights.forEach(l => l.setIntensity(0));
       this.sirenLights.forEach(l => l.setIntensity(0));
+      this._setSiren(false);
     }
   }
 
-  toggleSiren(forceState = null) {
+  _setSiren(on) {
     const prev = this.sirenOn;
-    this.sirenOn = forceState === null ? !this.sirenOn : !!forceState;
+    this.sirenOn = !!on;
     if (this.sirenOn && !prev) {
       this.scene.sound.stopByKey('siren');
       const s = this.scene.sound.add('siren', { loop: true, volume: 0.35 });

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -76,12 +76,10 @@ export class GameScene extends Phaser.Scene {
       left2: Phaser.Input.Keyboard.KeyCodes.LEFT,
       right2: Phaser.Input.Keyboard.KeyCodes.RIGHT,
       space: Phaser.Input.Keyboard.KeyCodes.SPACE,
-      L: Phaser.Input.Keyboard.KeyCodes.L,
-      H: Phaser.Input.Keyboard.KeyCodes.H
+      L: Phaser.Input.Keyboard.KeyCodes.L
     });
 
     this.keys.L.on('down', () => this.car.toggleLights());
-    this.keys.H.on('down', () => this.car.toggleSiren());
 
     // Listen to UI scene for virtual controls
     this.registry.set('mobileInputs', { throttle:0, steer:0, brake:0, handbrake:0 });

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -1,5 +1,5 @@
 // src/scenes/UIScene.js
-// Minimal on-screen controls for mobile + quick buttons for lights/siren.
+// Minimal on-screen controls for mobile + quick button for lights.
 import { GAME_CONFIG } from '../config.js';
 
 export class UIScene extends Phaser.Scene {
@@ -15,7 +15,7 @@ export class UIScene extends Phaser.Scene {
       this.createButtons();
     }
 
-    // Toggle buttons for lights/siren (also visible on desktop for convenience)
+    // Toggle button for lights (also visible on desktop for convenience)
     const makeBtn = (label, x, y, cb) => {
       const btn = this.add.text(x, y, label, { fontSize: 18, fontFamily: 'system-ui, -apple-system, sans-serif', padding:{x:10,y:6}, backgroundColor: '#222', color:'#fff' })
         .setScrollFactor(0)
@@ -26,12 +26,10 @@ export class UIScene extends Phaser.Scene {
       return btn;
     };
     this.lightBtn = makeBtn('Lights (L)', 120, 40, () => this.events.emit('toggleLights'));
-    this.sirenBtn = makeBtn('Siren (H)', 270, 40, () => this.events.emit('toggleSiren'));
 
     // Bridge to GameScene to call methods on the car
     const game = this.scene.get('Game');
     this.events.on('toggleLights', () => game.car.toggleLights());
-    this.events.on('toggleSiren', () => game.car.toggleSiren());
   }
 
   createButtons() {


### PR DESCRIPTION
## Summary
- Tie siren audio to light toggling and drop public siren toggle
- Remove keyboard and UI bindings for standalone siren control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8571a230c8329850d39e5159d82e3