### PR TITLE
feat: add tilemap roads

### DIFF
--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -7,6 +7,8 @@ export class BootScene extends Phaser.Scene {
     this.load.image('police-off', 'assets/police-off.png');
     this.load.image('police-blue', 'assets/police-blue.png');
     this.load.image('police-red', 'assets/police-red.png');
+    this.load.image('grass', 'assets/grass.jpg');
+    this.load.image('road', 'assets/road.jpg');
 
     // Audio (optional for local file usage; only starts after user gesture)
     this.load.audio('siren', ['assets/audio/siren.mp3']);


### PR DESCRIPTION
## Summary
- preload grass and road textures in boot scene
- create tilemap-based world with simple road network
- clamp car and camera to tilemap bounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86a12bde08329930d4a2ae367f9a5