### PR TITLE
Add MIDI background track with fallback playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
   </div>
   <!-- Phaser 3 -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.min.js"></script>
+  <!-- MIDI.js for MIDI playback fallback -->
+  <script src="https://cdn.jsdelivr.net/gh/mudcube/MIDI.js@master/build/MIDI.min.js"></script>
   <!-- Game modules -->
   <script type="module" src="./src/main.js"></script>
   <script>

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -12,6 +12,7 @@ export class BootScene extends Phaser.Scene {
 
     // Audio (optional for local file usage; only starts after user gesture)
     this.load.audio('siren', ['assets/audio/siren.mp3']);
+    this.load.audio('bgm', 'assets/AUD_AP0356.mid');
   }
   create() {
     this.scene.start('Game');

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -38,6 +38,16 @@ export class GameScene extends Phaser.Scene {
     this.cameras.main.startFollow(this.car, true, 0.12, 0.12);
     this.cameras.main.setZoom(1); // tweaked automatically by Resize handler
 
+    // Background music
+    if (this.cache.audio.exists('bgm')) {
+      this.bgm = this.sound.add('bgm', { loop: true, volume: 0.5 });
+      this.bgm.play();
+      this.events.once('shutdown', () => this.bgm.stop());
+    } else if (window.MIDIjs) {
+      window.MIDIjs.play('assets/AUD_AP0356.mid');
+      this.events.once('shutdown', () => window.MIDIjs.stop());
+    }
+
     // Inputs
     this.keys = this.input.keyboard.addKeys({
       up: Phaser.Input.Keyboard.KeyCodes.W,


### PR DESCRIPTION
## Summary
- Load MIDI background track in boot scene
- Play MIDI BGM in game scene with fallback to MIDI.js when decoding fails
- Include MIDI.js plugin on page for MIDI playback support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86d4981388329b6b93d1e1ddf0039