### PR TITLE
feat: add gameplay background music

### DIFF
--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -12,7 +12,7 @@ export class BootScene extends Phaser.Scene {
 
     // Audio (optional for local file usage; only starts after user gesture)
     this.load.audio('siren', ['assets/audio/siren.mp3']);
-    this.load.audio('bgm', 'assets/AUD_AP0356.mid');
+    this.load.audio('bgm', ['assets/AUD_AP0356.mp3']);
   }
   create() {
     this.scene.start('Game');


### PR DESCRIPTION
## Summary
- load MP3 track during boot so gameplay has background music

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86fa0bbd883298c6eb1117da83de7