### PR TITLE
Fix police car forward vector

### DIFF
--- a/src/objects/PoliceCar.js
+++ b/src/objects/PoliceCar.js
@@ -83,7 +83,7 @@ export class PoliceCar extends Phaser.Physics.Arcade.Sprite {
     const braking = this.inputs.brake > 0 || this.inputs.handbrake > 0;
 
     // Acceleration along current heading
-    const forward = this.rotation - Math.PI / 2; // sprite points 'up'
+    const forward = this.rotation + Math.PI / 2; // sprite points 'up'
     const forwardAccel = (t > 0 ? cfg.accel : (t < 0 ? -cfg.reverseAccel : 0));
 
     if (forwardAccel !== 0) {


### PR DESCRIPTION
## Summary
- adjust forward heading of police car so forward key moves correctly

## Testing
- `npm test` *(fails: missing package.json)*
- `python -m http.server` (server started)


------
https://chatgpt.com/codex/tasks/task_e_68a8813f754c832985caa8ad7c45ef30