### PR TITLE
Use scaled factors for speed display

### DIFF
--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -48,13 +48,9 @@ export class UIScene extends Phaser.Scene {
   }
 
   update() {
-    const speedMps = this.registry.get('carSpeed') || 0;
-    let speed;
-    if (this.speedUnit === 'mph') {
-      speed = Math.floor(speedMps * 2.23694);
-    } else {
-      speed = Math.floor(speedMps * 3.6);
-    }
+    const speedPx = this.registry.get('carSpeed') || 0;
+    const factor = this.speedUnit === 'mph' ? 0.1 : 0.16;
+    const speed = Math.floor(speedPx * factor);
     this.speedText.setText(`${speed} ${this.speedUnit}`);
   }
 


### PR DESCRIPTION
## Summary
- convert pixel-based speed to real-world units with mph/kph factors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a888ea8f488329bd7a926fcb2d9c45