### PR TITLE
feat: add dynamic tilemap generation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,8 +2,8 @@
 // Centralized config so we can tweak physics & UI easily.
 export const GAME_CONFIG = {
   world: {
-    width: 4000,        // World size in pixels (large enough for camera follow on ultrawide)
-    height: 3000
+    chunkSize: 16,      // tiles per chunk for on-demand generation
+    seed: 1             // seed for deterministic layout
   },
   car: {
     // "Realistic‑ish" top-down car physics model (arcade but grounded)


### PR DESCRIPTION
## Summary
- replace fixed world size with chunk and seed config
- dynamically spawn and clean tilemap chunks around the police car
- allow infinite driving with large camera bounds and grass background

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e7c28288329891c97506e068c5b