### PR TITLE
Reduce lateral slip on police car

### DIFF
--- a/src/objects/PoliceCar.js
+++ b/src/objects/PoliceCar.js
@@ -104,6 +104,20 @@ export class PoliceCar extends Phaser.Physics.Arcade.Sprite {
     const steerStrength = cfg.turnRate * Phaser.Math.Clamp(this.body.speed / cfg.maxSpeed, 0, 1);
     this.setAngularVelocity(Phaser.Math.RadToDeg(s * steerStrength));
 
+    // Reduce sideways slide by aligning velocity with the car's heading
+    const velocity = this.body.velocity.clone();
+    const forwardVec = new Phaser.Math.Vector2(Math.cos(forward), Math.sin(forward));
+    const forwardComponent = forwardVec.clone().scale(velocity.dot(forwardVec));
+    const lateralComponent = velocity.clone().subtract(forwardComponent);
+
+    let lateralScale = cfg.grip;
+    if (braking) {
+      lateralScale += cfg.handbrakeSlip;
+    }
+
+    const newVelocity = forwardComponent.add(lateralComponent.scale(lateralScale));
+    this.body.setVelocity(newVelocity.x, newVelocity.y);
+
     // Update light positions relative to car
     const cos = Math.cos(forward);
     const sin = Math.sin(forward);


### PR DESCRIPTION
## Summary
- compute velocity component along heading and lateral slide in police car update
- scale lateral velocity by grip and handbrake slip to curb sideways motion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a89173443c832992af99afe3992b90