### PR TITLE
Ensure police car renders above tile layers

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -21,6 +21,7 @@ export class GameScene extends Phaser.Scene {
 
     // Create the car at a default road intersection
     this.car = new PoliceCar(this, tileSize * 10 + tileSize / 2, tileSize * 5 + tileSize / 2);
+    this.car.setDepth(1);
 
     // Camera follow with very large bounds
     const bound = 1e6;
@@ -152,6 +153,7 @@ export class GameScene extends Phaser.Scene {
     const road = map.addTilesetImage('road');
     const layer = map.createBlankLayer('layer', [grass, road], cx * chunkSize * tileSize, cy * chunkSize * tileSize);
     layer.setCollision(0);
+    layer.setDepth(0);
 
     const offset = GAME_CONFIG.world.seed;
     for (let x = 0; x < chunkSize; x++) {


### PR DESCRIPTION
## Summary
- Ensure PoliceCar draws above map tiles by setting its depth to 1
- Assign depth 0 to generated tile layers so all new chunks respect z-ordering

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a915b0620c8329893c1bbbad44f1ae