### PR TITLE
Fix PoliceCar collision scale

### DIFF
--- a/src/objects/PoliceCar.js
+++ b/src/objects/PoliceCar.js
@@ -8,12 +8,13 @@ export class PoliceCar extends Phaser.Physics.Arcade.Sprite {
     super(scene, x, y, 'police-off');
 
     scene.add.existing(this);
+    // Scale the sprite before enabling physics so the body matches the visible size
+    this.setScale(0.3);
     scene.physics.add.existing(this);
 
     // Start facing 'up'
     this.setRotation(0);
     this.setOrigin(0.5, 0.5);
-    this.setScale(0.3);
     this.setDamping(true);
     this.setMaxVelocity(GAME_CONFIG.car.maxSpeed);
 


### PR DESCRIPTION
## Summary
- scale PoliceCar sprite before enabling physics so collision body matches visible size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a926f15fb08329a2f1873d8fb4a83a