### PR TITLE
feat: configure world bounds and disable car boundary collision

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -24,10 +24,13 @@ export class GameScene extends Phaser.Scene {
     const sy = ((5  - GAME_CONFIG.world.seed + 20) % 20) * tileSize + tileSize / 2;
     this.car = new PoliceCar(this, sx, sy);
     this.car.setDepth(1);
+    // Allow the car to leave the world bounds without collision
+    this.car.body.setCollideWorldBounds(false);
 
     // Camera follow with very large bounds
     const bound = 1e6;
     this.cameras.main.setBounds(-bound, -bound, bound * 2, bound * 2);
+    this.physics.world.setBounds(-bound, -bound, bound * 2, bound * 2);
     this.cameras.main.startFollow(this.car, true, 1, 1);
     this.cameras.main.centerOn(this.car.x, this.car.y);
     this.cameras.main.setZoom(1); // tweaked automatically by Resize handler


### PR DESCRIPTION
## Summary
- set Arcade Physics bounds to match world generation limits
- disable car collision with world bounds

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a92a19093c8329aee92a459cfe992b