### PR TITLE
Load roads tileset JSON in BootScene

### DIFF
--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -10,6 +10,9 @@ export class BootScene extends Phaser.Scene {
     this.load.image('grass', 'assets/grass.jpg');
     this.load.image('road', 'assets/road.jpg');
 
+    // Tilemap data
+    this.load.json('roads_tileset', 'assets/roads_tileset.json');
+
     // Audio (optional for local file usage; only starts after user gesture)
     this.load.audio('siren', ['assets/audio/siren.mp3']);
     this.load.audio('bgm', ['assets/AUD_AP0356.mp3']);


### PR DESCRIPTION
## Summary
- Load external roads tileset JSON during boot

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a94453f62083299d4f42823e75acee