### PR TITLE
Remove MIDI.js fallback and rely on MP3 audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,6 @@
   </div>
   <!-- Phaser 3 -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.min.js"></script>
-  <!-- MIDI.js for MIDI playback fallback -->
-  <script src="https://cdn.jsdelivr.net/gh/mudcube/MIDI.js@master/build/MIDI.min.js"></script>
   <!-- Game modules -->
   <script type="module" src="./src/main.js"></script>
   <script>

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -34,9 +34,6 @@ export class GameScene extends Phaser.Scene {
       this.bgm = this.sound.add('bgm', { loop: true, volume: 0.5 });
       this.bgm.play();
       this.events.once('shutdown', () => this.bgm.stop());
-    } else if (window.MIDIjs) {
-      window.MIDIjs.play('assets/AUD_AP0356.mid');
-      this.events.once('shutdown', () => window.MIDIjs.stop());
     }
 
     // Inputs


### PR DESCRIPTION
## Summary
- Drop MIDI.js script from index
- Remove MIDI-based background music fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a98fb493108329bbad0b0bbba0b35d