### PR TITLE
Add HUD audio player with autoplay and icon controls

### DIFF
--- a/src/music.js
+++ b/src/music.js
@@ -1,0 +1,4 @@
+export const MUSIC_TRACKS = [
+  { key: 'policecops', file: 'assets/audio/policecops.mp3' },
+  { key: 'AUD_AP0356', file: 'assets/audio/AUD_AP0356.mp3' },
+];

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,5 +1,7 @@
 // src/scenes/BootScene.js
 // Preloads assets and hands off to the main game.
+import { MUSIC_TRACKS } from '../music.js';
+
 export class BootScene extends Phaser.Scene {
   constructor() { super('Boot'); }
   preload() {
@@ -11,7 +13,7 @@ export class BootScene extends Phaser.Scene {
 
     // Audio (optional for local file usage; only starts after user gesture)
     this.load.audio('siren', ['assets/audio/siren.mp3']);
-    this.load.audio('bgm', ['assets/AUD_AP0356.mp3']);
+    MUSIC_TRACKS.forEach(t => this.load.audio(t.key, [t.file]));
   }
   create() {
     this.scene.start('Game');

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -29,13 +29,6 @@ export class GameScene extends Phaser.Scene {
     this.cameras.main.centerOn(this.car.x, this.car.y);
     this.cameras.main.setZoom(1); // tweaked automatically by Resize handler
 
-    // Background music
-    if (this.cache.audio.exists('bgm')) {
-      this.bgm = this.sound.add('bgm', { loop: true, volume: 0.5 });
-      this.bgm.play();
-      this.events.once('shutdown', () => this.bgm.stop());
-    }
-
     // Inputs
     this.keys = this.input.keyboard.addKeys({
       up: Phaser.Input.Keyboard.KeyCodes.W,

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -1,6 +1,7 @@
 // src/scenes/UIScene.js
 // Minimal on-screen controls for mobile + quick button for lights.
 import { GAME_CONFIG } from '../config.js';
+import { MUSIC_TRACKS } from '../music.js';
 
 export class UIScene extends Phaser.Scene {
   constructor() { super('UI'); }
@@ -55,6 +56,55 @@ export class UIScene extends Phaser.Scene {
       return btn;
     };
     this.lightBtn = makeBtn('Lights (L)', 120, 40, () => this.events.emit('toggleLights'));
+
+    // Simple music player (bottom-right)
+    const playlist = MUSIC_TRACKS.map(t => t.key);
+    this.musicIndex = 0;
+    let currentTrack;
+    let playBtn;
+    const width = this.cameras.main.width;
+    const height = this.cameras.main.height;
+    const bottom = height - 40;
+
+    const trackText = this.add.text(width - 40, bottom - 40, '', { fontSize: 14, color: '#ffffff' })
+      .setOrigin(1, 1)
+      .setScrollFactor(0);
+
+    const updateLabel = () => {
+      trackText.setText(playlist[this.musicIndex]);
+    };
+
+    const playCurrent = () => {
+      if (currentTrack) currentTrack.stop();
+      const key = playlist[this.musicIndex];
+      currentTrack = this.sound.add(key);
+      currentTrack.play();
+      currentTrack.once('complete', nextTrack);
+      playBtn.setText('⏸');
+      updateLabel();
+    };
+
+    const togglePlay = () => {
+      if (!currentTrack) {
+        playCurrent();
+      } else if (currentTrack.isPlaying) {
+        currentTrack.pause();
+        playBtn.setText('▶');
+      } else {
+        currentTrack.resume();
+        playBtn.setText('⏸');
+      }
+    };
+
+    const nextTrack = () => {
+      this.musicIndex = (this.musicIndex + 1) % playlist.length;
+      playCurrent();
+    };
+
+    playBtn = makeBtn('▶', width - 100, bottom, togglePlay);
+    makeBtn('⏭', width - 40, bottom, nextTrack);
+    updateLabel();
+    playCurrent();
 
     // Bridge to GameScene to call methods on the car
     const game = this.scene.get('Game');


### PR DESCRIPTION
## Summary
- Load all music tracks from `assets/audio` using shared playlist
- Add bottom-right HUD music player with play/pause and track skip
- Autoplay current track on game load and switch player buttons to icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9996908b48329b0721c90d11a005f