### PR TITLE
Add roaming NPC cars to game scene

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -2,6 +2,7 @@
 // Renders a simple city, spawns the car, handles input, and updates physics.
 import { GAME_CONFIG } from '../config.js';
 import { PoliceCar } from '../objects/PoliceCar.js';
+import { NpcCar } from '../objects/NpcCar.js';
 
 export class GameScene extends Phaser.Scene {
   constructor() { super('Game'); }
@@ -20,6 +21,15 @@ export class GameScene extends Phaser.Scene {
     this.car.setDepth(1);
     // Allow the car to leave the world bounds without collision
     this.car.body.setCollideWorldBounds(false);
+
+    // NPC cars
+    this.npcCars = [];
+    this.npcCars.push(new NpcCar(this, sx + 200, sy, 'taxi'));
+    this.npcCars.push(new NpcCar(this, sx - 200, sy, 'gti'));
+    for (const car of this.npcCars) {
+      car.setDepth(1);
+      car.body.setCollideWorldBounds(false);
+    }
 
     // Camera follow with very large bounds
     const bound = 1e6;
@@ -93,6 +103,9 @@ export class GameScene extends Phaser.Scene {
     });
 
     this.car.update(dt);
+    for (const car of this.npcCars) {
+      car.update(dt);
+    }
 
     // Scroll background with camera
     this.bg.tilePositionX = this.cameras.main.scrollX;


### PR DESCRIPTION
## Summary
- import and spawn NpcCar objects alongside the player car
- update NPC cars each frame for autonomous movement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a50469188329a8b73b2a99c80626