### PR TITLE
Rebuild label generator to match screenshot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy Vite to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,97 +1,13 @@
-<!DOCTYPE html>
-<html lang="en" x-data="labelApp()" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta charset="UTF-8">
-  <title>Gridfinity Label Generator</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/alpinejs" defer></script>
-</head>
-<body class="bg-gray-50 font-sans flex flex-col items-center p-6">
-  <h1 class="text-2xl font-bold mb-1">Gridfinity Label Generator</h1>
-  <p class="text-gray-500 mb-6">Print-Ready Labels for Your Gridfinity System</p>
-
-  <div class="bg-white shadow rounded-xl p-6 w-full max-w-5xl grid grid-cols-1 md:grid-cols-3 gap-6">
-    <!-- Left form -->
-    <div class="md:col-span-2 space-y-4">
-      <!-- Tabs -->
-      <div class="flex space-x-2">
-        <button :class="tab==='screw'?'bg-blue-600 text-white':'bg-gray-100'" @click="tab='screw'" class="px-4 py-2 rounded-lg text-sm font-medium">Screw</button>
-        <button :class="tab==='nut'?'bg-blue-600 text-white':'bg-gray-100'" @click="tab='nut'" class="px-4 py-2 rounded-lg text-sm font-medium">Nut</button>
-        <button :class="tab==='washer'?'bg-blue-600 text-white':'bg-gray-100'" @click="tab='washer'" class="px-4 py-2 rounded-lg text-sm font-medium">Washer</button>
-      </div>
-
-      <!-- Metric / Imperial -->
-      <div class="flex space-x-2">
-        <button :class="system==='metric'?'bg-blue-600 text-white':'bg-gray-100'" @click="system='metric'" class="flex-1 px-4 py-2 rounded-lg text-sm font-medium">Metric</button>
-        <button :class="system==='imperial'?'bg-blue-600 text-white':'bg-gray-100'" @click="system='imperial'" class="flex-1 px-4 py-2 rounded-lg text-sm font-medium">Imperial</button>
-      </div>
-
-      <!-- Inputs -->
-      <input type="text" placeholder="Thread size..." class="w-full border rounded-lg p-2 text-sm">
-      <input type="text" placeholder="Optional notes" class="w-full border rounded-lg p-2 text-sm">
-      <input type="text" placeholder="Hardware standard..." class="w-full border rounded-lg p-2 text-sm">
-
-      <!-- Preview -->
-      <div class="border border-dashed rounded-lg h-24 flex flex-col justify-center items-center text-gray-400 text-sm">
-        <span>Fill out the form to generate a label</span>
-      </div>
-
-      <!-- Download & Coffee -->
-      <div class="flex space-x-2">
-        <button disabled class="flex-1 bg-gray-100 text-gray-400 rounded-lg px-4 py-2 text-sm">Download</button>
-        <a href="https://www.buymeacoffee.com/" target="_blank" class="flex-1 bg-yellow-400 rounded-lg px-4 py-2 text-sm font-semibold">☕ Buy me a coffee</a>
-      </div>
-    </div>
-
-    <!-- Right settings -->
-    <div class="space-y-4">
-      <div class="flex items-center justify-between">
-        <span class="text-sm">Standard Reference</span>
-        <input type="checkbox" x-model="standardRef" class="h-5 w-5 text-blue-600 rounded">
-      </div>
-      <div class="flex items-center justify-between">
-        <span class="text-sm">Image</span>
-        <input type="checkbox" x-model="image" class="h-5 w-5 text-blue-600 rounded">
-      </div>
-      <div class="flex items-center justify-between">
-        <span class="text-sm">QR Code</span>
-        <input type="checkbox" x-model="qrCode" class="h-5 w-5 text-blue-600 rounded">
-      </div>
-
-      <div>
-        <label class="text-sm font-medium">Label Width (<span x-text="labelWidth"></span> mm)</label>
-        <input type="range" min="37" max="100" x-model="labelWidth" class="w-full">
-      </div>
-
-      <div>
-        <span class="text-sm font-medium mb-1 block">Label Height</span>
-        <div class="grid grid-cols-4 gap-2">
-          <template x-for="h in [9,12,18,24]" :key="h">
-            <button @click="labelHeight=h"
-              :class="labelHeight===h?'bg-blue-600 text-white':'bg-gray-100'"
-              class="px-2 py-1 rounded-lg text-sm">
-              <span x-text="h"></span> mm
-            </button>
-          </template>
-        </div>
-      </div>
-
-      <button class="w-full bg-gray-100 rounded-lg px-4 py-2 text-sm">Provide feedback</button>
-    </div>
-  </div>
-
-  <script>
-    function labelApp() {
-      return {
-        tab: 'washer',
-        system: 'metric',
-        standardRef: true,
-        image: true,
-        qrCode: false,
-        labelWidth: 55,
-        labelHeight: 12
-      }
-    }
-  </script>
-</body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gridfinity Label Generator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-neutral-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gridfinity-pro-labels",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "pdf-lib": "^1.17.1",
+    "qrcode": "^1.5.4",
+    "jsbarcode": "^3.11.6",
+    "papaparse": "^5.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useRef, useState } from "react";
+import { PDFDocument } from "pdf-lib";
+import QRCode from "qrcode";
+
+const mmToPt = (mm) => (mm * 72) / 25.4;
+const mmToPx = (mm) => mm * 3.7795275591;
+
+export default function App() {
+  const [part, setPart] = useState("screw");
+  const [system, setSystem] = useState("metric");
+  const [thread, setThread] = useState("M3");
+  const [kind, setKind] = useState("Bolt");
+  const [length, setLength] = useState("20");
+  const [standard, setStandard] = useState("DIN 186");
+  const [showImage, setShowImage] = useState(true);
+  const [showQR, setShowQR] = useState(false);
+  const [labelWidth, setLabelWidth] = useState(55);
+  const [tapeWidth, setTapeWidth] = useState(12);
+  const [qrData, setQrData] = useState(null);
+  const svgRef = useRef(null);
+
+  useEffect(() => {
+    if (showQR) {
+      const text = `${thread} × ${length} ${standard}`;
+      QRCode.toDataURL(text, { margin: 0 }).then(setQrData);
+    } else {
+      setQrData(null);
+    }
+  }, [showQR, thread, length, standard]);
+
+  const previewWidthPx = mmToPx(labelWidth);
+  const previewHeightPx = mmToPx(tapeWidth);
+
+  async function downloadPDF() {
+    const svg = svgRef.current;
+    const xml = new XMLSerializer().serializeToString(svg);
+    const svgBlob = new Blob([xml], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(svgBlob);
+    const img = new Image();
+    img.src = url;
+    await new Promise((res) => (img.onload = res));
+    const canvas = document.createElement("canvas");
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    const pngUrl = canvas.toDataURL("image/png");
+    const pngBytes = await fetch(pngUrl).then((r) => r.arrayBuffer());
+    const pdf = await PDFDocument.create();
+    const page = pdf.addPage([mmToPt(labelWidth), mmToPt(tapeWidth)]);
+    const pngImage = await pdf.embedPng(pngBytes);
+    page.drawImage(pngImage, {
+      x: 0,
+      y: 0,
+      width: page.getWidth(),
+      height: page.getHeight(),
+    });
+    const pdfBytes = await pdf.save();
+    const blob = new Blob([pdfBytes], { type: "application/pdf" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "label.pdf";
+    a.click();
+  }
+
+  const labelText = `${thread} × ${length} ${standard}`;
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-3xl font-bold text-center">Gridfinity Label Generator</h1>
+      <p className="text-center text-neutral-600 mb-6">
+        Print-Ready Labels for Your Gridfinity System
+      </p>
+      <div className="bg-white rounded-xl shadow p-6">
+        <div className="grid md:grid-cols-2 gap-8">
+          <div>
+            <h2 className="font-semibold mb-2">Screw Type</h2>
+            <div className="flex gap-2 mb-4">
+              {["screw", "nut", "washer"].map((p) => (
+                <button
+                  key={p}
+                  className={`px-3 py-1 rounded ${
+                    part === p ? "bg-blue-600 text-white" : "bg-neutral-200"
+                  }`}
+                  onClick={() => setPart(p)}
+                >
+                  {p[0].toUpperCase() + p.slice(1)}
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2 mb-4">
+              {["metric", "imperial"].map((s) => (
+                <button
+                  key={s}
+                  className={`px-3 py-1 rounded ${
+                    system === s ? "bg-blue-600 text-white" : "bg-neutral-200"
+                  }`}
+                  onClick={() => setSystem(s)}
+                >
+                  {s[0].toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              <select
+                className="border p-1 rounded"
+                value={thread}
+                onChange={(e) => setThread(e.target.value)}
+              >
+                <option>M3</option>
+                <option>M4</option>
+                <option>M5</option>
+                <option>M6</option>
+              </select>
+              <select
+                className="border p-1 rounded"
+                value={kind}
+                onChange={(e) => setKind(e.target.value)}
+              >
+                <option>Bolt</option>
+                <option>Socket</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              <input
+                className="border p-1 rounded"
+                value={length}
+                onChange={(e) => setLength(e.target.value)}
+              />
+              <select
+                className="border p-1 rounded"
+                value={standard}
+                onChange={(e) => setStandard(e.target.value)}
+              >
+                <option>DIN 186</option>
+                <option>DIN 912</option>
+              </select>
+            </div>
+            <div className="mb-4">
+              <div className="text-sm font-semibold mb-1">Label Preview</div>
+              <div
+                className="border bg-yellow-200 flex items-center justify-center"
+                style={{ width: previewWidthPx, height: previewHeightPx }}
+              >
+                <svg
+                  ref={svgRef}
+                  width={previewWidthPx}
+                  height={previewHeightPx}
+                  viewBox={`0 0 ${labelWidth} ${tapeWidth}`}
+                >
+                  <rect
+                    width={labelWidth}
+                    height={tapeWidth}
+                    fill="#FDE68A"
+                    rx="1"
+                  />
+                  {showImage && (
+                    <g transform="translate(2,1)">
+                      <path
+                        d="M1.5,3 L4.5,3 L4.5,9 L1.5,9 Z M3,3 L3,9 M1.5,3 L4.5,3"
+                        stroke="black"
+                        strokeWidth="0.3"
+                        fill="none"
+                      />
+                    </g>
+                  )}
+                  <text
+                    x="10"
+                    y={tapeWidth / 2 + 1}
+                    fontSize="3"
+                    dominantBaseline="middle"
+                  >
+                    {labelText}
+                  </text>
+                  {showQR && qrData && (
+                    <image
+                      href={qrData}
+                      x={labelWidth - 10}
+                      y={1}
+                      width="9"
+                      height="9"
+                    />
+                  )}
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h2 className="font-semibold mb-2">Label Settings</h2>
+            <div className="flex items-center justify-between mb-2">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={showImage}
+                  onChange={(e) => setShowImage(e.target.checked)}
+                />
+                Image
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={showQR}
+                  onChange={(e) => setShowQR(e.target.checked)}
+                />
+                QR code
+              </label>
+            </div>
+            <label className="block text-sm mb-2">
+              Label Width
+              <input
+                type="number"
+                className="w-full border p-1 rounded mt-1"
+                value={labelWidth}
+                onChange={(e) => setLabelWidth(Number(e.target.value))}
+              />
+            </label>
+            <div className="mb-4">
+              <div className="text-sm font-semibold mb-1">Label Height</div>
+              <div className="flex gap-2">
+                {[9, 12, 18, 24].map((h) => (
+                  <button
+                    key={h}
+                    className={`px-3 py-1 rounded ${
+                      tapeWidth === h
+                        ? "bg-blue-600 text-white"
+                        : "bg-neutral-200"
+                    }`}
+                    onClick={() => setTapeWidth(h)}
+                  >
+                    {h} mm
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <button
+                className="bg-blue-600 text-white px-4 py-2 rounded"
+                onClick={downloadPDF}
+              >
+                Download
+              </button>
+              <a
+                className="bg-yellow-400 text-black px-4 py-2 rounded"
+                href="https://www.buymeacoffee.com/"
+                target="_blank"
+              >
+                Buy me a coffee
+              </a>
+            </div>
+            <div className="mt-4">
+              <a
+                href="https://github.com/2wenty2wo/2wenty2wo.github.io/issues"
+                className="text-blue-600"
+              >
+                Provide feedback
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/' // user site root
+})


### PR DESCRIPTION
## Summary
- Set site title to "Gridfinity Label Generator"
- Replace previous app with screenshot-style interface featuring screw type selectors, label preview, and PDF export
- Add download and support links for user feedback and coffee donations

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf263864832983e04f63985f35aa