### PR TITLE
Add screw head icons and DIN selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -6,6 +6,20 @@
   <title>Gridfinity Label Generator</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/alpinejs" defer></script>
+  <script src="https://code.iconify.design/3/3.1.1/iconify.min.js"></script>
+  <script>
+    Iconify.addCollection({
+      prefix: 'screw-head',
+      icons: {
+        hex: {body: '<path d="M19 6.5l-7-4-7 4v7l7 4 7-4z"/>', width: 24, height: 24},
+        torx: {body: '<path d="M12 2l2.4 4.8 5.3.7-3.8 3.5 1 5.3-4.9-2.6-4.9 2.6 1-5.3-3.8-3.5 5.3-.7z"/>', width: 24, height: 24},
+        torx_sec: {body: '<path d="M12 2l2.4 4.8 5.3.7-3.8 3.5 1 5.3-4.9-2.6-4.9 2.6 1-5.3-3.8-3.5 5.3-.7z"/><circle cx="12" cy="12" r="2"/>', width: 24, height: 24},
+        button: {body: '<circle cx="12" cy="12" r="10"/>', width: 24, height: 24},
+        countersunk: {body: '<path d="M12 2L2 22h20z"/>', width: 24, height: 24},
+        cap: {body: '<circle cx="12" cy="12" r="10"/><path d="M19 6.5l-7-4-7 4v7l7 4 7-4z" fill="white"/>', width: 24, height: 24}
+      }
+    });
+  </script>
 </head>
 <body class="bg-gray-50 font-sans flex flex-col items-center p-6">
   <h1 class="text-2xl font-bold mb-1">Gridfinity Label Generator</h1>
@@ -29,6 +43,15 @@
           <option value="bolt">Bolt</option>
           <option value="machine">Machine</option>
           <option value="wood">Wood</option>
+        </select>
+      </label>
+
+      <!-- Head Type -->
+      <label class="block text-sm font-medium">Head Type
+        <select x-model="headType" @change="standard = headStandards[headType]" class="w-full mt-1 border rounded-lg p-2 text-sm">
+          <template x-for="(label, key) in headOptions" :key="key">
+            <option :value="key" x-text="label"></option>
+          </template>
         </select>
       </label>
 
@@ -113,14 +136,39 @@
         tab: 'screw',
         system: 'metric',
         screwType: 'bolt',
+        headType: 'hex',
         thread: 'M3',
         length: '20',
-        standard: 'DIN 186',
+        standard: 'DIN 912',
         standardRef: true,
         image: true,
         qrCode: false,
         labelWidth: 55,
         labelHeight: 12,
+        headOptions: {
+          hex: 'Hex',
+          torx: 'Torx',
+          'torx-sec': 'Security Torx',
+          button: 'Button Head',
+          countersunk: 'Countersunk',
+          cap: 'Cap Head'
+        },
+        headStandards: {
+          hex: 'DIN 912',
+          torx: 'DIN 7985',
+          'torx-sec': 'DIN 7985 Security',
+          button: 'DIN 7380',
+          countersunk: 'DIN 7991',
+          cap: 'DIN 912'
+        },
+        iconMap: {
+          hex: 'screw-head:hex',
+          torx: 'screw-head:torx',
+          'torx-sec': 'screw-head:torx_sec',
+          button: 'screw-head:button',
+          countersunk: 'screw-head:countersunk',
+          cap: 'screw-head:cap'
+        },
         metricSizes: ['M1','M2','M2.5','M3','M4','M5','M6','M8','M10'],
         imperialSizes: ['#4','#6','#8','#10','#12','1/4"','5/16"','3/8"'],
         lengths: ['5','10','15','20','25','30','35','40'],
@@ -135,10 +183,15 @@
           const mmToPx = 3.7795;
           const W = this.labelWidth * mmToPx;
           const H = this.labelHeight * mmToPx;
+          const iconEl = this.image ? Iconify.renderSVG(this.iconMap[this.headType], {height: 12}) : null;
+          if (iconEl) {
+            iconEl.setAttribute('x', '2');
+            iconEl.setAttribute('y', (H/2 - 6).toString());
+          }
+          const icon = iconEl ? iconEl.outerHTML : '';
           const textX = this.image ? 18 : 4;
           const mainText = `${this.thread} × ${this.length}`;
           const refText = this.standardRef ? this.standard : '';
-          const icon = this.image ? `<rect x='2' y='${H/2-6}' width='12' height='12' fill='none' stroke='black' stroke-width='1' />` : '';
           const qr = this.qrCode ? `<rect x='${W-14}' y='2' width='12' height='12' fill='none' stroke='black' stroke-width='1' />` : '';
           return `<svg xmlns='http://www.w3.org/2000/svg' width='${W}' height='${H}' viewBox='0 0 ${W} ${H}'>
             <rect width='100%' height='100%' rx='4' fill='#FFE500' stroke='#000' />


### PR DESCRIPTION
## Summary
- integrate Iconify and custom screw-head icon set
- add head type dropdown that auto-fills DIN references
- render selected screw-head icon on generated labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d1da1da083299d8681cd9ec2cca1