### PR TITLE
Ensure labelApp loads before Alpine

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gridfinity Label Generator</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/src/main.js" defer></script>
   <script src="https://unpkg.com/alpinejs" defer></script>
   <!-- Iconify is bundled via src/icons.js -->
 </head>
@@ -117,6 +118,5 @@
     </div>
   </div>
 
-  <script type="module" src="/src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load `/src/main.js` in the `<head>` before Alpine so the component is available at init

## Testing
- `npm run build`
- `node <script>` to verify head options, size options and SVG preview generation


------
https://chatgpt.com/codex/tasks/task_e_68c4f0a7eb8c83298837163c1a3c90f6