### PR TITLE
feat: load Iconify from CDN

### DIFF
--- a/src/icons.js
+++ b/src/icons.js
@@ -1,4 +1,4 @@
-import Iconify from '@iconify/iconify';
+import Iconify from 'https://code.iconify.design/3/3.1.1/iconify.min.js';
 
 Iconify.addCollection({
   prefix: 'screw-head',


### PR DESCRIPTION
## Summary
- load Iconify from CDN instead of package import

## Testing
- `npm run build`
- `node verify.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68c5029df41c83298ae1e7139b9f87fe