### PR TITLE
Lay out hardware icons horizontally

### DIFF
--- a/script.js
+++ b/script.js
@@ -283,20 +283,40 @@
     labelInner.style.height = innerHeightPx + 'px';
     labelInner.style.left = marginX + 'px';
     labelInner.style.top = marginY + 'px';
-    // Icon area: determine number of icon rows and size per icon
-    let iconCount = 1;
-    if (state.hardwareType === 'Screw' || state.hardwareType === 'Nut') {
-      iconCount = 2;
-    }
-    const iconGap = 4;
-    const iconHeightPx = state.showImage ? (iconCount > 0 ? (innerHeightPx - (iconCount - 1) * iconGap) / iconCount : 0) : 0;
-    // Insert hardware illustration if enabled
+    // Icon area: size artwork so that each SVG matches the printable height.
+    // For screws and nuts two views are displayed side-by-side; when the
+    // label is too narrow to accommodate their natural width they are scaled
+    // down uniformly to preserve their aspect ratio.
     if (state.showImage) {
-      hardwareImageDiv.style.display = 'flex';
-      hardwareImageDiv.innerHTML = getHardwareIcon(iconHeightPx);
+      const iconCount = (state.hardwareType === 'Screw' || state.hardwareType === 'Nut') ? 2 : 1;
+      const iconGapPx = 8; // Match the CSS gap on .hardware-icon
+      if (iconCount > 0) {
+        let iconHeightPx = innerHeightPx;
+        const maxStripWidth = innerWidthPx;
+        const naturalStripWidth = iconCount * iconHeightPx + (iconCount - 1) * iconGapPx;
+        if (naturalStripWidth > maxStripWidth) {
+          const availablePerIcon = Math.floor((maxStripWidth - (iconCount - 1) * iconGapPx) / iconCount);
+          iconHeightPx = Math.max(0, Math.min(iconHeightPx, availablePerIcon));
+        }
+        const finalStripWidth = Math.max(0, iconCount * iconHeightPx + (iconCount - 1) * iconGapPx);
+        hardwareImageDiv.style.display = 'flex';
+        hardwareImageDiv.style.maxWidth = finalStripWidth + 'px';
+        hardwareImageDiv.style.flexBasis = finalStripWidth + 'px';
+        hardwareImageDiv.style.flexShrink = '0';
+        hardwareImageDiv.innerHTML = getHardwareIcon(iconHeightPx);
+      } else {
+        hardwareImageDiv.style.display = 'none';
+        hardwareImageDiv.innerHTML = '';
+        hardwareImageDiv.style.removeProperty('max-width');
+        hardwareImageDiv.style.removeProperty('flex-basis');
+        hardwareImageDiv.style.removeProperty('flex-shrink');
+      }
     } else {
       hardwareImageDiv.style.display = 'none';
       hardwareImageDiv.innerHTML = '';
+      hardwareImageDiv.style.removeProperty('max-width');
+      hardwareImageDiv.style.removeProperty('flex-basis');
+      hardwareImageDiv.style.removeProperty('flex-shrink');
     }
     // Compose line1: size × length (when applicable)
     let line1 = '';

--- a/style.css
+++ b/style.css
@@ -370,15 +370,16 @@ main {
   background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2YzZjRmNiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZjNmNGY2Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2U1ZTdlYiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNlNWU3ZWIiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
   background-size: 20px 20px;
 }
-/* Container for hardware illustrations inside the yellow label.  The
-   icons are arranged vertically (for screws and nuts) or as a single
-   centred icon (for washers). */
+/* Container for hardware illustrations inside the yellow label.  Icons are
+   displayed in a horizontal row so that side and top views appear next to one
+   another. */
 .hardware-icon {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 8px;
+  flex: 0 0 auto;
 }
 
 /* Scale SVG illustrations to fit comfortably inside the label preview.  Without


### PR DESCRIPTION
## Summary
- display hardware SVGs in a horizontal row so side and top views sit together
- size icons to the full printable height and limit their strip width if labels are narrow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca980c0f8c83298efaa39f9135658e