### PR TITLE
Replace donation and feedback buttons with print action

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,10 +132,6 @@
             <label class="height-btn"><input type="radio" name="label-height" value="24" /><span>24&nbsp;mm</span></label>
           </div>
         </div>
-        <!-- Feedback button -->
-        <div class="feedback-row">
-          <button class="feedback-button" id="feedback-button" type="button">Provide feedback</button>
-        </div>
       </section>
     </div>
     <!-- Preview panel below controls -->
@@ -163,7 +159,7 @@
     </section>
     <div class="actions">
       <button id="download-button" disabled>Download</button>
-      <a href="https://www.buymeacoffee.com/" target="_blank" class="coffee-button" rel="noopener">☕ Buy me a coffee</a>
+      <button id="print-button" type="button" disabled>Print</button>
     </div>
   </main>
 </body>

--- a/script.js
+++ b/script.js
@@ -58,6 +58,7 @@
   const line2Div = document.getElementById('line2');
   const qrCanvas = document.getElementById('qr-canvas');
   const downloadButton = document.getElementById('download-button');
+  const printButton = document.getElementById('print-button');
 
   // Height radio buttons: listen at parent level
   const heightRadios = document.querySelectorAll('input[name="label-height"]');
@@ -386,7 +387,11 @@
   function updateDownloadState() {
     const hasSize = !!state.threadSize;
     const hasLength = state.hardwareType === 'Screw' ? !!state.length : true;
-    downloadButton.disabled = !(hasSize && hasLength);
+    const disabled = !(hasSize && hasLength);
+    downloadButton.disabled = disabled;
+    if (printButton) {
+      printButton.disabled = disabled;
+    }
   }
 
   /**
@@ -414,6 +419,33 @@
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+    });
+  }
+
+  /**
+   * Create a printable view of the current label preview.  The preview is
+   * rendered to a PNG at 300 DPI and injected into a lightweight popup
+   * window which immediately triggers the browser's print dialog.
+   */
+  function printLabel() {
+    const desiredDpi = 300;
+    const baseDpi = 96;
+    const scale = desiredDpi / baseDpi;
+    html2canvas(previewContainer, {
+      backgroundColor: null,
+      scale
+    }).then(canvas => {
+      const dataUrl = canvas.toDataURL('image/png');
+      const printWindow = window.open('', '_blank', 'noopener=yes,width=800,height=600');
+      if (!printWindow) {
+        alert('Please allow pop-ups to print the label.');
+        return;
+      }
+      printWindow.opener = null;
+      const html = `<!DOCTYPE html><html><head><title>Print Label</title><style>html,body{margin:0;height:100%;}body{display:flex;align-items:center;justify-content:center;background:#fff;}img{max-width:100%;max-height:100%;}</style></head><body><img src="${dataUrl}" alt="Gridfinity label" onload="window.focus();window.print();window.close();" /></body></html>`;
+      printWindow.document.open();
+      printWindow.document.write(html);
+      printWindow.document.close();
     });
   }
 
@@ -488,15 +520,10 @@
         }
       });
     });
-    // Download button
+    // Download and print buttons
     downloadButton.addEventListener('click', downloadLabel);
-
-    // Feedback button
-    const feedbackButton = document.getElementById('feedback-button');
-    if (feedbackButton) {
-      feedbackButton.addEventListener('click', () => {
-        alert('Thank you for your feedback!');
-      });
+    if (printButton) {
+      printButton.addEventListener('click', printLabel);
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -270,25 +270,7 @@ main {
 .height-btn.selected span {
   color: #fff;
 }
-/* Feedback button */
-.feedback-row {
-  margin-top: 12px;
-}
-.feedback-button {
-  width: 100%;
-  padding: 8px 12px;
-  border: none;
-  border-radius: 8px;
-  background: var(--gray-light);
-  color: var(--text);
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-.feedback-button:hover {
-  background: var(--gray);
-}
-/* Coffee button */
+/* Action buttons */
 .actions {
   text-align: center;
   margin-top: 20px;
@@ -314,21 +296,25 @@ main {
   background: var(--gray-medium);
   cursor: not-allowed;
 }
-.coffee-button {
+#print-button {
   padding: 12px 24px;
   font-size: 1rem;
-  border: none;
   border-radius: 8px;
-  background: #facc15; /* yellow */
-  color: #3f3f3f;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
+  border: 2px solid var(--primary);
+  background: #fff;
+  color: var(--primary);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
 }
-.coffee-button:hover {
-  filter: brightness(0.95);
+#print-button:hover:not([disabled]) {
+  background: var(--primary);
+  color: #fff;
+}
+#print-button[disabled] {
+  border-color: var(--gray-medium);
+  color: var(--gray-dark);
+  background: var(--gray-light);
+  cursor: not-allowed;
 }
 
 /* Preview section */


### PR DESCRIPTION
## Summary
- remove the feedback button from the settings panel and related styles
- replace the “Buy me a coffee” link with a print button styled alongside the download button
- add client-side logic to render the preview to an image in a popup and trigger the browser print dialog

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca9bb9d6488329b4e3a7a9e2344dce