### PR TITLE
Remove marketing tagline from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
   <main>
     <header class="title-section">
       <h1>Gridfinity Label Generator</h1>
-      <p>Print‑Ready Labels for Your Gridfinity System</p>
     </header>
     <!-- Two column layout: form (left) and settings (right). On small screens
          the sections stack vertically. -->


### PR DESCRIPTION
## Summary
- remove the tagline paragraph from the header to meet the updated copy requirement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cab4f583ac8329ae0a45ae05f1cb61