### PR TITLE
Adjust layout proportions for label settings

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,7 +54,6 @@ main {
   gap: 20px;
 }
 .form-section, .settings-section {
-  flex: 1;
   min-width: 280px;
   background: #fff;
   border-radius: 12px;
@@ -66,6 +65,10 @@ main {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex: 2 1 440px;
+}
+.settings-section {
+  flex: 1 1 280px;
 }
 .settings-section h2 {
   margin-top: 0;


### PR DESCRIPTION
## Summary
- increase the flex grow value for the main form section so it takes up more space
- reduce the flex basis of the Label Settings column to keep it slimmer on wide screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab5e9de788329bd919e69eafad43a