### PR TITLE
Show only standard names on labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -280,6 +280,7 @@
         const opt = document.createElement('option');
         opt.value = entry.code;
         opt.textContent = `${entry.code} — ${entry.name}`;
+        opt.dataset.name = entry.name;
         standardSelect.appendChild(opt);
       });
       standardSelect.disabled = false;
@@ -667,7 +668,8 @@
     standardSelect.addEventListener('change', () => {
       const selectedOption = standardSelect.selectedOptions[0];
       if (selectedOption && selectedOption.value) {
-        state.standard = selectedOption.textContent;
+        const displayName = selectedOption.dataset.name || selectedOption.textContent;
+        state.standard = displayName;
       } else {
         state.standard = '';
       }


### PR DESCRIPTION
## Summary
- update the standard dropdown options to expose the descriptive name separately
- store only the standard name in state so the label preview omits DIN/ISO codes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cab8ca0cc88329b145a6e41e11940a