### PR TITLE
Rely on Bootstrap for modern control styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,158 +5,266 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gridfinity Label Generator</title>
   <!--
-    Standalone tool for generating and printing Gridfinity labels.  All
-    styling is defined in a standalone CSS file.  Two small third‑party
-    libraries are loaded via CDN: html2canvas to capture the label preview
-    as an image and qrcode to generate optional QR codes.
+    Standalone tool for generating and printing Gridfinity labels.  Styling
+    now layers a lightweight Bootstrap 5 theme for modern form controls and
+    layout utilities.  Two small third-party libraries are loaded via CDN:
+    html2canvas to capture the label preview as an image and qrcode to
+    generate optional QR codes.
   -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+    crossorigin="anonymous"
+  />
   <link rel="stylesheet" href="style.css" />
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
   <script defer src="script.js"></script>
 </head>
-<body>
-  <main>
-    <header class="title-section">
-      <h1>Gridfinity Label Generator</h1>
+<body class="bg-body-tertiary">
+  <main class="container py-4">
+    <header class="title-section text-center mb-4">
+      <h1 class="display-5 fw-semibold">Gridfinity Label Generator</h1>
+      <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
     </header>
-    <!-- Two column layout: form (left) and settings (right). On small screens
-         the sections stack vertically. -->
-    <div class="config-panel">
-      <!-- Form controls for selecting hardware type, measurement system,
-           and physical parameters. -->
-      <section class="form-section">
-        <!-- Hardware type selector (Screw/Nut/Washer) -->
-        <div class="segmented-group" id="hardware-type-group">
-          <button class="segment selected" data-value="Screw">Screw</button>
-          <button class="segment" data-value="Nut">Nut</button>
-          <button class="segment" data-value="Washer">Washer</button>
-        </div>
-        <!-- Measurement system (metric/imperial) -->
-        <div class="segmented-group" id="system-type-group">
-          <button class="segment selected" data-value="Metric">Metric</button>
-          <button class="segment" data-value="Imperial">Imperial</button>
-        </div>
-        <!-- Screw specific: choose bolt or screw (hidden for other hardware types) -->
-        <div class="field-row" id="screw-type-container">
-          <label>Screw Type</label>
-          <div class="segmented-group" id="screw-type-group">
-            <button class="segment selected" data-value="Bolt">Bolt</button>
-            <button class="segment" data-value="Screw">Screw</button>
+    <div class="row g-4">
+      <section class="form-section col-lg-7">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h2 class="h5 mb-3">Hardware Details</h2>
+            <div class="vstack gap-3">
+              <div>
+                <label class="form-label fw-semibold">Hardware Type</label>
+                <div class="row g-2" id="hardware-type-group">
+                  <div class="col-12 col-sm-4">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="hardware-type"
+                      id="hardware-type-screw"
+                      value="Screw"
+                      autocomplete="off"
+                      checked
+                    />
+                    <label class="btn btn-outline-primary w-100" for="hardware-type-screw">Screw</label>
+                  </div>
+                  <div class="col-12 col-sm-4">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="hardware-type"
+                      id="hardware-type-nut"
+                      value="Nut"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-primary w-100" for="hardware-type-nut">Nut</label>
+                  </div>
+                  <div class="col-12 col-sm-4">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="hardware-type"
+                      id="hardware-type-washer"
+                      value="Washer"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-primary w-100" for="hardware-type-washer">Washer</label>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label class="form-label fw-semibold">Measurement System</label>
+                <div class="row g-2" id="system-type-group">
+                  <div class="col-12 col-sm-6">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="system-type"
+                      id="system-type-metric"
+                      value="Metric"
+                      autocomplete="off"
+                      checked
+                    />
+                    <label class="btn btn-outline-secondary w-100" for="system-type-metric">Metric</label>
+                  </div>
+                  <div class="col-12 col-sm-6">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="system-type"
+                      id="system-type-imperial"
+                      value="Imperial"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-secondary w-100" for="system-type-imperial">Imperial</label>
+                  </div>
+                </div>
+              </div>
+              <div id="screw-type-container">
+                <label class="form-label fw-semibold">Screw Type</label>
+                <div class="row g-2" id="screw-type-group">
+                  <div class="col-12 col-sm-6">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="screw-type"
+                      id="screw-type-bolt"
+                      value="Bolt"
+                      autocomplete="off"
+                      checked
+                    />
+                    <label class="btn btn-outline-secondary w-100" for="screw-type-bolt">Bolt</label>
+                  </div>
+                  <div class="col-12 col-sm-6">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="screw-type"
+                      id="screw-type-screw"
+                      value="Screw"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-secondary w-100" for="screw-type-screw">Screw</label>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label for="thread-size-select" class="form-label fw-semibold">Thread Size</label>
+                <select id="thread-size-select" class="form-select"></select>
+              </div>
+              <div id="length-container">
+                <label for="length-input" class="form-label fw-semibold">Length</label>
+                <input
+                  type="number"
+                  id="length-input"
+                  class="form-control"
+                  placeholder="e.g., 10"
+                  min="1"
+                />
+              </div>
+              <div>
+                <label for="notes-input" class="form-label fw-semibold">Optional Notes</label>
+                <input
+                  type="text"
+                  id="notes-input"
+                  class="form-control"
+                  placeholder="Notes (optional)"
+                />
+              </div>
+              <div>
+                <label for="standard-select" class="form-label fw-semibold">Hardware Standard</label>
+                <select id="standard-select" class="form-select"></select>
+              </div>
+            </div>
           </div>
         </div>
-        <!-- Thread size selection -->
-        <div class="field-row">
-          <label for="thread-size-select">Thread size</label>
-          <select id="thread-size-select"></select>
-        </div>
-        <!-- Length field: visible for screws, hidden for nuts and washers -->
-        <div class="field-row" id="length-container">
-          <label for="length-input">Length</label>
-          <input type="number" id="length-input" placeholder="e.g., 10" min="1" />
-        </div>
-        <!-- Optional notes -->
-        <div class="field-row">
-          <label for="notes-input">Optional notes</label>
-          <input type="text" id="notes-input" placeholder="Notes (optional)" />
-        </div>
-        <!-- Hardware standard selection -->
-        <div class="field-row">
-          <label for="standard-select">Hardware standard</label>
-          <select id="standard-select"></select>
-        </div>
       </section>
-      <!-- Settings panel for toggles and label size -->
-      <section class="settings-section">
-        <h2>Label Settings</h2>
-        <!-- Toggle rows with icons and custom switches -->
-        <div class="setting-row">
-          <span class="setting-label">
-            <!-- icon for standard reference -->
-            <svg class="setting-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
-              <path d="M8 8h2"></path>
-              <path d="M14 8h2"></path>
-              <path d="M8 12h8"></path>
-              <path d="M8 16h5"></path>
-            </svg>
-            Standard Reference
-          </span>
-          <label class="switch">
-            <input type="checkbox" id="standard-toggle" checked />
-            <span class="slider"></span>
-          </label>
-        </div>
-        <div class="setting-row">
-          <span class="setting-label">
-            <!-- icon for image -->
-            <svg class="setting-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
-              <circle cx="9" cy="9" r="2"></circle>
-              <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
-            </svg>
-            Image
-          </span>
-          <label class="switch">
-            <input type="checkbox" id="image-toggle" checked />
-            <span class="slider"></span>
-          </label>
-        </div>
-        <div class="setting-row">
-          <span class="setting-label">
-            <!-- icon for QR code -->
-            <svg class="setting-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h6v6H4z"></path><path d="M14 4h6v2"></path><path d="M14 8h2v2h-2z"></path><path d="M18 8h2v2h-2z"></path><path d="M14 14h6v6h-6z"></path><path d="M4 14h6v6H4z"></path></svg>
-            QR Code
-          </span>
-          <label class="switch">
-            <input type="checkbox" id="qrcode-toggle" />
-            <span class="slider"></span>
-          </label>
-        </div>
-        <!-- Label width slider with min/max labels -->
-        <div class="range-row">
-          <label class="range-label">Label Width <span id="width-value">55</span> mm</label>
-          <input type="range" id="width-range" min="37" max="100" value="55" />
-          <div class="range-minmax"><span>37&nbsp;mm</span><span>100&nbsp;mm</span></div>
-        </div>
-        <!-- Label height buttons -->
-        <div class="height-row">
-          <span class="range-label">Label Height</span>
-          <div class="height-options">
-            <label class="height-btn"><input type="radio" name="label-height" value="9" /><span>9&nbsp;mm</span></label>
-            <label class="height-btn"><input type="radio" name="label-height" value="12" checked /><span>12&nbsp;mm</span></label>
-            <label class="height-btn"><input type="radio" name="label-height" value="18" /><span>18&nbsp;mm</span></label>
-            <label class="height-btn"><input type="radio" name="label-height" value="24" /><span>24&nbsp;mm</span></label>
+      <section class="settings-section col-lg-5">
+        <div class="card shadow-sm h-100">
+          <div class="card-body">
+            <h2 class="h5 mb-3">Label Settings</h2>
+            <div class="vstack gap-3">
+              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
+                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+                    <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
+                    <path d="M8 8h2"></path>
+                    <path d="M14 8h2"></path>
+                    <path d="M8 12h8"></path>
+                    <path d="M8 16h5"></path>
+                  </svg>
+                  Standard Reference
+                </span>
+                <div class="form-check form-switch m-0">
+                  <input class="form-check-input" type="checkbox" role="switch" id="standard-toggle" checked />
+                  <label class="form-check-label visually-hidden" for="standard-toggle">Toggle standard reference</label>
+                </div>
+              </div>
+              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
+                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+                    <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
+                    <circle cx="9" cy="9" r="2"></circle>
+                    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
+                  </svg>
+                  Image
+                </span>
+                <div class="form-check form-switch m-0">
+                  <input class="form-check-input" type="checkbox" role="switch" id="image-toggle" checked />
+                  <label class="form-check-label visually-hidden" for="image-toggle">Toggle hardware image</label>
+                </div>
+              </div>
+              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
+                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
+                    <path d="M4 4h6v6H4z"></path>
+                    <path d="M14 4h6v2"></path>
+                    <path d="M14 8h2v2h-2z"></path>
+                    <path d="M18 8h2v2h-2z"></path>
+                    <path d="M14 14h6v6h-6z"></path>
+                    <path d="M4 14h6v6H4z"></path>
+                  </svg>
+                  QR Code
+                </span>
+                <div class="form-check form-switch m-0">
+                  <input class="form-check-input" type="checkbox" role="switch" id="qrcode-toggle" />
+                  <label class="form-check-label visually-hidden" for="qrcode-toggle">Toggle QR code</label>
+                </div>
+              </div>
+              <div>
+                <label for="width-range" class="form-label fw-semibold">Label Width <span id="width-value">55</span> mm</label>
+                <input type="range" class="form-range" id="width-range" min="37" max="100" value="55" />
+                <div class="d-flex justify-content-between text-muted small"><span>37&nbsp;mm</span><span>100&nbsp;mm</span></div>
+              </div>
+              <div>
+                <span class="form-label d-block fw-semibold">Label Height</span>
+                <div class="row row-cols-2 g-2 height-options">
+                  <div class="col">
+                    <input type="radio" class="btn-check" name="label-height" id="height-9" value="9" autocomplete="off" />
+                    <label class="btn btn-outline-secondary w-100" for="height-9">9&nbsp;mm</label>
+                  </div>
+                  <div class="col">
+                    <input type="radio" class="btn-check" name="label-height" id="height-12" value="12" autocomplete="off" checked />
+                    <label class="btn btn-outline-secondary w-100" for="height-12">12&nbsp;mm</label>
+                  </div>
+                  <div class="col">
+                    <input type="radio" class="btn-check" name="label-height" id="height-18" value="18" autocomplete="off" />
+                    <label class="btn btn-outline-secondary w-100" for="height-18">18&nbsp;mm</label>
+                  </div>
+                  <div class="col">
+                    <input type="radio" class="btn-check" name="label-height" id="height-24" value="24" autocomplete="off" />
+                    <label class="btn btn-outline-secondary w-100" for="height-24">24&nbsp;mm</label>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
     </div>
-    <!-- Preview panel below controls -->
-    <section class="preview-section">
-      <h2>Label Preview</h2>
-      <div class="size-info">
-        <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
-        <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
-      </div>
-      <div id="preview-container" class="label-preview">
-        <!-- The inner yellow label.  Positioned absolutely within the preview
-             container to leave a consistent margin on each side.  This
-             element holds the hardware illustration, the text lines and
-             an optional QR code.  Sizing and positioning are computed
-             dynamically in script.js. -->
-        <div id="label-inner" class="label-inner">
-          <div id="hardware-image" class="hardware-icon"></div>
-          <div id="preview-text" class="text-block">
-            <div id="line1" class="text-line"></div>
-            <div id="line2" class="text-line small"></div>
+    <section class="preview-section card shadow-sm mt-4">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Label Preview</h2>
+        <div class="size-info text-muted small mb-3">
+          <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
+          <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+        </div>
+        <div id="preview-container" class="label-preview">
+          <div id="label-inner" class="label-inner">
+            <div id="hardware-image" class="hardware-icon"></div>
+            <div id="preview-text" class="text-block">
+              <div id="line1" class="text-line"></div>
+              <div id="line2" class="text-line small"></div>
+            </div>
+            <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
           </div>
-          <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
         </div>
       </div>
     </section>
-    <div class="actions">
-      <button id="download-button" disabled>Download</button>
-      <button id="print-button" type="button" disabled>Print</button>
+    <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
+      <button id="download-button" class="btn btn-primary btn-lg px-4" disabled>Download</button>
+      <button id="print-button" class="btn btn-outline-primary btn-lg px-4" type="button" disabled>Print</button>
     </div>
   </main>
 </body>

--- a/script.js
+++ b/script.js
@@ -176,10 +176,7 @@
   const pxPerMm = 6;
 
   // Grab references to all relevant DOM nodes once at startup.
-  const hardwareTypeGroup = document.getElementById('hardware-type-group');
-  const systemTypeGroup = document.getElementById('system-type-group');
   const screwTypeContainer = document.getElementById('screw-type-container');
-  const screwTypeGroup = document.getElementById('screw-type-group');
   const threadSizeSelect = document.getElementById('thread-size-select');
   const lengthContainer = document.getElementById('length-container');
   const lengthInput = document.getElementById('length-input');
@@ -201,7 +198,9 @@
   const downloadButton = document.getElementById('download-button');
   const printButton = document.getElementById('print-button');
 
-  // Height radio buttons: listen at parent level
+  const hardwareTypeRadios = document.querySelectorAll('input[name="hardware-type"]');
+  const systemTypeRadios = document.querySelectorAll('input[name="system-type"]');
+  const screwTypeRadios = document.querySelectorAll('input[name="screw-type"]');
   const heightRadios = document.querySelectorAll('input[name="label-height"]');
 
   // Keep track of current selections.  This state object drives the preview
@@ -289,31 +288,6 @@
     state.standard = '';
     standardSelect.value = '';
     standardSelect.selectedIndex = 0;
-    updatePreview();
-  }
-
-  /**
-   * Update the selected state when a segmented button is clicked.
-   * At most one button within a group can be selected at any time.
-   */
-  function handleSegmentClick(event) {
-    const btn = event.target.closest('.segment');
-    if (!btn) return;
-    const group = btn.parentNode;
-    // Remove selection from siblings
-    Array.from(group.children).forEach(el => el.classList.remove('selected'));
-    btn.classList.add('selected');
-    const val = btn.getAttribute('data-value');
-    if (group.id === 'hardware-type-group') {
-      state.hardwareType = val;
-      onHardwareTypeChange();
-    } else if (group.id === 'system-type-group') {
-      state.systemType = val;
-      populateThreadSizes();
-    } else if (group.id === 'screw-type-group') {
-      state.screwType = val;
-      populateStandards();
-    }
     updatePreview();
   }
 
@@ -642,10 +616,32 @@
    * clear how user interactions flow through the system.
    */
   function initEventHandlers() {
-    // Handle segmented buttons
-    hardwareTypeGroup.addEventListener('click', handleSegmentClick);
-    systemTypeGroup.addEventListener('click', handleSegmentClick);
-    screwTypeGroup.addEventListener('click', handleSegmentClick);
+    hardwareTypeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          state.hardwareType = radio.value;
+          onHardwareTypeChange();
+        }
+      });
+    });
+
+    systemTypeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          state.systemType = radio.value;
+          populateThreadSizes();
+        }
+      });
+    });
+
+    screwTypeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          state.screwType = radio.value;
+          populateStandards();
+        }
+      });
+    });
     // Thread size selection
     threadSizeSelect.addEventListener('change', () => {
       state.threadSize = threadSizeSelect.value;
@@ -699,17 +695,6 @@
       r.addEventListener('change', () => {
         if (r.checked) {
           state.heightMm = parseInt(r.value, 10);
-          // Update visual selection on height buttons
-          heightRadios.forEach(btn => {
-            const label = btn.closest('label');
-            if (label) {
-              if (btn.checked) {
-                label.classList.add('selected');
-              } else {
-                label.classList.remove('selected');
-              }
-            }
-          });
           updatePreview();
         }
       });
@@ -730,18 +715,8 @@
     onHardwareTypeChange();
     initEventHandlers();
     updateDownloadState();
+    widthValueSpan.textContent = state.widthMm;
     updatePreview();
-    // Set initial selected class on height buttons
-    heightRadios.forEach(r => {
-      const label = r.closest('label');
-      if (label) {
-        if (r.checked) {
-          label.classList.add('selected');
-        } else {
-          label.classList.remove('selected');
-        }
-      }
-    });
   }
 
   // Wait until DOM content is loaded before initialising the app

--- a/style.css
+++ b/style.css
@@ -1,367 +1,38 @@
 /*
- * Basic styling for a custom Gridfinity label generator interface.
- * Colors and component shapes are inspired by modern manufacturing
- * tools while remaining custom defined.  The layout adapts to narrow
- * viewports by stacking the sections vertically.  Utility classes
- * defined here avoid external dependencies like Tailwind.
+ * Supplemental styles layered on top of Bootstrap 5 to support the
+ * Gridfinity label generator preview and custom artwork.
  */
 
-/* Color palette */
-:root {
-  --primary: #2563eb; /* blue‑600 */
-  --primary-light: #dbeafe; /* blue‑100 */
-  --gray-light: #f9fafb; /* gray‑50 */
-  --gray: #f3f4f6;       /* gray‑100 */
-  --gray-medium: #d1d5db; /* gray‑300 */
-  --gray-dark: #4b5563;  /* gray‑600 */
-  --text: #374151;       /* gray‑700 */
-}
-
-html, body {
-  margin: 0;
-  padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  color: var(--text);
-  background: linear-gradient(to bottom, var(--gray-light), var(--gray));
+body {
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  min-height: 100vh;
 }
 
 main {
   max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
 }
 
-/* Title styling */
-.title-section {
-  text-align: center;
-  margin-bottom: 20px;
-}
-.title-section h1 {
-  margin: 0;
-  font-size: 2rem;
-  font-weight: 700;
-}
 .title-section p {
-  margin-top: 4px;
-  font-size: 1rem;
-  color: var(--gray-dark);
+  max-width: 520px;
+  margin: 0.5rem auto 0;
 }
 
-/* Panel layout */
-.config-panel {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-}
-.form-section, .settings-section {
-  min-width: 280px;
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  padding: 20px;
-  box-sizing: border-box;
-}
-.form-section {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  flex: 2 1 440px;
-}
-.settings-section {
-  flex: 1 1 280px;
-}
-.settings-section h2 {
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-size: 1.2rem;
-  font-weight: 600;
-}
-
-/* Segmented button groups */
-.segmented-group {
-  display: flex;
-  gap: 4px;
-}
-.segment {
-  flex: 1;
-  padding: 12px 16px;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text);
-  font-size: 0.9rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.2s, color 0.2s;
-}
-.segment:hover {
-  background: var(--gray-light);
-}
-.segment.selected {
-  background: var(--primary);
-  color: #fff;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-}
-
-/* Form field styling */
-.field-row {
-  display: flex;
-  flex-direction: column;
-}
-.field-row label {
-  font-size: 0.85rem;
-  margin-bottom: 4px;
-  color: var(--gray-dark);
-}
-.field-row input[type="number"], .field-row input[type="text"], .field-row select {
-  padding: 10px;
-  border: 1px solid var(--gray-medium);
-  border-radius: 6px;
-  font-size: 0.95rem;
-  outline: none;
-  transition: border 0.2s;
-}
-.field-row input:focus, .field-row select:focus {
-  border-color: var(--primary);
-}
-
-/* Settings panel toggles and sliders */
-/* Settings panel rows */
-.setting-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 12px;
-}
-/* Label and icon */
-.setting-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.9rem;
-  color: var(--text);
-  flex-grow: 1;
-}
-.setting-icon {
-  width: 18px;
-  height: 18px;
-  stroke: var(--gray-dark);
-}
-/* Custom toggle switch */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 20px;
-}
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--gray-medium);
-  transition: background-color 0.2s;
-  border-radius: 20px;
-}
-.slider::before {
-  position: absolute;
-  content: "";
-  height: 16px;
-  width: 16px;
-  left: 2px;
-  top: 2px;
-  background-color: #fff;
-  border-radius: 50%;
-  transition: transform 0.2s;
-}
-.switch input:checked + .slider {
-  background-color: var(--primary);
-}
-.switch input:checked + .slider::before {
-  transform: translateX(20px);
-}
-/* Range row styling */
-.range-row {
-  margin-bottom: 16px;
-}
-.range-label {
-  display: block;
-  font-size: 0.85rem;
-  color: var(--text);
-  margin-bottom: 4px;
-}
-.range-row input[type="range"] {
-  width: 100%;
-  cursor: pointer;
-  appearance: none;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--gray-medium);
-  outline: none;
-}
-.range-row input[type="range"]::-webkit-slider-thumb {
-  appearance: none;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--primary);
-  cursor: pointer;
-  margin-top: -5px;
-}
-.range-row input[type="range"]::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--primary);
-  border: none;
-  cursor: pointer;
-}
-.range-minmax {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.75rem;
-  color: var(--gray-dark);
-  margin-top: 2px;
-}
-/* Height options */
-.height-row {
-  margin-bottom: 16px;
-}
-.height-options {
-  display: flex;
-  gap: 6px;
-}
-.height-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--gray-light);
-  color: var(--text);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
-}
-.height-btn input {
-  display: none;
-}
-.height-btn input:checked + span {
-  color: #fff;
-}
-.height-btn input:checked ~ span {
-  /* fallback if not next sibling */
-  color: #fff;
-}
-.height-btn input:checked {
-  /* nothing here, the parent color is controlled by JS */
-}
-
-/* highlight selected height button via JS */
-.height-btn.selected {
-  background: var(--primary);
-  color: #fff;
-}
-.height-btn.selected span {
-  color: #fff;
-}
-/* Action buttons */
-.actions {
-  text-align: center;
-  margin-top: 20px;
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-#download-button {
-  padding: 12px 28px;
-  font-size: 1rem;
-  border: none;
-  border-radius: 8px;
-  color: #fff;
-  background: var(--primary);
-  cursor: pointer;
-  transition: background 0.2s;
-}
-#download-button:hover:not([disabled]) {
-  background: #1d4ed8; /* darker blue */
-}
-#download-button[disabled] {
-  background: var(--gray-medium);
-  cursor: not-allowed;
-}
-#print-button {
-  padding: 12px 24px;
-  font-size: 1rem;
-  border-radius: 8px;
-  border: 2px solid var(--primary);
-  background: #fff;
-  color: var(--primary);
-  cursor: pointer;
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
-}
-#print-button:hover:not([disabled]) {
-  background: var(--primary);
-  color: #fff;
-}
-#print-button[disabled] {
-  border-color: var(--gray-medium);
-  color: var(--gray-dark);
-  background: var(--gray-light);
-  cursor: not-allowed;
-}
-
-/* Preview section */
-.preview-section {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  padding: 20px;
-  margin-top: 20px;
-}
-.preview-section h2 {
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-size: 1.2rem;
-  font-weight: 600;
-}
 .size-info {
-  font-size: 0.85rem;
-  color: var(--gray-dark);
-  margin-bottom: 8px;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 0.75rem;
 }
-/*
- * Preview container.  This element represents the full label including
- * the 2mm side margins and the 1mm top/bottom margins.  A subtle
- * checkerboard pattern fills the background to evoke a technical
- * blueprint backdrop.  The pattern is embedded as a base64 encoded SVG.
- * The container has a thin border and rounded corners, and is positioned
- * relative so that the inner yellow label can be absolutely positioned
- * within it.
- */
+
 .label-preview {
   position: relative;
-  border: 1px solid var(--gray-medium);
-  border-radius: 8px;
+  margin: 0 auto;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 0.75rem;
   overflow: hidden;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2YzZjRmNiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZjNmNGY2Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2U1ZTdlYiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNlNWU3ZWIiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
   background-size: 20px 20px;
 }
-/* Container for hardware illustrations inside the yellow label.  Icons are
-   displayed in a horizontal row so that side and top views appear next to one
-   another. */
+
 .hardware-icon {
   display: flex;
   flex-direction: row;
@@ -371,13 +42,10 @@ main {
   flex: 0 0 auto;
 }
 
-/* Scale SVG illustrations to fit comfortably inside the label preview.  Without
-   explicit rules the intrinsic width and height on the SVG elements may
-   overflow their container at small label heights. */
 .hardware-icon svg {
-  /* Dimensions are set dynamically via inline styles from script.js */
   width: auto;
 }
+
 .text-block {
   display: flex;
   flex-direction: column;
@@ -386,26 +54,22 @@ main {
   white-space: nowrap;
   flex: 1;
 }
+
 .text-line {
   line-height: 1;
   font-weight: 700;
 }
+
 .text-line.small {
   font-size: 0.7em;
   font-weight: 500;
 }
+
 .qr-code {
   position: absolute;
-  display: none; /* toggled via JS */
+  display: none;
 }
 
-/*
- * The inner yellow label.  This element sits within the preview
- * container and is sized and positioned by script.js.  It uses a
- * vibrant yellow background with a solid black border to deliver the
- * intended label aesthetic.  Flexbox is used to lay out the hardware
- * icons, text and optional QR code horizontally.
- */
 .label-inner {
   background-color: #ffe500;
   border: 2px solid #000;
@@ -420,31 +84,9 @@ main {
   padding-right: 6px;
 }
 
-/* Action button */
-.actions {
-  text-align: center;
-  margin-top: 20px;
-}
-#download-button {
-  padding: 12px 28px;
-  font-size: 1rem;
-  border: none;
-  border-radius: 8px;
-  color: #fff;
-  background: var(--primary);
-  cursor: pointer;
-  transition: background 0.2s;
-}
-#download-button:hover:not([disabled]) {
-  background: #1d4ed8; /* darker blue */
-}
-#download-button[disabled] {
-  background: var(--gray-medium);
-  cursor: not-allowed;
-}
-
 @media (max-width: 768px) {
-  .config-panel {
-    flex-direction: column;
+  main {
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- load Bootstrap 5 from CDN and rewrite the form markup to use its modern buttons, switches, and layout utilities
- trim the bespoke stylesheet down to preview-specific rules that complement the Bootstrap theme
- update UI wiring to listen to the new radio inputs and remove the now unnecessary range styling logic

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cabc6a4ab483298954777adc61e7b2