### PR TITLE
Keep thread size and length inputs aligned on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,11 +130,11 @@
                 </div>
               </div>
               <div class="row g-3" id="thread-length-row">
-                <div class="col-12 col-sm-6">
+                <div class="col-12 col-sm-6 thread-length-field" id="thread-size-container">
                   <label for="thread-size-select" class="form-label fw-semibold">Thread Size</label>
                   <select id="thread-size-select" class="form-select"></select>
                 </div>
-                <div class="col-12 col-sm-6" id="length-container">
+                <div class="col-12 col-sm-6 thread-length-field" id="length-container">
                   <label for="length-input" class="form-label fw-semibold">Length</label>
                   <input
                     type="number"

--- a/script.js
+++ b/script.js
@@ -178,6 +178,7 @@
   // Grab references to all relevant DOM nodes once at startup.
   const screwTypeContainer = document.getElementById('screw-type-container');
   const threadSizeSelect = document.getElementById('thread-size-select');
+  const threadLengthRow = document.getElementById('thread-length-row');
   const lengthContainer = document.getElementById('length-container');
   const lengthInput = document.getElementById('length-input');
   const notesInput = document.getElementById('notes-input');
@@ -300,15 +301,17 @@
    */
   function onHardwareTypeChange() {
     const type = state.hardwareType;
-    if (type === 'Screw') {
-      screwTypeContainer.style.display = '';
-      lengthContainer.style.display = '';
-    } else {
-      screwTypeContainer.style.display = 'none';
-      lengthContainer.style.display = 'none';
+    const showScrewFields = type === 'Screw';
+
+    screwTypeContainer.style.display = showScrewFields ? '' : 'none';
+    lengthContainer.style.display = showScrewFields ? '' : 'none';
+
+    if (threadLengthRow) {
+      threadLengthRow.classList.toggle('single-column', !showScrewFields);
     }
     populateThreadSizes();
     populateStandards();
+    updateDownloadState();
   }
 
   /**

--- a/style.css
+++ b/style.css
@@ -156,6 +156,32 @@ main {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
 }
 
+@media (max-width: 575.98px) {
+  #thread-length-row {
+    --thread-length-gap: 0.75rem;
+    margin-left: 0;
+    margin-right: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: var(--thread-length-gap);
+    row-gap: var(--thread-length-gap);
+  }
+
+  #thread-length-row > .thread-length-field {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  #thread-length-row.single-column {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+#thread-length-row.single-column > .thread-length-field {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
 @media (max-width: 768px) {
   main {
     padding-left: 1rem;


### PR DESCRIPTION
## Summary
- ensure the thread size and length controls stay side-by-side on phones by giving them a shared helper class and a mobile grid layout
- toggle a row-level helper class when screw-specific fields are hidden so thread size can expand to full width
- remove the obsolete column helper and update the script to manage the new layout hooks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb395e530c8329a7b900db955cf5a1