### PR TITLE
Add connector hardware option with guidance and preview support

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,57 @@
                     />
                     <label class="btn btn-outline-primary w-100" for="hardware-type-fuse">Fuse</label>
                   </div>
+                  <div class="col-12 col-sm-6 col-lg-3">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="hardware-type"
+                      id="hardware-type-connector"
+                      value="Connector"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-primary w-100" for="hardware-type-connector">Connector</label>
+                  </div>
                 </div>
+              </div>
+              <div id="connector-info" class="connector-info d-none mt-3">
+                <p class="fw-semibold mb-2">
+                  The red, yellow, and blue connectors you’re thinking of are insulated crimp connectors / terminals (commonly
+                  called spade connectors, ring terminals, butt connectors, etc., depending on the style).
+                </p>
+                <p class="mb-0">
+                  The color coding doesn’t refer to voltage or function, but rather the wire size (AWG / mm²) they’re designed
+                  for:
+                </p>
+                <div class="connector-divider my-3" aria-hidden="true"></div>
+                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🔵🟡🔴 Color Code (Standard)</h3>
+                <ul class="mb-3">
+                  <li><strong>Red</strong> → for 22–16 AWG wire (0.5–1.5 mm²)</li>
+                  <li><strong>Blue</strong> → for 16–14 AWG wire (1.5–2.5 mm²)</li>
+                  <li><strong>Yellow</strong> → for 12–10 AWG wire (4–6 mm²)</li>
+                </ul>
+                <p class="mb-0">These colors are standard across most brands.</p>
+                <div class="connector-divider my-3" aria-hidden="true"></div>
+                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🧰 Connector Types (insulated)</h3>
+                <ul class="mb-3">
+                  <li>Ring Terminals → bolt or screw passes through</li>
+                  <li>Spade (Fork) Terminals → easy connect/disconnect under a screw</li>
+                  <li>Butt Connectors → join two wires inline</li>
+                  <li>Quick Disconnects (Male/Female Spades) → flat blade push-on connectors</li>
+                  <li>Pin Terminals → small round pins for terminal blocks</li>
+                  <li>Bullet Connectors → round push-fit male/female</li>
+                </ul>
+                <div class="connector-divider my-3" aria-hidden="true"></div>
+                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🧩 Size / Fit Options</h3>
+                <ul class="mb-3">
+                  <li><strong>Stud/bolt size for rings &amp; spades:</strong> M3, M4, M5, M6, M8, ¼″, etc.</li>
+                  <li><strong>Tab size for quick disconnects:</strong> Common are 6.3&nbsp;mm (¼″), 4.8&nbsp;mm, 2.8&nbsp;mm widths.</li>
+                  <li><strong>Butt connectors:</strong> Sized to match wire gauge.</li>
+                </ul>
+                <p class="small text-body-secondary mb-0">
+                  Use the notes field below to record the connector color, gauge, and terminal style for your label before
+                  exporting.
+                </p>
               </div>
               <div>
                 <label class="form-label fw-semibold">Measurement System</label>
@@ -227,6 +277,9 @@
                   class="form-control"
                   placeholder="Notes (optional)"
                 />
+                <div id="connector-notes-hint" class="form-text d-none">
+                  Provide the connector color, wire size, and terminal style when labelling connectors.
+                </div>
               </div>
               <div>
                 <label for="standard-select" class="form-label fw-semibold">Hardware Standard</label>

--- a/script.js
+++ b/script.js
@@ -169,6 +169,7 @@
       { code: 'DIN 988', name: 'Shim Ring' }
     ],
     'Heat Insert': [],
+    Connector: [],
     Fuse: [
       { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
       { code: 'IEC 60127-3', name: 'Fast-Acting Cartridge Fuse' },
@@ -200,6 +201,11 @@
   const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
   const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
   const notesInput = document.getElementById('notes-input');
+  const connectorInfo = document.getElementById('connector-info');
+  const connectorNotesHint = document.getElementById('connector-notes-hint');
+  const notesLabel = document.querySelector('label[for="notes-input"]');
+  const defaultNotesLabel = notesLabel ? notesLabel.textContent : '';
+  const defaultNotesPlaceholder = notesInput ? notesInput.getAttribute('placeholder') || '' : '';
   const standardSelect = document.getElementById('standard-select');
   const standardToggle = document.getElementById('standard-toggle');
   const imageToggle = document.getElementById('image-toggle');
@@ -258,7 +264,7 @@
    * hardware or system selection changes.
    */
   function populateThreadSizes() {
-    if (state.hardwareType === 'Fuse') {
+    if (state.hardwareType === 'Fuse' || state.hardwareType === 'Connector') {
       if (threadSizeSelect) {
         threadSizeSelect.innerHTML = '';
         const placeholder = document.createElement('option');
@@ -512,6 +518,7 @@
     const type = state.hardwareType;
     const showScrewFields = type === 'Screw';
     const showFuseFields = type === 'Fuse';
+    const showConnectorFields = type === 'Connector';
 
     if (screwTypeContainer) {
       screwTypeContainer.style.display = showScrewFields ? '' : 'none';
@@ -521,11 +528,15 @@
     }
 
     if (threadLengthRow) {
-      threadLengthRow.classList.toggle('single-column', !showScrewFields && !showFuseFields);
-      threadLengthRow.style.display = showFuseFields ? 'none' : '';
+      const hideThreadLength = showFuseFields || showConnectorFields;
+      threadLengthRow.classList.toggle(
+        'single-column',
+        !showScrewFields && !showFuseFields && !showConnectorFields
+      );
+      threadLengthRow.style.display = hideThreadLength ? 'none' : '';
     }
     if (threadSizeContainer) {
-      threadSizeContainer.style.display = showFuseFields ? 'none' : '';
+      threadSizeContainer.style.display = showFuseFields || showConnectorFields ? 'none' : '';
     }
     if (fuseTypeContainer) {
       fuseTypeContainer.classList.toggle('d-none', !showFuseFields);
@@ -537,6 +548,26 @@
       fuseValueSelect.disabled = !showFuseFields;
       if (showFuseFields) {
         fuseValueSelect.value = state.fuseValue || '';
+      }
+    }
+    if (connectorInfo) {
+      connectorInfo.classList.toggle('d-none', !showConnectorFields);
+    }
+    if (connectorNotesHint) {
+      connectorNotesHint.classList.toggle('d-none', !showConnectorFields);
+    }
+    if (notesLabel) {
+      notesLabel.textContent = showConnectorFields ? 'Connector Details' : defaultNotesLabel;
+    }
+    if (notesInput) {
+      if (showConnectorFields) {
+        notesInput.placeholder = 'e.g., Red quick-disconnect, 16–14 AWG';
+        notesInput.required = true;
+        notesInput.setAttribute('aria-required', 'true');
+      } else {
+        notesInput.placeholder = defaultNotesPlaceholder;
+        notesInput.required = false;
+        notesInput.setAttribute('aria-required', 'false');
       }
     }
     updateGlassOptionVisibility({ resetIfHidden: !showFuseFields });
@@ -647,6 +678,17 @@
         <polygon points="50,18 72,30 82,50 72,70 50,82 28,70 18,50 28,30" />
         <circle cx="50" cy="50" r="18" />
       `));
+    } else if (type === 'Connector') {
+      // Connector: pair of insulated crimp terminals, showing sleeve and mating end
+      pieces.push(buildSvg(`
+        <!-- Insulated crimp connectors -->
+        <path d="M22 72L34 28H56L44 72Z" />
+        <rect x="34" y="20" width="12" height="8" />
+        <rect x="62" y="32" width="26" height="34" rx="8" />
+        <polygon points="70,20 82,20 90,34 78,34" />
+        <line x1="48" y1="52" x2="62" y2="46" />
+        <line x1="46" y1="60" x2="60" y2="54" />
+      `));
     } else if (type === 'Fuse') {
       if (state.fuseType === 'Glass') {
         pieces.push(buildSvg(`
@@ -744,6 +786,10 @@
         fuseParts.push(`${state.fuseValue} A`);
       }
       line1 = fuseParts.filter(Boolean).join(' — ');
+    } else if (state.hardwareType === 'Connector') {
+      if (state.notes) {
+        line1 = state.notes;
+      }
     } else {
       if (state.threadSize) {
         line1 = state.threadSize;
@@ -774,6 +820,10 @@
         fuseDetails.push(state.notes);
       }
       line2 = fuseDetails.join(' • ');
+    } else if (state.hardwareType === 'Connector') {
+      if (state.showStandard && state.standard) {
+        line2 = state.standard;
+      }
     } else {
       if (state.showStandard && state.standard) {
         line2 = state.standard;
@@ -875,6 +925,8 @@
     let ready = false;
     if (state.hardwareType === 'Fuse') {
       ready = !!state.fuseValue;
+    } else if (state.hardwareType === 'Connector') {
+      ready = !!state.notes;
     } else if (state.hardwareType === 'Screw') {
       ready = !!state.threadSize && !!state.length;
     } else {
@@ -921,6 +973,11 @@
           if (state.glassSpeed) {
             fileParts.push(state.glassSpeed);
           }
+        }
+      } else if (state.hardwareType === 'Connector') {
+        fileParts.push('Connector');
+        if (state.notes) {
+          fileParts.push(state.notes);
         }
       } else {
         if (state.threadSize) {
@@ -1095,6 +1152,7 @@
     // Notes
     notesInput.addEventListener('input', () => {
       state.notes = notesInput.value.trim();
+      updateDownloadState();
       updatePreview();
     });
     // Standard select

--- a/style.css
+++ b/style.css
@@ -84,6 +84,28 @@ main {
   padding-right: 6px;
 }
 
+.connector-info {
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.connector-info ul {
+  margin-bottom: 0;
+  padding-left: 1.25rem;
+}
+
+.connector-info li + li {
+  margin-top: 0.35rem;
+}
+
+.connector-divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.2), rgba(15, 23, 42, 0));
+}
+
 .qr-info-icon {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- add a Connector hardware type with an information panel covering color codes, insulated terminal styles, and sizing notes
- adapt the label generator logic to hide irrelevant fields, require connector details, and render a connector-specific icon and export name
- style the connector guidance panel to blend with the existing UI

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb5eb20d448329ab9dd17c17c93923