### PR TITLE
Hide measurement system for fuses and connectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,46 +106,7 @@
                   </div>
                 </div>
               </div>
-              <div id="connector-info" class="connector-info d-none mt-3">
-                <p class="fw-semibold mb-2">
-                  The red, yellow, and blue connectors you’re thinking of are insulated crimp connectors / terminals (commonly
-                  called spade connectors, ring terminals, butt connectors, etc., depending on the style).
-                </p>
-                <p class="mb-0">
-                  The color coding doesn’t refer to voltage or function, but rather the wire size (AWG / mm²) they’re designed
-                  for:
-                </p>
-                <div class="connector-divider my-3" aria-hidden="true"></div>
-                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🔵🟡🔴 Color Code (Standard)</h3>
-                <ul class="mb-3">
-                  <li><strong>Red</strong> → for 22–16 AWG wire (0.5–1.5 mm²)</li>
-                  <li><strong>Blue</strong> → for 16–14 AWG wire (1.5–2.5 mm²)</li>
-                  <li><strong>Yellow</strong> → for 12–10 AWG wire (4–6 mm²)</li>
-                </ul>
-                <p class="mb-0">These colors are standard across most brands.</p>
-                <div class="connector-divider my-3" aria-hidden="true"></div>
-                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🧰 Connector Types (insulated)</h3>
-                <ul class="mb-3">
-                  <li>Ring Terminals → bolt or screw passes through</li>
-                  <li>Spade (Fork) Terminals → easy connect/disconnect under a screw</li>
-                  <li>Butt Connectors → join two wires inline</li>
-                  <li>Quick Disconnects (Male/Female Spades) → flat blade push-on connectors</li>
-                  <li>Pin Terminals → small round pins for terminal blocks</li>
-                  <li>Bullet Connectors → round push-fit male/female</li>
-                </ul>
-                <div class="connector-divider my-3" aria-hidden="true"></div>
-                <h3 class="h6 text-uppercase text-secondary fw-semibold mb-2">🧩 Size / Fit Options</h3>
-                <ul class="mb-3">
-                  <li><strong>Stud/bolt size for rings &amp; spades:</strong> M3, M4, M5, M6, M8, ¼″, etc.</li>
-                  <li><strong>Tab size for quick disconnects:</strong> Common are 6.3&nbsp;mm (¼″), 4.8&nbsp;mm, 2.8&nbsp;mm widths.</li>
-                  <li><strong>Butt connectors:</strong> Sized to match wire gauge.</li>
-                </ul>
-                <p class="small text-body-secondary mb-0">
-                  Use the notes field below to record the connector color, gauge, and terminal style for your label before
-                  exporting.
-                </p>
-              </div>
-              <div>
+              <div id="measurement-system-container">
                 <label class="form-label fw-semibold">Measurement System</label>
                 <div class="row g-2" id="system-type-group">
                   <div class="col-12 col-sm-6">

--- a/script.js
+++ b/script.js
@@ -201,7 +201,7 @@
   const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
   const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
   const notesInput = document.getElementById('notes-input');
-  const connectorInfo = document.getElementById('connector-info');
+  const measurementSystemContainer = document.getElementById('measurement-system-container');
   const connectorNotesHint = document.getElementById('connector-notes-hint');
   const notesLabel = document.querySelector('label[for="notes-input"]');
   const defaultNotesLabel = notesLabel ? notesLabel.textContent : '';
@@ -527,6 +527,15 @@
       lengthContainer.style.display = showScrewFields ? '' : 'none';
     }
 
+    if (measurementSystemContainer) {
+      const hideMeasurementSystem = showFuseFields || showConnectorFields;
+      measurementSystemContainer.style.display = hideMeasurementSystem ? 'none' : '';
+      measurementSystemContainer.setAttribute('aria-hidden', hideMeasurementSystem ? 'true' : 'false');
+    }
+    systemTypeRadios.forEach(radio => {
+      radio.disabled = showFuseFields || showConnectorFields;
+    });
+
     if (threadLengthRow) {
       const hideThreadLength = showFuseFields || showConnectorFields;
       threadLengthRow.classList.toggle(
@@ -549,9 +558,6 @@
       if (showFuseFields) {
         fuseValueSelect.value = state.fuseValue || '';
       }
-    }
-    if (connectorInfo) {
-      connectorInfo.classList.toggle('d-none', !showConnectorFields);
     }
     if (connectorNotesHint) {
       connectorNotesHint.classList.toggle('d-none', !showConnectorFields);

--- a/style.css
+++ b/style.css
@@ -84,28 +84,6 @@ main {
   padding-right: 6px;
 }
 
-.connector-info {
-  background: rgba(15, 23, 42, 0.04);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 1rem;
-  padding: 1.5rem;
-}
-
-.connector-info ul {
-  margin-bottom: 0;
-  padding-left: 1.25rem;
-}
-
-.connector-info li + li {
-  margin-top: 0.35rem;
-}
-
-.connector-divider {
-  height: 1px;
-  width: 100%;
-  background: linear-gradient(90deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.2), rgba(15, 23, 42, 0));
-}
-
 .qr-info-icon {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- hide the measurement system controls when Fuse or Connector hardware types are selected
- remove the connector information panel and associated styles now that only the notes hint remains

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb638f7d0883298543ac0a2c2957ae