### PR TITLE
Add JST connector families to connector catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
                   placeholder="Notes (optional)"
                 />
                 <div id="connector-notes-hint" class="form-text d-none">
-                  Provide the connector color, wire size, and terminal style when labelling connectors.
+                  Provide the connector series, pin count, wire size, and terminal style when labelling connectors.
                 </div>
               </div>
               <div>

--- a/script.js
+++ b/script.js
@@ -169,7 +169,17 @@
       { code: 'DIN 988', name: 'Shim Ring' }
     ],
     'Heat Insert': [],
-    Connector: [],
+    Connector: [
+      { code: 'JST-PH', name: '2.0 mm wire-to-board plug (PH series)' },
+      { code: 'JST-XH', name: '2.5 mm wire-to-board plug (XH series)' },
+      { code: 'JST-SH', name: '1.0 mm wire-to-board plug (SH series)' },
+      { code: 'JST-GH', name: '1.25 mm wire-to-board plug (GH series)' },
+      { code: 'JST-ZH', name: '1.5 mm wire-to-board plug (ZH series)' },
+      { code: 'JST-VH', name: '3.96 mm wire-to-board plug (VH series)' },
+      { code: 'JST-SM', name: '2.54 mm wire-to-wire plug (SM series)' },
+      { code: 'JST-JWPF', name: '2.0 mm sealed connector (JWPF series)' },
+      { code: 'JST-RCY', name: '2.54 mm battery connector (RCY series)' }
+    ],
     Fuse: [
       { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
       { code: 'IEC 60127-3', name: 'Fast-Acting Cartridge Fuse' },
@@ -567,7 +577,7 @@
     }
     if (notesInput) {
       if (showConnectorFields) {
-        notesInput.placeholder = 'e.g., Red quick-disconnect, 16–14 AWG';
+        notesInput.placeholder = 'e.g., 3-pin JST-PH plug, 26 AWG leads';
         notesInput.required = true;
         notesInput.setAttribute('aria-required', 'true');
       } else {


### PR DESCRIPTION
## Summary
- add a catalog of common JST plug families so connector labels have ready-made options
- refresh the connector details hint and placeholder to highlight series- and pin-related info

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb70003ba08329bdb1533c525fe57a