### PR TITLE
Adjust heading typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       <section class="form-section col-lg-7">
         <div class="card shadow-sm h-100">
           <div class="card-body">
-            <h2 class="h5 mb-3">Hardware Details</h2>
+            <h2 class="h5 mb-3 section-heading">Hardware Details</h2>
             <div class="vstack gap-3">
               <div>
                 <label class="form-label fw-semibold">Hardware Type</label>
@@ -323,7 +323,7 @@
       <section class="settings-section col-lg-5">
         <div class="card shadow-sm h-100">
           <div class="card-body">
-            <h2 class="h5 mb-3">Label Settings</h2>
+            <h2 class="h5 mb-3 section-heading">Label Settings</h2>
             <div class="vstack gap-3">
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
                 <span class="d-flex align-items-center gap-2 fw-semibold text-body">
@@ -429,7 +429,7 @@
     </div>
     <section class="preview-section card shadow-sm mt-4">
       <div class="card-body">
-        <h2 class="h5 mb-3">Label Preview</h2>
+        <h2 class="h5 mb-3 section-heading">Label Preview</h2>
         <div class="size-info text-muted small mb-3">
           <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
           <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,12 @@ main {
 
 .title-section h1 {
   font-family: "Farsan", cursive;
+  font-size: clamp(3.25rem, 6vw, 4.5rem);
+  line-height: 1.05;
+}
+
+.section-heading {
+  font-family: "Farsan", cursive;
 }
 
 .size-info {


### PR DESCRIPTION
## Summary
- enlarge the hero title styling so it scales larger while keeping line-height tight
- apply the Farsan typeface to the form and preview section headings via a shared class

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbdb088f7c8329ba361592ff86d1d9