### PR TITLE
Switch heading typography to Walter Turncoat

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Farsan&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Walter+Turncoat&display=swap"
     rel="stylesheet"
   />
   <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -18,13 +18,14 @@ main {
 }
 
 .title-section h1 {
-  font-family: "Farsan", cursive;
+  font-family: "Walter Turncoat", cursive;
   font-size: clamp(3.25rem, 6vw, 4.5rem);
   line-height: 1.05;
 }
 
 .section-heading {
-  font-family: "Farsan", cursive;
+  font-family: "Walter Turncoat", cursive;
+  font-size: clamp(1.5rem, 2.5vw, 1.9rem);
 }
 
 .size-info {


### PR DESCRIPTION
## Summary
- swap the Google Font import from Farsan to Walter Turncoat
- update the title and section heading styles to use the new font family

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbe4baef688329a52a2c3c4ba858d2