### PR TITLE
Show placeholder preview until label input is provided

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,7 +435,31 @@
           <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
         </div>
         <div id="preview-container" class="label-preview">
-          <div id="label-inner" class="label-inner">
+          <div id="preview-placeholder" class="preview-placeholder">
+            <svg
+              class="placeholder-icon"
+              width="36"
+              height="36"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M4.75 5.75a1 1 0 0 1 1-1h9.086a1 1 0 0 1 .707.293l3.414 3.414a1 1 0 0 1 .293.707V18.25a1 1 0 0 1-1 1H5.75a1 1 0 0 1-1-1V5.75Z"
+                stroke="currentColor"
+                stroke-width="1.5"
+              />
+              <path
+                d="M9 9.75h3.5M9 12.75h6"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+            <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
+          </div>
+          <div id="label-inner" class="label-inner" style="display: none;">
             <div id="hardware-image" class="hardware-icon"></div>
             <div id="preview-text" class="text-block">
               <div id="line1" class="text-line"></div>

--- a/script.js
+++ b/script.js
@@ -352,6 +352,7 @@
   const labelSizeDisplay = document.getElementById('label-size-display');
   const printAreaDisplay = document.getElementById('print-area-display');
   const previewContainer = document.getElementById('preview-container');
+  const previewPlaceholder = document.getElementById('preview-placeholder');
   const labelInner = document.getElementById('label-inner');
   const hardwareImageDiv = document.getElementById('hardware-image');
   const textBlockDiv = document.getElementById('preview-text');
@@ -1221,6 +1222,37 @@
     labelInner.style.height = innerHeightPx + 'px';
     labelInner.style.left = marginX + 'px';
     labelInner.style.top = marginY + 'px';
+    const readyForPreview = isLabelReady();
+
+    if (!readyForPreview) {
+      if (previewPlaceholder) {
+        previewPlaceholder.style.display = 'flex';
+        previewPlaceholder.setAttribute('aria-hidden', 'false');
+      }
+      labelInner.style.display = 'none';
+      hardwareImageDiv.style.display = 'none';
+      hardwareImageDiv.innerHTML = '';
+      hardwareImageDiv.style.removeProperty('max-width');
+      hardwareImageDiv.style.removeProperty('flex-basis');
+      hardwareImageDiv.style.removeProperty('flex-shrink');
+      hardwareImageDiv.style.removeProperty('min-height');
+      line1Div.textContent = '';
+      line2Div.textContent = '';
+      line2Div.style.display = 'none';
+      const ctx = qrCanvas.getContext('2d');
+      if (ctx) {
+        ctx.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
+      }
+      qrCanvas.style.display = 'none';
+      labelInner.style.removeProperty('padding-right');
+      return;
+    }
+
+    if (previewPlaceholder) {
+      previewPlaceholder.style.display = 'none';
+      previewPlaceholder.setAttribute('aria-hidden', 'true');
+    }
+    labelInner.style.display = 'flex';
     // Icon area: size artwork so that each SVG matches the printable height.
     // For screws and nuts two views are displayed side-by-side; when the
     // label is too narrow to accommodate their natural width they are scaled
@@ -1488,6 +1520,26 @@
     }
   }
 
+  function isLabelReady() {
+    if (state.hardwareType === 'Fuse') {
+      return Boolean(state.fuseValue);
+    }
+    if (state.hardwareType === 'Connector') {
+      const hasNotes = Boolean(state.notes && state.notes.trim());
+      return hasNotes && Boolean(state.connectorCategory);
+    }
+    if (state.hardwareType === 'Custom') {
+      return Boolean(state.customLine1 && state.customLine1.trim());
+    }
+    if (state.hardwareType === 'Bearing') {
+      return Boolean(state.bearingType);
+    }
+    if (state.hardwareType === 'Screw') {
+      return Boolean(state.threadSize && state.length);
+    }
+    return Boolean(state.threadSize);
+  }
+
   /**
    * Enable or disable the download button based on whether enough
    * information has been provided.  For screws, both size and length
@@ -1495,20 +1547,7 @@
    * thread size is required.  For fuses, the amp rating is required.
    */
   function updateDownloadState() {
-    let ready = false;
-    if (state.hardwareType === 'Fuse') {
-      ready = !!state.fuseValue;
-    } else if (state.hardwareType === 'Connector') {
-      ready = !!state.notes && !!state.connectorCategory;
-    } else if (state.hardwareType === 'Custom') {
-      ready = !!(state.customLine1 && state.customLine1.trim());
-    } else if (state.hardwareType === 'Bearing') {
-      ready = !!state.bearingType;
-    } else if (state.hardwareType === 'Screw') {
-      ready = !!state.threadSize && !!state.length;
-    } else {
-      ready = !!state.threadSize;
-    }
+    const ready = isLabelReady();
     const disabled = !ready;
     downloadButton.disabled = disabled;
     if (printButton) {

--- a/style.css
+++ b/style.css
@@ -44,6 +44,32 @@ main {
   background-size: 20px 20px;
 }
 
+.preview-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  text-align: center;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 600;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
+.preview-placeholder .placeholder-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  opacity: 0.65;
+}
+
+.preview-placeholder .placeholder-text {
+  font-size: 0.95rem;
+}
+
 .hardware-icon {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- add a placeholder panel to the label preview so the empty state mirrors the mock-up
- style the placeholder with centered iconography and messaging
- reuse a single readiness helper to gate both the preview rendering and download availability

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cbebfcf6f08329aada6dd89a09b1bf