### PR TITLE
Use Font Awesome icons for UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
     crossorigin="anonymous"
   />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -327,13 +334,7 @@
             <div class="vstack gap-3">
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
                 <span class="d-flex align-items-center gap-2 fw-semibold text-body">
-                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
-                    <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
-                    <path d="M8 8h2"></path>
-                    <path d="M14 8h2"></path>
-                    <path d="M8 12h8"></path>
-                    <path d="M8 16h5"></path>
-                  </svg>
+                  <i class="fa-solid fa-book text-secondary fs-5" aria-hidden="true"></i>
                   Standard Reference
                 </span>
                 <div class="form-check form-switch m-0">
@@ -343,11 +344,7 @@
               </div>
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
                 <span class="d-flex align-items-center gap-2 fw-semibold text-body">
-                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
-                    <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
-                    <circle cx="9" cy="9" r="2"></circle>
-                    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
-                  </svg>
+                  <i class="fa-solid fa-image text-secondary fs-5" aria-hidden="true"></i>
                   Image
                 </span>
                 <div class="form-check form-switch m-0">
@@ -357,14 +354,7 @@
               </div>
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
                 <span class="d-flex align-items-center gap-2 fw-semibold text-body">
-                  <svg class="text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20">
-                    <path d="M4 4h6v6H4z"></path>
-                    <path d="M14 4h6v2"></path>
-                    <path d="M14 8h2v2h-2z"></path>
-                    <path d="M18 8h2v2h-2z"></path>
-                    <path d="M14 14h6v6h-6z"></path>
-                    <path d="M4 14h6v6H4z"></path>
-                  </svg>
+                  <i class="fa-solid fa-qrcode text-secondary fs-5" aria-hidden="true"></i>
                   QR Code
                 </span>
                 <div class="form-check form-switch m-0">
@@ -382,7 +372,7 @@
                     aria-label="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
                     data-tooltip="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
                   >
-                    i
+                    <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
                   </span>
                 </label>
                 <input
@@ -436,27 +426,7 @@
         </div>
         <div id="preview-container" class="label-preview">
           <div id="preview-placeholder" class="preview-placeholder">
-            <svg
-              class="placeholder-icon"
-              width="36"
-              height="36"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                d="M4.75 5.75a1 1 0 0 1 1-1h9.086a1 1 0 0 1 .707.293l3.414 3.414a1 1 0 0 1 .293.707V18.25a1 1 0 0 1-1 1H5.75a1 1 0 0 1-1-1V5.75Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-              />
-              <path
-                d="M9 9.75h3.5M9 12.75h6"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-              />
-            </svg>
+            <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
             <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
           </div>
           <div id="label-inner" class="label-inner" style="display: none;">

--- a/style.css
+++ b/style.css
@@ -61,8 +61,12 @@ main {
 }
 
 .preview-placeholder .placeholder-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 2.25rem;
   height: 2.25rem;
+  font-size: 1.75rem;
   opacity: 0.65;
 }
 
@@ -160,17 +164,20 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 999px;
   background-color: rgba(15, 23, 42, 0.08);
   color: #0f172a;
-  font-weight: 700;
-  font-size: 0.85rem;
+  font-size: 1rem;
   line-height: 1;
   cursor: default;
   flex-shrink: 0;
   user-select: none;
+}
+
+.qr-info-icon i {
+  line-height: 1;
 }
 
 .qr-info-icon::after {


### PR DESCRIPTION
## Summary
- load Font Awesome 6 via CDN to provide consistent iconography
- replace inline SVG and text placeholders with Font Awesome icons for settings toggles and preview placeholder
- tweak tooltip and placeholder styling to suit the new icon elements

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cbf21802f48329bf44e2f2118ae229