### PR TITLE
Restyle label preview to match reference design

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
     href="https://fonts.googleapis.com/css2?family=Walter+Turncoat&display=swap"
     rel="stylesheet"
   />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Barlow:wght@500;600;700&display=swap"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="style.css" />
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -37,11 +37,28 @@ main {
 .label-preview {
   position: relative;
   margin: 0 auto;
-  border: 1px solid rgba(148, 163, 184, 0.6);
+  border: none;
   border-radius: 0.75rem;
-  overflow: hidden;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2YzZjRmNiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZjNmNGY2Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2U1ZTdlYiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNlNWU3ZWIiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
   background-size: 20px 20px;
+  overflow: hidden;
+}
+
+.label-preview::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 0.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f7fafc 100%);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
+  border: 1.25px solid rgba(15, 23, 42, 0.82);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.label-preview > * {
+  position: relative;
+  z-index: 1;
 }
 
 .preview-placeholder {
@@ -123,21 +140,25 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-left: 6px;
+  padding-left: 4px;
   min-width: 0;
   white-space: normal;
   overflow-wrap: anywhere;
   flex: 1;
+  gap: 0.15em;
 }
 
 .text-line {
   line-height: 1;
   font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 .text-line.small {
-  font-size: 0.7em;
-  font-weight: 500;
+  font-size: 0.68em;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: rgba(15, 23, 42, 0.7);
 }
 
 .qr-code {
@@ -146,17 +167,18 @@ main {
 }
 
 .label-inner {
-  background-color: #ffe500;
-  border: 2px solid #000;
-  border-radius: 4px;
+  position: absolute;
   display: flex;
   align-items: center;
-  position: absolute;
-  overflow: hidden;
+  gap: 12px;
+  padding: 4px 14px;
   box-sizing: border-box;
-  gap: 8px;
-  padding-left: 6px;
-  padding-right: 6px;
+  border-radius: 5px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.18);
+  color: #0f172a;
+  font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  overflow: hidden;
 }
 
 .qr-info-icon {


### PR DESCRIPTION
## Summary
- add the Barlow typeface for label typography that matches the provided reference
- restyle the preview container and printable area to remove the yellow fill and mimic the uploaded label layout, including updated text styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbf60797fc83299b93921052cfe9a3