### PR TITLE
Revamp label preview layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,7 +426,7 @@
         <h2 class="h5 mb-3 section-heading">Label Preview</h2>
         <div class="size-info text-muted small mb-3">
           <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
-          <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+          <div id="print-area-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (print-ready image size)</div>
         </div>
         <div id="preview-container" class="label-preview">
           <div id="preview-placeholder" class="preview-placeholder">

--- a/script.js
+++ b/script.js
@@ -711,7 +711,7 @@
         if (state.hardwareType === 'Connector') {
           const display = entry.name ? `${entry.code} — ${entry.name}` : entry.code;
           opt.textContent = display;
-          opt.dataset.name = display;
+          opt.dataset.name = entry.name || entry.code;
         } else {
           opt.textContent = `${entry.code} — ${entry.name}`;
           opt.dataset.name = entry.name;
@@ -1203,25 +1203,22 @@
     // Compute the physical sizes and printable area
     const width = state.widthMm;
     const height = state.heightMm;
-    const printableWidth = Math.max(0, width - 4); // 2mm margin each side
-    const printableHeight = Math.max(0, height - 2); // 1mm margin top/bottom
+    const printableWidth = width;
+    const printableHeight = height;
     labelSizeDisplay.innerHTML = `${width}&nbsp;mm ×&nbsp;${height}&nbsp;mm (label size)`;
-    printAreaDisplay.innerHTML = `${printableWidth}&nbsp;mm ×&nbsp;${printableHeight}&nbsp;mm (printable area)`;
+    printAreaDisplay.innerHTML = `${printableWidth}&nbsp;mm ×&nbsp;${printableHeight}&nbsp;mm (print-ready image size)`;
     // Compute preview container dimensions in pixels
     const pxWidth = width * pxPerMm;
     const pxHeight = height * pxPerMm;
     previewContainer.style.width = pxWidth + 'px';
     previewContainer.style.height = pxHeight + 'px';
-    // Compute inner label margins (2mm side margins, 1mm top/bottom)
-    const marginX = 2 * pxPerMm;
-    const marginY = 1 * pxPerMm;
-    const innerWidthPx = Math.max(0, pxWidth - 2 * marginX);
-    const innerHeightPx = Math.max(0, pxHeight - 2 * marginY);
-    // Position and size the yellow label
+    const innerWidthPx = pxWidth;
+    const innerHeightPx = pxHeight;
+    // Position and size the label so it fills the preview
     labelInner.style.width = innerWidthPx + 'px';
     labelInner.style.height = innerHeightPx + 'px';
-    labelInner.style.left = marginX + 'px';
-    labelInner.style.top = marginY + 'px';
+    labelInner.style.left = '0px';
+    labelInner.style.top = '0px';
     const readyForPreview = isLabelReady();
 
     if (!readyForPreview) {
@@ -1244,7 +1241,7 @@
         ctx.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
       }
       qrCanvas.style.display = 'none';
-      labelInner.style.removeProperty('padding-right');
+      labelInner.style.setProperty('--label-padding-right-extra', '0px');
       return;
     }
 
@@ -1253,6 +1250,15 @@
       previewPlaceholder.setAttribute('aria-hidden', 'true');
     }
     labelInner.style.display = 'flex';
+    const basePaddingX = Math.max(10, Math.round(innerHeightPx * 0.22));
+    const basePaddingY = Math.max(6, Math.round(innerHeightPx * 0.16));
+    const baseGap = Math.max(8, Math.round(innerHeightPx * 0.12));
+    const accentWidth = Math.min(Math.max(6, Math.round(innerHeightPx * 0.1)), Math.round(basePaddingX * 0.85));
+    labelInner.style.setProperty('--label-padding-x', `${basePaddingX}px`);
+    labelInner.style.setProperty('--label-padding-y', `${basePaddingY}px`);
+    labelInner.style.setProperty('--label-gap', `${baseGap}px`);
+    labelInner.style.setProperty('--label-accent-width', `${accentWidth}px`);
+    labelInner.style.setProperty('--label-padding-right-extra', '0px');
     // Icon area: size artwork so that each SVG matches the printable height.
     // For screws and nuts two views are displayed side-by-side; when the
     // label is too narrow to accommodate their natural width they are scaled
@@ -1462,7 +1468,8 @@
       qrCanvas.height = qrSize;
       qrCanvas.style.width = qrSize + 'px';
       qrCanvas.style.height = qrSize + 'px';
-      qrCanvas.style.right = pxPerMm + 'px'; // 1mm right margin
+      const qrOffset = Math.max(pxPerMm, Math.round(basePaddingX * 0.5));
+      qrCanvas.style.right = qrOffset + 'px';
       qrCanvas.style.top = '50%';
       qrCanvas.style.transform = 'translateY(-50%)';
       qrCanvas.style.display = 'block';
@@ -1484,15 +1491,16 @@
       } catch (err) {
         console.error('QR code generation failed', err);
       }
-      const qrPadding = Math.max(6, qrSize + pxPerMm * 2);
-      labelInner.style.paddingRight = qrPadding + 'px';
+      const qrPadding = Math.max(basePaddingX, Math.round(qrSize + pxPerMm * 1.5));
+      const extraRight = Math.max(0, qrPadding - basePaddingX);
+      labelInner.style.setProperty('--label-padding-right-extra', `${extraRight}px`);
     } else {
       const ctx = qrCanvas.getContext('2d');
       if (ctx) {
         ctx.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
       }
       qrCanvas.style.display = 'none';
-      labelInner.style.removeProperty('padding-right');
+      labelInner.style.setProperty('--label-padding-right-extra', '0px');
     }
 
     applyTextFitting(primaryFontSize, secondaryFontSize);
@@ -1560,8 +1568,8 @@
       return Promise.reject(new Error('Label preview is not available.'));
     }
 
-    const printableWidthMm = Math.max(0, state.widthMm - 4);
-    const printableHeightMm = Math.max(0, state.heightMm - 2);
+    const printableWidthMm = state.widthMm;
+    const printableHeightMm = state.heightMm;
     const exportDpi = 300;
     const pixelsPerMmAtExportDpi = exportDpi / 25.4;
     const scale = pixelsPerMmAtExportDpi / pxPerMm;

--- a/style.css
+++ b/style.css
@@ -34,24 +34,24 @@ main {
   gap: 0.75rem;
 }
 
+
 .label-preview {
   position: relative;
   margin: 0 auto;
-  border: none;
-  border-radius: 0.75rem;
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2YzZjRmNiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZjNmNGY2Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2U1ZTdlYiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNlNWU3ZWIiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
+  border-radius: 0.9rem;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2Y4ZjhhZiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZTFmMWY1Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2RmZTllNiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNkZmU5ZTYiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
   background-size: 20px 20px;
   overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
 }
 
 .label-preview::before {
   content: '';
   position: absolute;
   inset: 0;
-  border-radius: 0.5rem;
-  background: linear-gradient(180deg, #ffffff 0%, #f7fafc 100%);
-  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
-  border: 1.25px solid rgba(15, 23, 42, 0.82);
+  border-radius: 0.75rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.85) 100%);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
   pointer-events: none;
   z-index: 0;
 }
@@ -93,11 +93,14 @@ main {
 
 .hardware-icon {
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: center;
   gap: 8px;
   flex: 0 0 auto;
+  padding: 6px;
+  border-radius: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.38);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
 
 .hardware-icon svg {
@@ -109,6 +112,7 @@ main {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.18));
 }
 
 .custom-image-preview {
@@ -116,6 +120,7 @@ main {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.18));
 }
 
 .custom-image-placeholder {
@@ -126,13 +131,13 @@ main {
   height: 100%;
   min-width: 48px;
   padding: 4px;
-  border: 1px dashed rgba(15, 23, 42, 0.35);
-  border-radius: 4px;
+  border: 1px dashed rgba(180, 83, 9, 0.45);
+  border-radius: 0.45rem;
   text-transform: uppercase;
   font-size: 0.65rem;
   letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.65);
-  background-color: rgba(255, 255, 255, 0.35);
+  color: rgba(148, 64, 11, 0.85);
+  background-color: rgba(255, 255, 255, 0.5);
   text-align: center;
 }
 
@@ -140,45 +145,77 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-left: 4px;
+  align-items: flex-start;
   min-width: 0;
   white-space: normal;
   overflow-wrap: anywhere;
   flex: 1;
-  gap: 0.15em;
+  gap: 0.2em;
 }
 
 .text-line {
   line-height: 1;
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0.01em;
 }
 
 .text-line.small {
-  font-size: 0.68em;
+  font-size: 0.7em;
   font-weight: 600;
-  letter-spacing: 0.06em;
-  color: rgba(15, 23, 42, 0.7);
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.72);
 }
 
 .qr-code {
   position: absolute;
   display: none;
+  border-radius: 0.45rem;
+  background-color: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.22);
 }
 
 .label-inner {
   position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 4px 14px;
+  gap: var(--label-gap, 12px);
   box-sizing: border-box;
-  border-radius: 5px;
-  background-color: #ffffff;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.18);
-  color: #0f172a;
+  border-radius: 0.65rem;
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #fcd34d 100%);
+  border: 1.75px solid rgba(180, 83, 9, 0.4);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+  color: #1f2937;
   font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   overflow: hidden;
+  z-index: 1;
+  --label-padding-x: 14px;
+  --label-padding-y: 10px;
+  --label-padding-right-extra: 0px;
+  --label-accent-width: 12px;
+  padding:
+    var(--label-padding-y)
+    calc(var(--label-padding-x) + var(--label-padding-right-extra))
+    var(--label-padding-y)
+    calc(var(--label-padding-x) + var(--label-accent-width));
+}
+
+.label-inner::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--label-accent-width);
+  background: linear-gradient(180deg, #f97316 0%, #b45309 100%);
+  border-top-left-radius: inherit;
+  border-bottom-left-radius: inherit;
+  z-index: 0;
+}
+
+.label-inner > * {
+  position: relative;
+  z-index: 1;
 }
 
 .qr-info-icon {


### PR DESCRIPTION
## Summary
- restyle the live label preview with a full-bleed layout, new gradient styling, and dynamic spacing so the printed image fills the exported area
- remove the artificial printable-margin calculations so downloads use the exact selected dimensions and update copy to reflect the print-ready size
- ensure standard selections populate labels with the human-readable name only to avoid surfacing DIN codes on the artwork

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc015dd6f883298565496ab11912d2