### PR TITLE
Return label preview to black and white

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,10 +39,9 @@ main {
   position: relative;
   margin: 0 auto;
   border-radius: 0.9rem;
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImNoZWNrZXJlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBwYXR0ZXJuVHJhbnNmb3JtPSJyb3RhdGUoMCkiPjxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2Y4ZjhhZiIvPjxyZWN0IHg9IjEwIiB5PSIxMCIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSIjZTFmMWY1Ii8+PHJlY3QgeD0iMTAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2RmZTllNiIvPjxyZWN0IHk9IjEwIiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIGZpbGw9IiNkZmU5ZTYiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjY2hlY2tlcmVkKSIvPjwvc3ZnPg==");
-  background-size: 20px 20px;
+  background-color: #ffffff;
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+  border: 1px solid #000000;
 }
 
 .label-preview::before {
@@ -50,8 +49,8 @@ main {
   position: absolute;
   inset: 0;
   border-radius: 0.75rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.85) 100%);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+  background: transparent;
+  box-shadow: none;
   pointer-events: none;
   z-index: 0;
 }
@@ -99,8 +98,9 @@ main {
   flex: 0 0 auto;
   padding: 6px;
   border-radius: 0.5rem;
-  background-color: rgba(255, 255, 255, 0.38);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  background-color: #ffffff;
+  border: 1px solid #000000;
+  box-shadow: none;
 }
 
 .hardware-icon svg {
@@ -112,7 +112,7 @@ main {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.18));
+  filter: grayscale(100%);
 }
 
 .custom-image-preview {
@@ -120,7 +120,7 @@ main {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.18));
+  filter: grayscale(100%);
 }
 
 .custom-image-placeholder {
@@ -131,12 +131,12 @@ main {
   height: 100%;
   min-width: 48px;
   padding: 4px;
-  border: 1px dashed rgba(180, 83, 9, 0.45);
+  border: 1px dashed #000000;
   border-radius: 0.45rem;
   text-transform: uppercase;
   font-size: 0.65rem;
   letter-spacing: 0.08em;
-  color: rgba(148, 64, 11, 0.85);
+  color: #000000;
   background-color: rgba(255, 255, 255, 0.5);
   text-align: center;
 }
@@ -163,15 +163,16 @@ main {
   font-size: 0.7em;
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.72);
+  color: #000000;
 }
 
 .qr-code {
   position: absolute;
   display: none;
   border-radius: 0.45rem;
-  background-color: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.22);
+  background-color: #ffffff;
+  border: 1px solid #000000;
+  box-shadow: none;
 }
 
 .label-inner {
@@ -182,10 +183,10 @@ main {
   gap: var(--label-gap, 12px);
   box-sizing: border-box;
   border-radius: 0.65rem;
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #fcd34d 100%);
-  border: 1.75px solid rgba(180, 83, 9, 0.4);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.45);
-  color: #1f2937;
+  background: #ffffff;
+  border: 2px solid #000000;
+  box-shadow: none;
+  color: #000000;
   font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   overflow: hidden;
   z-index: 1;
@@ -207,7 +208,7 @@ main {
   bottom: 0;
   left: 0;
   width: var(--label-accent-width);
-  background: linear-gradient(180deg, #f97316 0%, #b45309 100%);
+  background: #000000;
   border-top-left-radius: inherit;
   border-bottom-left-radius: inherit;
   z-index: 0;


### PR DESCRIPTION
## Summary
- restore the label preview container with a white background and black border to match the monochrome brief
- replace gradient fills, colored accents, and shadows on the label with solid black and white styling
- force hardware images and custom artwork to render in grayscale with neutral placeholder accents

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc091044a88329b9893ac72fccceaa