### PR TITLE
Add mobile dropdown for hardware type selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,25 @@
             <h2 class="h5 mb-3 section-heading">Hardware Details</h2>
             <div class="vstack gap-3">
               <div>
-                <label class="form-label fw-semibold">Hardware Type</label>
-                <div class="row g-2" id="hardware-type-group">
+                <label class="form-label fw-semibold" id="hardware-type-label">Hardware Type</label>
+                <div class="d-sm-none">
+                  <select
+                    id="hardware-type-select"
+                    class="form-select"
+                    aria-labelledby="hardware-type-label"
+                  >
+                    <option value="Screw">Screw</option>
+                    <option value="Nut">Nut</option>
+                    <option value="Heat Insert">Heat Insert</option>
+                    <option value="Washer">Washer</option>
+                    <option value="Fuse">Fuse</option>
+                    <option value="Connector">Connector</option>
+                    <option value="Component">Component</option>
+                    <option value="Bearing">Bearing</option>
+                    <option value="Custom">Custom</option>
+                  </select>
+                </div>
+                <div class="row g-2 d-none d-sm-flex" id="hardware-type-group">
                   <div class="col-12 col-sm-6 col-lg-3">
                     <input
                       type="radio"

--- a/script.js
+++ b/script.js
@@ -376,6 +376,7 @@
   const printButton = document.getElementById('print-button');
 
   const hardwareTypeRadios = document.querySelectorAll('input[name="hardware-type"]');
+  const hardwareTypeSelect = document.getElementById('hardware-type-select');
   const systemTypeRadios = document.querySelectorAll('input[name="system-type"]');
   const screwTypeRadios = document.querySelectorAll('input[name="screw-type"]');
   const fuseTypeRadios = document.querySelectorAll('input[name="fuse-type"]');
@@ -959,12 +960,23 @@
     }
   }
 
+  function syncHardwareTypeControls(nextType) {
+    const desiredType = nextType || state.hardwareType;
+    if (hardwareTypeSelect) {
+      hardwareTypeSelect.value = desiredType;
+    }
+    hardwareTypeRadios.forEach(radio => {
+      radio.checked = radio.value === desiredType;
+    });
+  }
+
   /**
    * Handle changes when the hardware type (Screw, Nut, Washer) changes.
    * Show or hide relevant form fields accordingly.
    */
   function onHardwareTypeChange() {
     const type = state.hardwareType;
+    syncHardwareTypeControls(type);
     const showScrewFields = type === 'Screw';
     const showFuseFields = type === 'Fuse';
     const showConnectorFields = type === 'Connector';
@@ -2009,6 +2021,16 @@
         }
       });
     });
+
+    if (hardwareTypeSelect) {
+      hardwareTypeSelect.addEventListener('change', () => {
+        const selectedType = hardwareTypeSelect.value;
+        if (selectedType) {
+          state.hardwareType = selectedType;
+          onHardwareTypeChange();
+        }
+      });
+    }
 
     if (connectorCategorySelect) {
       connectorCategorySelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- add a mobile-only hardware type `<select>` to replace the long radio list on small screens
- keep desktop radio buttons and synchronise both controls in JavaScript so selections stay in sync

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc910334d083299e8b4eb9bdffcfac