### PR TITLE
Improve form control labelling for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
                 </div>
               </div>
               <div id="custom-fields" class="d-none">
-                <span class="form-label d-block fw-semibold">Custom Image</span>
+                <label for="custom-image-input" class="form-label d-block fw-semibold">Custom Image</label>
                 <input type="file" class="form-control" id="custom-image-input" accept="image/*" />
                 <div class="form-text">Square images work best. PNG, JPG and SVG files are supported.</div>
                 <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
@@ -464,33 +464,39 @@
             <h2 class="h5 mb-3 section-heading">Label Settings</h2>
             <div class="vstack gap-3">
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                <label
+                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                  for="standard-toggle"
+                >
                   <i class="fa-solid fa-book text-secondary fs-5" aria-hidden="true"></i>
-                  Standard Reference
-                </span>
-                <div class="form-check form-switch m-0">
+                  <span>Standard Reference</span>
+                </label>
+                <div class="form-check form-switch m-0 ps-0">
                   <input class="form-check-input" type="checkbox" role="switch" id="standard-toggle" checked />
-                  <label class="form-check-label visually-hidden" for="standard-toggle">Toggle standard reference</label>
                 </div>
               </div>
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                <label
+                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                  for="image-toggle"
+                >
                   <i class="fa-solid fa-image text-secondary fs-5" aria-hidden="true"></i>
-                  Image
-                </span>
-                <div class="form-check form-switch m-0">
+                  <span>Image</span>
+                </label>
+                <div class="form-check form-switch m-0 ps-0">
                   <input class="form-check-input" type="checkbox" role="switch" id="image-toggle" checked />
-                  <label class="form-check-label visually-hidden" for="image-toggle">Toggle hardware image</label>
                 </div>
               </div>
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <span class="d-flex align-items-center gap-2 fw-semibold text-body">
+                <label
+                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                  for="qrcode-toggle"
+                >
                   <i class="fa-solid fa-qrcode text-secondary fs-5" aria-hidden="true"></i>
-                  QR Code
-                </span>
-                <div class="form-check form-switch m-0">
+                  <span>QR Code</span>
+                </label>
+                <div class="form-check form-switch m-0 ps-0">
                   <input class="form-check-input" type="checkbox" role="switch" id="qrcode-toggle" />
-                  <label class="form-check-label visually-hidden" for="qrcode-toggle">Toggle QR code</label>
                 </div>
               </div>
               <div id="qr-content-wrapper" class="p-3 rounded-4 border bg-body-secondary d-none">


### PR DESCRIPTION
## Summary
- add a visible label to the custom image file input to follow W3C guidance
- rework the standard, image, and QR code toggles to use visible `<label>` associations instead of hidden text
- remove extra padding on the switch containers to keep their alignment after the markup change

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccb1a77e6483299a7ebc3f4f67ef70