### PR TITLE
Lazy load optional libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
   <!--
     Standalone tool for generating and printing Gridfinity labels.  Styling
     now layers a lightweight Bootstrap 5 theme for modern form controls and
-    layout utilities.  Two small third-party libraries are loaded via CDN:
-    html2canvas to capture the label preview as an image and qrcode to
-    generate optional QR codes.
+    layout utilities.  Two small third-party libraries are loaded on demand
+    via CDN: html2canvas to capture the label preview as an image and qrcode
+    to generate optional QR codes.
   -->
   <link
     rel="stylesheet"
@@ -54,8 +54,6 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
-  <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
   <script type="module" src="js/main.js"></script>
 </head>
 <body>

--- a/js/lazy-loaders.js
+++ b/js/lazy-loaders.js
@@ -1,0 +1,57 @@
+const scriptPromises = new Map();
+
+function loadScript(src, globalName) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.reject(new Error('Script loading is only available in the browser.'));
+  }
+
+  if (globalName && window[globalName]) {
+    return Promise.resolve(window[globalName]);
+  }
+
+  if (scriptPromises.has(src)) {
+    return scriptPromises.get(src);
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+
+    script.addEventListener('load', () => {
+      if (globalName) {
+        const globalValue = window[globalName];
+        if (!globalValue) {
+          scriptPromises.delete(src);
+          reject(new Error(`Global ${globalName} was not found after loading ${src}.`));
+          return;
+        }
+        resolve(globalValue);
+        return;
+      }
+      resolve();
+    });
+
+    script.addEventListener('error', () => {
+      scriptPromises.delete(src);
+      reject(new Error(`Failed to load script: ${src}`));
+    });
+
+    document.head.appendChild(script);
+  });
+
+  scriptPromises.set(src, promise);
+  return promise;
+}
+
+export function loadHtml2Canvas() {
+  return loadScript(
+    'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js',
+    'html2canvas'
+  );
+}
+
+export function loadQrCodeLibrary() {
+  return loadScript('https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js', 'QRCode');
+}

--- a/js/preview.js
+++ b/js/preview.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
 import { pxPerMm, hardwareImageFolders, findConnectorCategory } from './data.js';
+import { loadHtml2Canvas, loadQrCodeLibrary } from './lazy-loaders.js';
 
 const {
   labelSizeDisplay,
@@ -18,6 +19,8 @@ const {
   downloadButton,
   printButton
 } = elements;
+
+let qrRenderRequestId = 0;
 
 function normalizeStandardCode(code) {
   return (code || '')
@@ -637,18 +640,46 @@ export function updatePreview() {
     if (ctx) {
       ctx.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
     }
-    try {
-      QRCode.toCanvas(qrCanvas, qrContent, {
-        margin: 1,
-        width: qrSize,
-        color: {
-          dark: '#000',
-          light: '#00000000'
+
+    const requestId = ++qrRenderRequestId;
+    loadQrCodeLibrary()
+      .then(qrCodeLib => {
+        if (qrRenderRequestId !== requestId) {
+          return;
         }
+        const latestContent = state.qrContent ? state.qrContent.trim() : '';
+        if (!state.showQr || !latestContent || !qrCanvas) {
+          return;
+        }
+        const renderFn = qrCodeLib && typeof qrCodeLib.toCanvas === 'function' ? qrCodeLib.toCanvas : null;
+        if (!renderFn) {
+          throw new Error('QR code library is missing the toCanvas function.');
+        }
+        try {
+          renderFn.call(qrCodeLib, qrCanvas, latestContent, {
+            margin: 1,
+            width: qrSize,
+            color: {
+              dark: '#000',
+              light: '#00000000'
+            }
+          });
+        } catch (err) {
+          console.error('QR code generation failed', err);
+        }
+      })
+      .catch(err => {
+        if (qrRenderRequestId === requestId && qrCanvas) {
+          const qrContext = qrCanvas.getContext('2d');
+          if (qrContext) {
+            qrContext.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
+          }
+          qrCanvas.style.display = 'none';
+          labelInner.style.setProperty('--label-padding-right-extra', '0px');
+        }
+        console.error('QR code library failed to load', err);
       });
-    } catch (err) {
-      console.error('QR code generation failed', err);
-    }
+
     const qrPadding = Math.max(basePaddingX, Math.round(qrSize + pxPerMm * 1.5));
     const extraRight = Math.max(0, qrPadding - basePaddingX);
     labelInner.style.setProperty('--label-padding-right-extra', `${extraRight}px`);
@@ -664,9 +695,9 @@ export function updatePreview() {
   applyTextFitting(primaryFontSize, secondaryFontSize);
 }
 
-export function renderLabelCanvas() {
+export async function renderLabelCanvas() {
   if (!previewContainer || !labelInner) {
-    return Promise.reject(new Error('Label preview is not available.'));
+    throw new Error('Label preview is not available.');
   }
 
   const printableWidthMm = state.widthMm;
@@ -678,51 +709,52 @@ export function renderLabelCanvas() {
   const containerWidth = previewContainer.offsetWidth || previewContainer.clientWidth;
   const containerHeight = previewContainer.offsetHeight || previewContainer.clientHeight;
   if (!containerWidth || !containerHeight) {
-    return Promise.reject(new Error('Label preview has no measurable size.'));
+    throw new Error('Label preview has no measurable size.');
   }
 
-  return html2canvas(previewContainer, {
+  const html2canvas = await loadHtml2Canvas();
+  const canvas = await html2canvas(previewContainer, {
     backgroundColor: null,
     scale,
     width: containerWidth,
     height: containerHeight,
     scrollX: 0,
     scrollY: 0
-  }).then(canvas => {
-    const containerRect = previewContainer.getBoundingClientRect();
-    const innerRect = labelInner.getBoundingClientRect();
-    const ratioX = canvas.width / containerWidth;
-    const ratioY = canvas.height / containerHeight;
-    const cropX = Math.max(0, Math.floor((innerRect.left - containerRect.left) * ratioX));
-    const cropY = Math.max(0, Math.floor((innerRect.top - containerRect.top) * ratioY));
-    const cropWidth = Math.max(1, Math.ceil(innerRect.width * ratioX));
-    const cropHeight = Math.max(1, Math.ceil(innerRect.height * ratioY));
-    const sourceWidth = Math.min(cropWidth, canvas.width - cropX);
-    const sourceHeight = Math.min(cropHeight, canvas.height - cropY);
-
-    if (sourceWidth <= 0 || sourceHeight <= 0) {
-      throw new Error('Computed label dimensions are invalid.');
-    }
-
-    const outputCanvas = document.createElement('canvas');
-    const targetWidthPx = Math.max(1, Math.round(printableWidthMm * pixelsPerMmAtExportDpi));
-    const targetHeightPx = Math.max(1, Math.round(printableHeightMm * pixelsPerMmAtExportDpi));
-    outputCanvas.width = targetWidthPx;
-    outputCanvas.height = targetHeightPx;
-    const ctx = outputCanvas.getContext('2d');
-    if (ctx) {
-      ctx.drawImage(
-        canvas,
-        cropX,
-        cropY,
-        sourceWidth,
-        sourceHeight,
-        0,
-        0,
-        outputCanvas.width,
-        outputCanvas.height
-      );
-    }
-    return outputCanvas;
   });
+
+  const containerRect = previewContainer.getBoundingClientRect();
+  const innerRect = labelInner.getBoundingClientRect();
+  const ratioX = canvas.width / containerWidth;
+  const ratioY = canvas.height / containerHeight;
+  const cropX = Math.max(0, Math.floor((innerRect.left - containerRect.left) * ratioX));
+  const cropY = Math.max(0, Math.floor((innerRect.top - containerRect.top) * ratioY));
+  const cropWidth = Math.max(1, Math.ceil(innerRect.width * ratioX));
+  const cropHeight = Math.max(1, Math.ceil(innerRect.height * ratioY));
+  const sourceWidth = Math.min(cropWidth, canvas.width - cropX);
+  const sourceHeight = Math.min(cropHeight, canvas.height - cropY);
+
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    throw new Error('Computed label dimensions are invalid.');
+  }
+
+  const outputCanvas = document.createElement('canvas');
+  const targetWidthPx = Math.max(1, Math.round(printableWidthMm * pixelsPerMmAtExportDpi));
+  const targetHeightPx = Math.max(1, Math.round(printableHeightMm * pixelsPerMmAtExportDpi));
+  outputCanvas.width = targetWidthPx;
+  outputCanvas.height = targetHeightPx;
+  const ctx = outputCanvas.getContext('2d');
+  if (ctx) {
+    ctx.drawImage(
+      canvas,
+      cropX,
+      cropY,
+      sourceWidth,
+      sourceHeight,
+      0,
+      0,
+      outputCanvas.width,
+      outputCanvas.height
+    );
+  }
+  return outputCanvas;
 }


### PR DESCRIPTION
## Summary
- add a shared loader that injects external scripts on demand and resolves their global exports
- lazy load html2canvas for downloads/printing and the QR code library only when a QR code is shown
- drop upfront CDN script tags now that optional libraries load dynamically

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccb701856c83299c4358bc9d09319c