### PR TITLE
Add inline validation guidance for label form

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
                   </button>
                   <span id="custom-image-name" class="text-muted small d-none"></span>
                 </div>
-                <div class="mt-3">
+                <div class="mt-3" id="custom-line1-field">
                   <label for="custom-line1-input" class="form-label fw-semibold">Top Line</label>
                   <input
                     type="text"
@@ -249,8 +249,13 @@
                     id="custom-line1-input"
                     placeholder="e.g., 5 mm Drill Bits"
                     maxlength="60"
+                    aria-describedby="custom-line1-hint custom-line1-message"
                   />
-                  <div class="form-text">Shown as the large title on the label.</div>
+                  <div class="form-text" id="custom-line1-hint">Shown as the large title on the label.</div>
+                  <div
+                    id="custom-line1-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
                 </div>
                 <div>
                   <label for="custom-line2-input" class="form-label fw-semibold">Bottom Line</label>
@@ -265,8 +270,16 @@
               </div>
               <div id="connector-category-container" class="d-none">
                 <label for="connector-category-select" class="form-label fw-semibold">Connector Category</label>
-                <select id="connector-category-select" class="form-select"></select>
+                <select
+                  id="connector-category-select"
+                  class="form-select"
+                  aria-describedby="connector-category-message"
+                ></select>
                 <div id="connector-category-help" class="form-text d-none"></div>
+                <div
+                  id="connector-category-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="component-category-container" class="d-none">
                 <span class="form-label d-block fw-semibold">Component Type</span>
@@ -306,6 +319,10 @@
                     <label class="btn btn-outline-secondary w-100" for="component-type-diode">Diode</label>
                   </div>
                 </div>
+                <div
+                  id="component-category-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="component-mount-container" class="d-none">
                 <span class="form-label d-block fw-semibold">Mounting Style</span>
@@ -334,11 +351,23 @@
                     <label class="btn btn-outline-secondary w-100" for="component-mount-smd">SMD</label>
                   </div>
                 </div>
+                <div
+                  id="component-mount-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="bearing-options-container" class="d-none">
                 <label for="bearing-type-select" class="form-label fw-semibold">Bearing Selection</label>
-                <select id="bearing-type-select" class="form-select"></select>
+                <select
+                  id="bearing-type-select"
+                  class="form-select"
+                  aria-describedby="bearing-type-message"
+                ></select>
                 <div class="form-text">Common miniature and deep-groove bearings used in hobby projects.</div>
+                <div
+                  id="bearing-type-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="screw-type-container">
                 <label class="form-label fw-semibold">Screw Type</label>
@@ -371,7 +400,15 @@
               <div class="row g-3" id="thread-length-row">
                 <div class="col-12 col-sm-6 thread-length-field" id="thread-size-container">
                   <label for="thread-size-select" class="form-label fw-semibold">Thread Size</label>
-                  <select id="thread-size-select" class="form-select"></select>
+                  <select
+                    id="thread-size-select"
+                    class="form-select"
+                    aria-describedby="thread-size-message"
+                  ></select>
+                  <div
+                    id="thread-size-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
                 </div>
                 <div class="col-12 col-sm-6 thread-length-field" id="length-container">
                   <label for="length-input" class="form-label fw-semibold">Length</label>
@@ -381,7 +418,32 @@
                     class="form-control"
                     placeholder="e.g., 10"
                     min="1"
+                    aria-describedby="length-tip length-message"
                   />
+                  <div id="length-tip" class="form-text">
+                    Measure from under the head for socket and hex fasteners; include the head for
+                    countersunk screws.
+                  </div>
+                  <details class="field-help mt-2" id="length-help">
+                    <summary class="field-help-summary">
+                      <i class="fa-solid fa-ruler-combined" aria-hidden="true"></i>
+                      <span>How to measure screw length</span>
+                    </summary>
+                    <div class="field-help-body">
+                      <p class="mb-2">
+                        Use a caliper or ruler and follow the conventions below when entering the length value:
+                      </p>
+                      <ul class="mb-0 ps-3">
+                        <li>Socket head, button head, and hex bolts: measure from under the head to the tip.</li>
+                        <li>Flat head or countersunk screws: measure the full length including the head.</li>
+                        <li>Set screws and grub screws: measure the overall body length end to end.</li>
+                      </ul>
+                    </div>
+                  </details>
+                  <div
+                    id="length-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
                 </div>
               </div>
               <div id="fuse-type-container" class="d-none">
@@ -414,7 +476,15 @@
               </div>
               <div id="fuse-value-container" class="d-none">
                 <label for="fuse-value-select" class="form-label fw-semibold">Fuse Value (amps)</label>
-                <select id="fuse-value-select" class="form-select"></select>
+                <select
+                  id="fuse-value-select"
+                  class="form-select"
+                  aria-describedby="fuse-value-message"
+                ></select>
+                <div
+                  id="fuse-value-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="glass-options-container" class="d-none">
                 <span class="form-label d-block fw-semibold">Glass Fuse Options</span>
@@ -443,10 +513,15 @@
                   id="notes-input"
                   class="form-control"
                   placeholder="Notes (optional)"
+                  aria-describedby="connector-notes-hint connector-notes-message"
                 />
                 <div id="connector-notes-hint" class="form-text d-none">
                   Provide the connector series, pin count, wire size, and terminal style when labelling connectors.
                 </div>
+                <div
+                  id="connector-notes-message"
+                  class="validation-message text-danger small mt-2 d-none"
+                ></div>
               </div>
               <div id="standard-field">
                 <label for="standard-select" class="form-label fw-semibold">Hardware Standard</label>
@@ -575,6 +650,12 @@
         </div>
       </div>
     </section>
+    <div
+      id="form-status-message"
+      class="alert alert-warning d-none mt-4"
+      role="status"
+      aria-live="polite"
+    ></div>
     <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
       <button id="download-button" class="btn btn-primary btn-lg px-4" disabled>Download</button>
       <button id="print-button" class="btn btn-outline-primary btn-lg px-4" type="button" disabled>Print</button>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -8,6 +8,8 @@ const threadSizeSelect = document.getElementById('thread-size-select');
 const threadLengthRow = document.getElementById('thread-length-row');
 const lengthContainer = document.getElementById('length-container');
 const lengthInput = document.getElementById('length-input');
+const threadSizeMessage = document.getElementById('thread-size-message');
+const lengthMessage = document.getElementById('length-message');
 const fuseTypeContainer = document.getElementById('fuse-type-container');
 const fuseValueContainer = document.getElementById('fuse-value-container');
 const glassOptionsContainer = document.getElementById('glass-options-container');
@@ -15,22 +17,28 @@ const fuseValueSelect = document.getElementById('fuse-value-select');
 const glassSizeSelect = document.getElementById('glass-size-select');
 const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
 const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
+const fuseValueMessage = document.getElementById('fuse-value-message');
 const notesInput = document.getElementById('notes-input');
 const measurementSystemContainer = document.getElementById('measurement-system-container');
 const connectorCategoryContainer = document.getElementById('connector-category-container');
 const connectorCategorySelect = document.getElementById('connector-category-select');
 const connectorCategoryHelp = document.getElementById('connector-category-help');
 const connectorNotesHint = document.getElementById('connector-notes-hint');
+const connectorCategoryMessage = document.getElementById('connector-category-message');
+const connectorNotesMessage = document.getElementById('connector-notes-message');
 const componentCategoryContainer = document.getElementById('component-category-container');
 const componentMountContainer = document.getElementById('component-mount-container');
 const bearingOptionsContainer = document.getElementById('bearing-options-container');
 const bearingTypeSelect = document.getElementById('bearing-type-select');
+const bearingTypeMessage = document.getElementById('bearing-type-message');
 const customFieldsContainer = document.getElementById('custom-fields');
 const customImageInput = document.getElementById('custom-image-input');
 const customImageClearButton = document.getElementById('custom-image-clear');
 const customImageNameDisplay = document.getElementById('custom-image-name');
 const customLine1Input = document.getElementById('custom-line1-input');
 const customLine2Input = document.getElementById('custom-line2-input');
+const customLine1Field = document.getElementById('custom-line1-field');
+const customLine1Message = document.getElementById('custom-line1-message');
 const notesField = document.getElementById('notes-field');
 const standardField = document.getElementById('standard-field');
 const notesLabel = document.querySelector('label[for="notes-input"]');
@@ -77,6 +85,9 @@ const fuseTypeRadios = Array.from(document.querySelectorAll('input[name="fuse-ty
 const heightRadios = Array.from(document.querySelectorAll('input[name="label-height"]'));
 const componentCategoryRadios = Array.from(document.querySelectorAll('input[name="component-category"]'));
 const componentMountRadios = Array.from(document.querySelectorAll('input[name="component-mount"]'));
+const componentCategoryMessage = document.getElementById('component-category-message');
+const componentMountMessage = document.getElementById('component-mount-message');
+const formStatusMessage = document.getElementById('form-status-message');
 
 export const elements = {
   themeToggleButton,
@@ -88,6 +99,8 @@ export const elements = {
   threadLengthRow,
   lengthContainer,
   lengthInput,
+  threadSizeMessage,
+  lengthMessage,
   fuseTypeContainer,
   fuseValueContainer,
   glassOptionsContainer,
@@ -95,22 +108,28 @@ export const elements = {
   glassSizeSelect,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
+  fuseValueMessage,
   notesInput,
   measurementSystemContainer,
   connectorCategoryContainer,
   connectorCategorySelect,
   connectorCategoryHelp,
   connectorNotesHint,
+  connectorCategoryMessage,
+  connectorNotesMessage,
   componentCategoryContainer,
   componentMountContainer,
   bearingOptionsContainer,
   bearingTypeSelect,
+  bearingTypeMessage,
   customFieldsContainer,
   customImageInput,
   customImageClearButton,
   customImageNameDisplay,
   customLine1Input,
   customLine2Input,
+  customLine1Field,
+  customLine1Message,
   notesField,
   standardField,
   notesLabel,
@@ -146,5 +165,8 @@ export const elements = {
   fuseTypeRadios,
   heightRadios,
   componentCategoryRadios,
-  componentMountRadios
+  componentMountRadios,
+  componentCategoryMessage,
+  componentMountMessage,
+  formStatusMessage
 };

--- a/js/preview.js
+++ b/js/preview.js
@@ -17,10 +17,236 @@ const {
   qrContentWrapper,
   qrContentInput,
   downloadButton,
-  printButton
+  printButton,
+  threadSizeSelect,
+  threadSizeContainer,
+  lengthInput,
+  lengthContainer,
+  fuseValueSelect,
+  fuseValueContainer,
+  connectorCategorySelect,
+  connectorCategoryContainer,
+  notesInput,
+  notesField,
+  bearingTypeSelect,
+  bearingOptionsContainer,
+  componentCategoryContainer,
+  componentCategoryRadios,
+  componentMountContainer,
+  componentMountRadios,
+  customLine1Input,
+  customLine1Field,
+  threadSizeMessage,
+  lengthMessage,
+  fuseValueMessage,
+  connectorCategoryMessage,
+  connectorNotesMessage,
+  bearingTypeMessage,
+  componentCategoryMessage,
+  componentMountMessage,
+  customLine1Message,
+  formStatusMessage
 } = elements;
 
 let qrRenderRequestId = 0;
+
+function setMessageVisibility(messageElement, message, show) {
+  if (!messageElement) {
+    return;
+  }
+  if (show) {
+    messageElement.textContent = message;
+    messageElement.classList.remove('d-none');
+    messageElement.setAttribute('aria-hidden', 'false');
+  } else {
+    messageElement.textContent = '';
+    messageElement.classList.add('d-none');
+    messageElement.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function updateInputFieldState({ input, container, messageElement, valid, message }) {
+  if (input) {
+    if (valid) {
+      input.classList.remove('is-invalid');
+      input.removeAttribute('aria-invalid');
+    } else {
+      input.classList.add('is-invalid');
+      input.setAttribute('aria-invalid', 'true');
+    }
+  }
+  if (container) {
+    container.classList.toggle('field-invalid', !valid);
+  }
+  setMessageVisibility(messageElement, message, !valid);
+}
+
+function updateRadioGroupFeedback({ radios, container, messageElement, valid, message }) {
+  if (Array.isArray(radios)) {
+    radios.forEach(radio => {
+      if (!radio) {
+        return;
+      }
+      if (valid) {
+        radio.removeAttribute('aria-invalid');
+      } else {
+        radio.setAttribute('aria-invalid', 'true');
+      }
+    });
+  }
+  if (container) {
+    container.classList.toggle('field-invalid', !valid);
+  }
+  setMessageVisibility(messageElement, message, !valid);
+}
+
+function formatRequirementSummary(requirements) {
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return '';
+  }
+  if (requirements.length === 1) {
+    return requirements[0];
+  }
+  const allButLast = requirements.slice(0, -1);
+  const last = requirements[requirements.length - 1];
+  return `${allButLast.join(', ')} and ${last}`;
+}
+
+function applyValidationFeedback(disabled) {
+  const requirements = [];
+  const hardwareType = state.hardwareType;
+  const hardwareLabel = hardwareType ? hardwareType.toLowerCase() : 'hardware';
+  const screwLabel = (state.screwType || 'screw').toLowerCase();
+
+  const needsThreadSize = !['Fuse', 'Connector', 'Custom', 'Bearing', 'Component'].includes(hardwareType);
+  const threadValid = !needsThreadSize || Boolean(state.threadSize);
+  const threadMessage = `Select a thread size for your ${hardwareType === 'Screw' ? screwLabel : hardwareLabel} to continue.`;
+  updateInputFieldState({
+    input: threadSizeSelect,
+    container: threadSizeContainer,
+    messageElement: threadSizeMessage,
+    valid: threadValid,
+    message: threadMessage
+  });
+  if (!threadValid) {
+    requirements.push('select a thread size');
+  }
+
+  const needsLength = hardwareType === 'Screw';
+  const lengthValue = Number.parseFloat(state.length);
+  const lengthValid = !needsLength || (Number.isFinite(lengthValue) && lengthValue > 0);
+  updateInputFieldState({
+    input: lengthInput,
+    container: lengthContainer,
+    messageElement: lengthMessage,
+    valid: lengthValid,
+    message: `Enter the ${screwLabel} length in millimeters to continue.`
+  });
+  if (!lengthValid) {
+    requirements.push(`enter the ${screwLabel} length`);
+  }
+
+  const needsFuseValue = hardwareType === 'Fuse';
+  const fuseValid = !needsFuseValue || Boolean(state.fuseValue);
+  updateInputFieldState({
+    input: fuseValueSelect,
+    container: fuseValueContainer,
+    messageElement: fuseValueMessage,
+    valid: fuseValid,
+    message: 'Choose a fuse value to continue.'
+  });
+  if (!fuseValid) {
+    requirements.push('choose a fuse value');
+  }
+
+  const needsConnectorDetails = hardwareType === 'Connector';
+  const connectorCategoryValid = !needsConnectorDetails || Boolean(state.connectorCategory);
+  updateInputFieldState({
+    input: connectorCategorySelect,
+    container: connectorCategoryContainer,
+    messageElement: connectorCategoryMessage,
+    valid: connectorCategoryValid,
+    message: 'Choose a connector category to continue.'
+  });
+  if (!connectorCategoryValid) {
+    requirements.push('choose a connector category');
+  }
+
+  const connectorNotesValid = !needsConnectorDetails || Boolean(state.notes && state.notes.trim().length > 0);
+  updateInputFieldState({
+    input: notesInput,
+    container: notesField,
+    messageElement: connectorNotesMessage,
+    valid: connectorNotesValid,
+    message: 'Add connector details (series, pin count, wire gauge) to continue.'
+  });
+  if (!connectorNotesValid) {
+    requirements.push('add connector details');
+  }
+
+  const needsBearingSelection = hardwareType === 'Bearing';
+  const bearingValid = !needsBearingSelection || Boolean(state.bearingType);
+  updateInputFieldState({
+    input: bearingTypeSelect,
+    container: bearingOptionsContainer,
+    messageElement: bearingTypeMessage,
+    valid: bearingValid,
+    message: 'Select a bearing to continue.'
+  });
+  if (!bearingValid) {
+    requirements.push('select a bearing');
+  }
+
+  const needsComponentSelection = hardwareType === 'Component';
+  const componentCategoryValid = !needsComponentSelection || Boolean(state.componentCategory);
+  updateRadioGroupFeedback({
+    radios: componentCategoryRadios,
+    container: componentCategoryContainer,
+    messageElement: componentCategoryMessage,
+    valid: componentCategoryValid,
+    message: 'Choose a component type to continue.'
+  });
+  if (!componentCategoryValid) {
+    requirements.push('choose a component type');
+  }
+
+  const componentMountValid = !needsComponentSelection || Boolean(state.componentMount);
+  updateRadioGroupFeedback({
+    radios: componentMountRadios,
+    container: componentMountContainer,
+    messageElement: componentMountMessage,
+    valid: componentMountValid,
+    message: 'Choose a mounting style to continue.'
+  });
+  if (!componentMountValid) {
+    requirements.push('choose a mounting style');
+  }
+
+  const needsCustomTitle = hardwareType === 'Custom';
+  const customTitle = (state.customLine1 || '').trim();
+  const customTitleValid = !needsCustomTitle || customTitle.length > 0;
+  updateInputFieldState({
+    input: customLine1Input,
+    container: customLine1Field,
+    messageElement: customLine1Message,
+    valid: customTitleValid,
+    message: 'Add a title for your custom label to continue.'
+  });
+  if (!customTitleValid) {
+    requirements.push('add a custom label title');
+  }
+
+  if (formStatusMessage) {
+    if (disabled) {
+      const summary = requirements.length > 0 ? formatRequirementSummary(requirements) : 'complete the required fields';
+      formStatusMessage.textContent = `To enable Download and Print, ${summary}.`;
+      formStatusMessage.classList.remove('d-none');
+    } else {
+      formStatusMessage.textContent = '';
+      formStatusMessage.classList.add('d-none');
+    }
+  }
+}
 
 function normalizeStandardCode(code) {
   return (code || '')
@@ -338,6 +564,7 @@ export function updateDownloadState() {
   if (printButton) {
     printButton.disabled = disabled;
   }
+  applyValidationFeedback(disabled);
 }
 
 export function updateQrContentVisibility(options = {}) {

--- a/style.css
+++ b/style.css
@@ -20,6 +20,9 @@
   --theme-toggle-border: rgba(15, 23, 42, 0.12);
   --theme-toggle-color: #0f172a;
   --theme-toggle-focus-ring: rgba(59, 130, 246, 0.4);
+  --field-invalid-ring: rgba(220, 53, 69, 0.45);
+  --field-help-bg: rgba(148, 163, 184, 0.12);
+  --field-help-border: rgba(148, 163, 184, 0.4);
 }
 
 :root[data-theme='dark'] {
@@ -39,6 +42,9 @@
   --theme-toggle-border: rgba(148, 163, 184, 0.55);
   --theme-toggle-color: #e2e8f0;
   --theme-toggle-focus-ring: rgba(125, 211, 252, 0.45);
+  --field-invalid-ring: rgba(248, 113, 113, 0.6);
+  --field-help-bg: rgba(148, 163, 184, 0.18);
+  --field-help-border: rgba(148, 163, 184, 0.55);
 }
 
 body {
@@ -65,6 +71,70 @@ main {
 .section-heading {
   font-family: "Walter Turncoat", cursive;
   font-size: clamp(1.5rem, 2.5vw, 1.9rem);
+}
+
+.field-help {
+  border-radius: 0.9rem;
+  border: 1px solid var(--field-help-border);
+  background-color: var(--field-help-bg);
+  padding: 0.75rem 1rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.field-help[open] {
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.field-help-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.field-help-summary::-webkit-details-marker {
+  display: none;
+}
+
+.field-help-summary i {
+  color: #2563eb;
+}
+
+.field-help-summary:focus-visible {
+  outline: 2px solid var(--theme-toggle-focus-ring);
+  outline-offset: 2px;
+}
+
+:root[data-theme='dark'] .field-help-summary i {
+  color: #93c5fd;
+}
+
+.field-help-body {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.validation-message {
+  font-weight: 600;
+}
+
+.field-invalid {
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+}
+
+.field-invalid::after {
+  content: '';
+  position: absolute;
+  inset: -0.35rem;
+  border-radius: 1rem;
+  border: 2px solid var(--field-invalid-ring);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .size-info {


### PR DESCRIPTION
## Summary
- surface inline validation messages and disable downloads until required fields are completed
- add contextual help for measuring screw length along with a global status alert when information is missing
- wire up DOM references and styling so missing selections are highlighted across hardware types

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccbb8ce2c08329944c69699927edc2