### PR TITLE
Add tooltips and labels to export controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,8 +657,26 @@
       aria-live="polite"
     ></div>
     <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
-      <button id="download-button" class="btn btn-primary btn-lg px-4" disabled>Download</button>
-      <button id="print-button" class="btn btn-outline-primary btn-lg px-4" type="button" disabled>Print</button>
+      <button
+        id="download-button"
+        class="btn btn-primary btn-lg px-4"
+        type="button"
+        disabled
+        aria-label="Download label as a PNG image"
+        title="Download label as a PNG image"
+      >
+        Download
+      </button>
+      <button
+        id="print-button"
+        class="btn btn-outline-primary btn-lg px-4"
+        type="button"
+        disabled
+        aria-label="Open a print-ready preview of the label"
+        title="Open a print-ready preview of the label"
+      >
+        Print
+      </button>
     </div>
   </main>
 </body>

--- a/js/preview.js
+++ b/js/preview.js
@@ -560,9 +560,19 @@ export function updateDownloadState() {
   const disabled = !ready;
   if (downloadButton) {
     downloadButton.disabled = disabled;
+    const downloadActionLabel = 'Download label as a PNG image';
+    downloadButton.setAttribute('aria-label', downloadActionLabel);
+    downloadButton.title = disabled
+      ? 'Complete the label details to enable downloading.'
+      : downloadActionLabel;
   }
   if (printButton) {
     printButton.disabled = disabled;
+    const printActionLabel = 'Open a print-ready preview of the label';
+    printButton.setAttribute('aria-label', printActionLabel);
+    printButton.title = disabled
+      ? 'Complete the label details to enable printing.'
+      : printActionLabel;
   }
   applyValidationFeedback(disabled);
 }


### PR DESCRIPTION
## Summary
- add explicit tooltips and ARIA labels to the download and print buttons in the actions footer
- keep tooltips up to date in JavaScript so users are prompted when the export actions are disabled

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cce3bd2278832989e179ae0e42dbd6