### PR TITLE
Use Tagesschrift font for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Walter+Turncoat&display=swap"
-    rel="stylesheet"
-  />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Tagesschrift&display=swap"
     rel="stylesheet"
   />
   <link

--- a/style.css
+++ b/style.css
@@ -63,13 +63,13 @@ main {
 }
 
 .title-section h1 {
-  font-family: "Montserrat", sans-serif;
+  font-family: "Tagesschrift", sans-serif;
   font-size: clamp(3.25rem, 6vw, 4.5rem);
   line-height: 1.05;
 }
 
 .section-heading {
-  font-family: "Walter Turncoat", cursive;
+  font-family: "Tagesschrift", sans-serif;
   font-size: clamp(1.5rem, 2.5vw, 1.9rem);
 }
 


### PR DESCRIPTION
## Summary
- replace the Walter Turncoat and Montserrat Google font imports with a single Tagesschrift include
- update heading styles to use the Tagesschrift family for consistent typography

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd4852afcc8329b242390201480a9a