### PR TITLE
Adjust main content width

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,7 +54,8 @@ body {
 }
 
 main {
-  max-width: 1200px;
+  max-width: 960px;
+  margin-inline: auto;
 }
 
 .title-section p {


### PR DESCRIPTION
## Summary
- narrow the main content column to a 960px maximum and center it inline to better match the slimmer reference layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd49da926483299cd3e9de5608207c