### PR TITLE
Use Barlow font stack for section headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -70,7 +70,7 @@ main {
 }
 
 .section-heading {
-  font-family: "Tagesschrift", sans-serif;
+  font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   font-size: clamp(1.5rem, 2.5vw, 1.9rem);
 }
 


### PR DESCRIPTION
## Summary
- switch `.section-heading` to the Barlow/Inter font stack already used for label text so headings align with the rest of the UI

## Testing
- Verified in a headless Chromium session that section headings report the Barlow font family and the hero title retains Tagesschrift

------
https://chatgpt.com/codex/tasks/task_e_68cd4c9ee8c483299cffbe34d0e36334