### PR TITLE
Flatten label preview styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,10 +149,10 @@ main {
 .label-preview {
   position: relative;
   margin: 0 auto;
-  border-radius: 0.9rem;
+  border-radius: 0;
   background-color: #ffffff;
-  overflow: hidden;
-  border: 1px solid #000000;
+  overflow: visible;
+  border: 0;
 }
 
 .label-preview::before {
@@ -324,7 +324,7 @@ main {
   box-sizing: border-box;
   border-radius: 0;
   background: #ffffff;
-  border: 2px solid #000000;
+  border: 0;
   box-shadow: none;
   color: #000000;
   font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## Summary
- set the label preview container border radius, border, and overflow to zero for square exports
- remove the inner label border so rendered previews stay flat

## Testing
- Playwright preview/download verification (custom script)


------
https://chatgpt.com/codex/tasks/task_e_68cd76570ef08329baae23f2b2cdbc90