### PR TITLE
Adjust padding for compact labels

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -625,7 +625,20 @@ export function updatePreview() {
   const paddingScale = Math.max(1, Math.min(baseScale, 1.35));
   const verticalScale = Math.max(1, Math.min(baseScale, 1.2));
   const gapScale = Math.max(1, Math.min(baseScale, 1.15));
-  const basePaddingX = Math.max(mmToPx(1.5 * paddingScale), mmToPx(1.2));
+  let horizontalPaddingBaselineMm = 1.5;
+  let minHorizontalPaddingMm = 1.2;
+  if (heightMm <= 12) {
+    const normalizedHeight = Math.max(0, Math.min(heightMm, 12));
+    const heightRatio = normalizedHeight / 12;
+    const minBaselineMm = 1.0;
+    const maxBaselineMm = 1.35;
+    horizontalPaddingBaselineMm = minBaselineMm + (maxBaselineMm - minBaselineMm) * heightRatio;
+    minHorizontalPaddingMm = 0.9;
+  }
+  const basePaddingX = Math.max(
+    mmToPx(horizontalPaddingBaselineMm * paddingScale),
+    mmToPx(minHorizontalPaddingMm)
+  );
   const basePaddingY = Math.max(mmToPx(1.0 * verticalScale), mmToPx(0.8));
   const baseGap = Math.max(mmToPx(0.8 * gapScale), mmToPx(0.6));
   labelInner.style.setProperty('--label-padding-x', `${basePaddingX}px`);

--- a/style.css
+++ b/style.css
@@ -208,7 +208,7 @@ main {
   justify-content: center;
   gap: 8px;
   flex: 0 0 auto;
-  padding: 6px;
+  padding: 0;
   border-radius: 0;
   background-color: transparent;
   border: none;


### PR DESCRIPTION
## Summary
- scale the horizontal padding baseline for labels 12 mm tall or less so compact layouts keep icons near the edge
- remove default padding from the hardware icon wrapper so artwork aligns with the new horizontal gutter

## Testing
- Verified 37 mm × 12 mm label preview in the browser

------
https://chatgpt.com/codex/tasks/task_e_68cd77dffab48329b9962546156c932f