### PR TITLE
Add icons to action buttons and settings heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,10 @@
       <section class="settings-section col-lg-5">
         <div class="card shadow-sm h-100">
           <div class="card-body">
-            <h2 class="h5 mb-3 section-heading">Label Settings</h2>
+            <h2 class="h5 mb-3 section-heading">
+              <i class="fa-solid fa-gear me-2" aria-hidden="true"></i>
+              <span>Label Settings</span>
+            </h2>
             <div class="vstack gap-3">
               <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
                 <label
@@ -639,23 +642,25 @@
     <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
       <button
         id="download-button"
-        class="btn btn-primary btn-lg px-4"
+        class="btn btn-primary btn-lg px-4 d-inline-flex align-items-center"
         type="button"
         disabled
         aria-label="Download label as a PNG image"
         title="Download label as a PNG image"
       >
-        Download
+        <i class="fa-solid fa-download me-2" aria-hidden="true"></i>
+        <span>Download</span>
       </button>
       <button
         id="print-button"
-        class="btn btn-outline-primary btn-lg px-4"
+        class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
         type="button"
         disabled
         aria-label="Open a print-ready preview of the label"
         title="Open a print-ready preview of the label"
       >
-        Print
+        <i class="fa-solid fa-print me-2" aria-hidden="true"></i>
+        <span>Print</span>
       </button>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add a Font Awesome gear icon before the Label Settings heading
- add download and print icons to their respective action buttons and align the button content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd83f4e7088329a1be8620041ac884