### PR TITLE
Improve iOS dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,21 @@
 <html lang="en" data-bs-theme="light" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+  />
   <title>Gridfinity Label Maker</title>
+  <meta name="color-scheme" content="light dark" />
+  <meta name="supported-color-schemes" content="light dark" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="Gridfinity Label Maker" />
+  <meta
+    name="apple-mobile-web-app-status-bar-style"
+    content="default"
+    id="apple-mobile-web-app-status-bar-style"
+  />
+  <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
   <!--
     Standalone tool for generating and printing Gridfinity labels.  Styling
     now layers a lightweight Bootstrap 5 theme for modern form controls and
@@ -17,6 +30,7 @@
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
     crossorigin="anonymous"
   />
+  <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png" />
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
@@ -37,6 +51,8 @@
   <script>
     (function() {
       const storageKey = 'gridfinity-theme-preference';
+      const themeColors = { light: '#f8fafc', dark: '#0f172a' };
+      const statusBarStyles = { light: 'default', dark: 'black-translucent' };
       let theme = 'light';
       try {
         const storedTheme = localStorage.getItem(storageKey);
@@ -51,6 +67,14 @@
       }
       document.documentElement.setAttribute('data-theme', theme);
       document.documentElement.setAttribute('data-bs-theme', theme);
+      const themeColorMeta = document.getElementById('theme-color-meta');
+      if (themeColorMeta) {
+        themeColorMeta.setAttribute('content', themeColors[theme] || themeColors.light);
+      }
+      const statusBarMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
+      if (statusBarMeta) {
+        statusBarMeta.setAttribute('content', statusBarStyles[theme] || statusBarStyles.light);
+      }
     })();
   </script>
   <link rel="stylesheet" href="style.css" />

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,6 +1,10 @@
 import { elements } from './dom-elements.js';
 
 const themeStorageKey = 'gridfinity-theme-preference';
+const themeColorMeta = document.getElementById('theme-color-meta');
+const statusBarStyleMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
+const themeColorByMode = { light: '#f8fafc', dark: '#0f172a' };
+const statusBarStyleByMode = { light: 'default', dark: 'black-translucent' };
 const prefersDarkScheme = typeof window.matchMedia === 'function'
   ? window.matchMedia('(prefers-color-scheme: dark)')
   : { matches: false };
@@ -63,6 +67,14 @@ function applyTheme(theme) {
   if (document.body) {
     document.body.setAttribute('data-theme', normalized);
     document.body.setAttribute('data-bs-theme', normalized);
+  }
+  if (themeColorMeta) {
+    const color = themeColorByMode[normalized] || themeColorByMode.light;
+    themeColorMeta.setAttribute('content', color);
+  }
+  if (statusBarStyleMeta) {
+    const statusBarStyle = statusBarStyleByMode[normalized] || statusBarStyleByMode.light;
+    statusBarStyleMeta.setAttribute('content', statusBarStyle);
   }
   updateThemeToggleUi(normalized);
 }

--- a/style.css
+++ b/style.css
@@ -48,9 +48,22 @@
 }
 
 body {
+  /*
+   * Opt-in to the dynamic viewport units used by mobile Safari and pad safe
+   * areas so the gradient background fills the notch and home indicator space
+   * when the site is saved to the home screen.
+   */
   background: linear-gradient(180deg, var(--page-bg-start) 0%, var(--page-bg-end) 100%);
   min-height: 100vh;
+  min-height: 100dvh;
+  min-height: 100svh;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
   transition: background 0.3s ease;
+  -webkit-font-smoothing: antialiased;
+  text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 main {


### PR DESCRIPTION
## Summary
- add iOS-specific meta tags, theme color handling, and link to an apple touch icon so the web app behaves well on iOS home screens (icon asset provided separately)
- update the theme switcher to keep the browser UI and status bar colors in sync with light and dark mode
- adjust global styles to respect dynamic viewport units and safe areas on iOS devices

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd8799f94c8329b9567ab9f52c761c