### PR TITLE
Add meta description to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     id="apple-mobile-web-app-status-bar-style"
   />
   <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
+  <meta name="description" content="Gridfinity Label Maker – design and print perfectly sized labels for Gridfinity storage bins.">
   <!--
     Standalone tool for generating and printing Gridfinity labels.  Styling
     now layers a lightweight Bootstrap 5 theme for modern form controls and


### PR DESCRIPTION
## Summary
- add a meta description to the home page for improved SEO and sharing metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce23964dfc8329aa5b3dc902bd8802