### PR TITLE
refactor: extract thread size population

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1,8 +1,6 @@
 import { state, standardFilterState } from './state.js';
 import { elements } from './dom-elements.js';
 import {
-  metricThreadSizes,
-  imperialThreadSizes,
   fuseValues,
   bearingOptions,
   hardwareCatalog,
@@ -12,11 +10,11 @@ import {
   findConnectorCategory
 } from './data.js';
 import { updatePreview, updateDownloadState } from './preview.js';
+import { populateThreadSizes } from './threadSizes.js';
 
 const {
   screwTypeContainer,
   threadSizeContainer,
-  threadSizeSelect,
   threadLengthRow,
   lengthContainer,
   fuseTypeContainer,
@@ -138,51 +136,7 @@ export function updateConnectorCategoryUi() {
   notesInput.placeholder = example;
 }
 
-export function populateThreadSizes() {
-  if (
-    state.hardwareType === 'Fuse' ||
-    state.hardwareType === 'Connector' ||
-    state.hardwareType === 'Custom' ||
-    state.hardwareType === 'Bearing' ||
-    state.hardwareType === 'Component'
-  ) {
-    if (threadSizeSelect) {
-      threadSizeSelect.innerHTML = '';
-      const placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = 'Not applicable';
-      threadSizeSelect.appendChild(placeholder);
-      threadSizeSelect.value = '';
-      threadSizeSelect.disabled = true;
-    }
-    state.threadSize = '';
-    updateDownloadState();
-    updatePreview();
-    return;
-  }
-  if (threadSizeSelect) {
-    threadSizeSelect.disabled = false;
-  }
-  const list = state.systemType === 'Metric' ? metricThreadSizes : imperialThreadSizes;
-  if (!threadSizeSelect) {
-    return;
-  }
-  threadSizeSelect.innerHTML = '';
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = 'Select size…';
-  threadSizeSelect.appendChild(placeholder);
-  list.forEach(size => {
-    const opt = document.createElement('option');
-    opt.value = size;
-    opt.textContent = size;
-    threadSizeSelect.appendChild(opt);
-  });
-  state.threadSize = '';
-  threadSizeSelect.value = '';
-  updateDownloadState();
-  updatePreview();
-}
+export { populateThreadSizes };
 
 export function populateFuseValues() {
   if (!fuseValueSelect) {

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -1,0 +1,52 @@
+import { state } from './state.js';
+import { elements } from './dom-elements.js';
+import { metricThreadSizes, imperialThreadSizes } from './data.js';
+import { updatePreview, updateDownloadState } from './preview.js';
+
+const { threadSizeSelect } = elements;
+
+export function populateThreadSizes() {
+  if (
+    state.hardwareType === 'Fuse' ||
+    state.hardwareType === 'Connector' ||
+    state.hardwareType === 'Custom' ||
+    state.hardwareType === 'Bearing' ||
+    state.hardwareType === 'Component'
+  ) {
+    if (threadSizeSelect) {
+      threadSizeSelect.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'Not applicable';
+      threadSizeSelect.appendChild(placeholder);
+      threadSizeSelect.value = '';
+      threadSizeSelect.disabled = true;
+    }
+    state.threadSize = '';
+    updateDownloadState();
+    updatePreview();
+    return;
+  }
+  if (threadSizeSelect) {
+    threadSizeSelect.disabled = false;
+  }
+  const list = state.systemType === 'Metric' ? metricThreadSizes : imperialThreadSizes;
+  if (!threadSizeSelect) {
+    return;
+  }
+  threadSizeSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Select size…';
+  threadSizeSelect.appendChild(placeholder);
+  list.forEach(size => {
+    const opt = document.createElement('option');
+    opt.value = size;
+    opt.textContent = size;
+    threadSizeSelect.appendChild(opt);
+  });
+  state.threadSize = '';
+  threadSizeSelect.value = '';
+  updateDownloadState();
+  updatePreview();
+}


### PR DESCRIPTION
## Summary
- move the thread size population logic into a new `threadSizes.js` module
- re-export `populateThreadSizes` from `forms.js` so existing imports keep working

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce570460848329aa5ac79a4f27c628