### PR TITLE
Add print stylesheet and improve print flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="print.css" />
   <script type="module" src="js/main.js"></script>
 </head>
 <body>

--- a/js/actions.js
+++ b/js/actions.js
@@ -89,33 +89,71 @@ export function printLabel() {
   }
   printWindow.opener = null;
   const doc = printWindow.document;
-  doc.title = 'Print Label';
-  const style = doc.createElement('style');
-  style.textContent = 'html,body{margin:0;height:100%;font-family:system-ui,-apple-system,Segoe UI,sans-serif;}body{display:flex;align-items:center;justify-content:center;background:#fff;color:#111;} .status{padding:1rem;text-align:center;}';
-  doc.head.appendChild(style);
-  doc.body.innerHTML = '';
-  const statusDiv = doc.createElement('div');
-  statusDiv.className = 'status';
-  statusDiv.textContent = 'Preparing print preview…';
-  doc.body.appendChild(statusDiv);
+  const stylesheetHref = new URL('print.css', window.location.href).href;
+  const initialHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Print Label</title>
+<link rel="stylesheet" href="${stylesheetHref}" />
+</head>
+<body class="print-window" data-ready="false">
+  <main>
+    <div id="print-status" class="print-status" role="status" aria-live="polite">Preparing print preview…</div>
+    <img id="print-image" class="print-label-image" alt="Gridfinity label" decoding="async" />
+  </main>
+</body>
+</html>`;
+  doc.open();
+  doc.write(initialHtml);
+  doc.close();
+
+  const widthMm = Number.isFinite(state.widthMm) && state.widthMm > 0 ? state.widthMm : 1;
+  const heightMm = Number.isFinite(state.heightMm) && state.heightMm > 0 ? state.heightMm : 1;
+  const widthValue = `${widthMm}mm`;
+  const heightValue = `${heightMm}mm`;
+  doc.documentElement.style.setProperty('--label-width-mm', widthValue);
+  doc.documentElement.style.setProperty('--label-height-mm', heightValue);
+  const printBody = doc.body;
+  const statusDiv = doc.getElementById('print-status');
+  const img = doc.getElementById('print-image');
+  if (img instanceof HTMLImageElement) {
+    img.style.width = widthValue;
+    img.style.height = heightValue;
+    img.style.maxWidth = 'none';
+    img.style.maxHeight = 'none';
+    img.style.imageRendering = 'pixelated';
+  }
   renderLabelCanvas()
     .then(canvas => {
       const dataUrl = canvas.toDataURL('image/png');
-      const img = doc.createElement('img');
-      img.src = dataUrl;
-      img.alt = 'Gridfinity label';
-      img.style.maxWidth = '100%';
-      img.style.maxHeight = '100%';
-      img.onload = () => {
+      if (!(img instanceof HTMLImageElement)) {
+        throw new Error('Print image element was not created.');
+      }
+      img.setAttribute('width', String(canvas.width));
+      img.setAttribute('height', String(canvas.height));
+      const handleLoad = () => {
+        if (printBody) {
+          printBody.setAttribute('data-ready', 'true');
+        }
+        if (statusDiv) {
+          statusDiv.textContent = 'Label ready – opening printer dialog…';
+        }
         printWindow.focus();
         printWindow.print();
         printWindow.close();
       };
-      doc.body.innerHTML = '';
-      doc.body.appendChild(img);
+      img.addEventListener('load', handleLoad, { once: true });
+      img.src = dataUrl;
     })
     .catch(err => {
       console.error('Print preview generation failed', err);
-      doc.body.innerHTML = '<div class="status">Unable to prepare the label for printing.</div>';
+      if (printBody) {
+        printBody.setAttribute('data-ready', 'error');
+      }
+      if (statusDiv) {
+        statusDiv.textContent = 'Unable to prepare the label for printing.';
+      }
     });
 }

--- a/js/preview.js
+++ b/js/preview.js
@@ -574,6 +574,10 @@ export function updatePreview() {
   const printableHeight = height;
   labelSizeDisplay.innerHTML = `${width}&nbsp;mm ×&nbsp;${height}&nbsp;mm (label size)`;
   printAreaDisplay.innerHTML = `${printableWidth}&nbsp;mm ×&nbsp;${printableHeight}&nbsp;mm (print-ready image size)`;
+  const safeWidthMm = Number.isFinite(width) && width > 0 ? width : 1;
+  const safeHeightMm = Number.isFinite(height) && height > 0 ? height : 1;
+  document.documentElement.style.setProperty('--label-width-mm', `${safeWidthMm}mm`);
+  document.documentElement.style.setProperty('--label-height-mm', `${safeHeightMm}mm`);
   const pxWidth = width * pxPerMm;
   const pxHeight = height * pxPerMm;
   previewContainer.style.width = pxWidth + 'px';

--- a/print.css
+++ b/print.css
@@ -1,0 +1,129 @@
+@page {
+  margin: 0;
+}
+
+:root {
+  --label-width-mm: 55mm;
+  --label-height-mm: 12mm;
+}
+
+body.print-window {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  color: #0f172a;
+  font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+}
+
+body.print-window main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12mm, 5vw, 24mm);
+  width: 100%;
+  box-sizing: border-box;
+  gap: 1rem;
+}
+
+.print-status {
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.4;
+  color: inherit;
+}
+
+.print-label-image {
+  display: none;
+  width: var(--label-width-mm);
+  height: var(--label-height-mm);
+  max-width: none;
+  max-height: none;
+  image-rendering: pixelated;
+  background: #ffffff;
+  box-shadow: 0 0 0.5mm rgba(15, 23, 42, 0.12);
+}
+
+body.print-window[data-ready='true'] .print-label-image {
+  display: block;
+}
+
+body.print-window[data-ready='true'] .print-status {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.print-window {
+    background: #0f172a;
+    color: #e2e8f0;
+  }
+}
+
+@media print {
+  html,
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  body.print-window {
+    padding: 0;
+  }
+
+  .print-status {
+    display: none !important;
+  }
+
+  img.print-label-image {
+    display: block !important;
+    width: var(--label-width-mm) !important;
+    height: var(--label-height-mm) !important;
+    max-width: none !important;
+    max-height: none !important;
+    image-rendering: pixelated;
+    background: #ffffff;
+    box-shadow: none;
+  }
+
+  .theme-toggle-wrapper,
+  .title-section,
+  .form-section,
+  .actions,
+  #form-status-message,
+  .size-info,
+  .preview-section .section-heading {
+    display: none !important;
+  }
+
+  main {
+    max-width: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  .preview-section,
+  .label-preview,
+  #preview-container,
+  #label-inner {
+    width: var(--label-width-mm) !important;
+    height: var(--label-height-mm) !important;
+    max-width: none !important;
+    max-height: none !important;
+    box-shadow: none !important;
+    border: 0 !important;
+    background: #ffffff !important;
+    margin: 0 auto !important;
+  }
+
+  #label-inner {
+    overflow: visible;
+  }
+
+  .preview-placeholder {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated print stylesheet that centers the exported label, hides non-print UI, and enforces physical sizing
- update the print workflow to load the new stylesheet, size the exported image in millimetres, and keep the 300 DPI pixel data intact
- expose the current label dimensions as CSS custom properties so the main preview prints at the same dimensions as the generated label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce5cb25c448329b9c81ffe328232e3