### PR TITLE
Improve accessibility focus cues and dark mode contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,13 @@
             <h2 class="h5 mb-3 section-heading">Hardware Details</h2>
             <div class="vstack gap-3">
               <div>
-                <label class="form-label fw-semibold" id="hardware-type-label">Hardware Type</label>
+                <label
+                  class="form-label fw-semibold"
+                  for="hardware-type-select"
+                  id="hardware-type-label"
+                >
+                  Hardware Type
+                </label>
                 <div class="d-sm-none">
                   <select
                     id="hardware-type-select"
@@ -651,7 +657,7 @@
     <section class="preview-section card shadow-sm mt-4">
       <div class="card-body">
         <h2 class="h5 mb-3 section-heading">Label Preview</h2>
-        <div class="size-info text-muted small mb-3">
+        <div class="size-info text-muted small mb-3" role="status" aria-live="polite" aria-atomic="true">
           <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
           <div id="print-area-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (print-ready image size)</div>
         </div>

--- a/style.css
+++ b/style.css
@@ -20,6 +20,8 @@
   --theme-toggle-border: rgba(15, 23, 42, 0.12);
   --theme-toggle-color: #0f172a;
   --theme-toggle-focus-ring: rgba(59, 130, 246, 0.4);
+  --focus-ring-color: rgba(59, 130, 246, 0.45);
+  --focus-ring-border: #2563eb;
   --field-invalid-ring: rgba(220, 53, 69, 0.45);
   --field-help-bg: rgba(148, 163, 184, 0.12);
   --field-help-border: rgba(148, 163, 184, 0.4);
@@ -42,6 +44,8 @@
   --theme-toggle-border: rgba(148, 163, 184, 0.55);
   --theme-toggle-color: #e2e8f0;
   --theme-toggle-focus-ring: rgba(125, 211, 252, 0.45);
+  --focus-ring-color: rgba(125, 211, 252, 0.55);
+  --focus-ring-border: #38bdf8;
   --field-invalid-ring: rgba(248, 113, 113, 0.6);
   --field-help-bg: rgba(148, 163, 184, 0.18);
   --field-help-border: rgba(148, 163, 184, 0.55);
@@ -490,6 +494,71 @@ main {
 
 .theme-toggle-text {
   font-size: 0.85rem;
+}
+
+/*
+ * Provide highly visible focus indicators across form controls, radio button
+ * groups that use the Bootstrap `.btn-check` pattern, and the range slider.
+ * Exclude invalid controls so their red validation state remains dominant
+ * when focused.
+ */
+.form-control:focus:not(.is-invalid),
+.form-select:focus:not(.is-invalid) {
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
+  outline: none;
+}
+
+.form-check-input:focus:not(.is-invalid) {
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
+  outline: none;
+}
+
+.btn-check:focus-visible + .btn {
+  outline: none;
+  box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
+  border-color: var(--focus-ring-border);
+  z-index: 1;
+}
+
+.form-range:focus-visible {
+  outline: none;
+}
+
+.form-range:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
+}
+
+.form-range:focus-visible::-moz-range-thumb {
+  outline: 2px solid var(--focus-ring-border);
+  outline-offset: 2px;
+}
+
+/*
+ * Bolster dark mode contrast so that text and icons meet WCAG AA levels when
+ * placed on secondary surfaces.
+ */
+:root[data-theme='dark'] .card {
+  background-color: #111827;
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+:root[data-theme='dark'] .bg-body-secondary {
+  background-color: #1f2937 !important;
+  color: #f1f5f9 !important;
+}
+
+:root[data-theme='dark'] .bg-body-secondary.border {
+  border-color: rgba(148, 163, 184, 0.6) !important;
+}
+
+:root[data-theme='dark'] .bg-body-secondary .text-secondary {
+  color: #cbd5f5 !important;
+}
+
+:root[data-theme='dark'] .text-muted {
+  color: rgba(226, 232, 240, 0.78) !important;
 }
 
 @media (min-width: 576px) {


### PR DESCRIPTION
## Summary
- associate the hardware-type selector with its label and announce preview size changes via aria-live
- strengthen focus styling for form controls, button-radio groups, and the range slider without overriding validation cues
- tune dark theme secondary surfaces and muted text colors to meet WCAG AA contrast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce5f3842c88329bc23c6da551c3ef7