### PR TITLE
Refactor entrypoint into controls module and render exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="style-print.css" media="print" />
   <link rel="stylesheet" href="print.css" />
-  <script type="module" src="js/main.js"></script>
+  <script type="module" defer src="js/controls.js"></script>
 </head>
 <body>
   <main class="container py-4">

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { findConnectorCategory } from './data.js';
-import { renderLabelCanvas } from './preview.js';
+import { renderLabelCanvas } from './render.js';
 
 export function downloadLabel() {
   renderLabelCanvas()

--- a/js/controls.js
+++ b/js/controls.js
@@ -8,7 +8,7 @@ import {
   updateCustomImageUi,
   onHardwareTypeChange
 } from './forms.js';
-import { updateDownloadState, updateQrContentVisibility, updatePreview } from './preview.js';
+import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
 
 function init() {
@@ -32,3 +32,5 @@ if (document.readyState === 'loading') {
 } else {
   init();
 }
+
+export { init };

--- a/js/events.js
+++ b/js/events.js
@@ -11,7 +11,7 @@ import {
   handleStandardSelectKeydown,
   clearStandardFilter
 } from './forms.js';
-import { updatePreview, updateDownloadState, updateQrContentVisibility } from './preview.js';
+import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel } from './actions.js';
 
 const {

--- a/js/forms.js
+++ b/js/forms.js
@@ -9,7 +9,7 @@ import {
   CONNECTOR_PLACEHOLDER_TEXT,
   findConnectorCategory
 } from './data.js';
-import { updatePreview, updateDownloadState } from './preview.js';
+import { updatePreview, updateDownloadState } from './render.js';
 import { populateThreadSizes } from './threadSizes.js';
 
 const {

--- a/js/render.js
+++ b/js/render.js
@@ -1193,3 +1193,31 @@ export async function renderLabelCanvas() {
   }
   return outputCanvas;
 }
+
+export async function renderLabelBlob(type = 'image/png', quality) {
+  const canvas = await renderLabelCanvas();
+  if (typeof canvas.toBlob === 'function') {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(
+        blob => {
+          if (blob) {
+            resolve(blob);
+            return;
+          }
+          reject(new Error('Unable to convert canvas to blob.'));
+        },
+        type,
+        quality
+      );
+    });
+  }
+
+  const dataUrl = canvas.toDataURL(type, quality);
+  const byteString = atob(dataUrl.split(',')[1] || '');
+  const mimeType = dataUrl.split(';')[0].split(':')[1] || type;
+  const buffer = new Uint8Array(byteString.length);
+  for (let i = 0; i < byteString.length; i += 1) {
+    buffer[i] = byteString.charCodeAt(i);
+  }
+  return new Blob([buffer], { type: mimeType });
+}

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -1,7 +1,7 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
 import { metricThreadSizes, imperialThreadSizes } from './data.js';
-import { updatePreview, updateDownloadState } from './preview.js';
+import { updatePreview, updateDownloadState } from './render.js';
 
 const { threadSizeSelect } = elements;
 

--- a/test/threadSizes.test.js
+++ b/test/threadSizes.test.js
@@ -30,7 +30,7 @@ jest.mock('../js/dom-elements.js', () => ({
   }
 }));
 
-jest.mock('../js/preview.js', () => ({
+jest.mock('../js/render.js', () => ({
   __esModule: true,
   updatePreview: mockUpdatePreview,
   updateDownloadState: mockUpdateDownloadState


### PR DESCRIPTION
## Summary
- Load the application through a deferred module entry point and split the former main.js responsibilities.
- Move initialization into the new controls.js module while keeping the same setup flow and exports.
- Rename preview.js to render.js, add a blob helper, and update all imports to use the new module structure.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce82c639088329b8b70b676e3aee13