### PR TITLE
Improve preview status announcements and focus outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -658,7 +658,14 @@
     <section class="preview-section card shadow-sm mt-4">
       <div class="card-body">
         <h2 class="h5 mb-3 section-heading">Label Preview</h2>
-        <div class="size-info text-muted small mb-3" role="status" aria-live="polite" aria-atomic="true">
+        <div class="size-info text-muted small mb-3">
+          <span
+            id="preview-status-text"
+            class="visually-hidden"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          ></span>
           <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
           <div id="print-area-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (print-ready image size)</div>
         </div>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -56,6 +56,7 @@ const labelSizeDisplay = document.getElementById('label-size-display');
 const printAreaDisplay = document.getElementById('print-area-display');
 const previewContainer = document.getElementById('preview-container');
 const previewPlaceholder = document.getElementById('preview-placeholder');
+const previewStatusText = document.getElementById('preview-status-text');
 const labelInner = document.getElementById('label-inner');
 const hardwareImageDiv = document.getElementById('hardware-image');
 const textBlockDiv = document.getElementById('preview-text');
@@ -147,6 +148,7 @@ export const elements = {
   printAreaDisplay,
   previewContainer,
   previewPlaceholder,
+  previewStatusText,
   labelInner,
   hardwareImageDiv,
   textBlockDiv,

--- a/js/render.js
+++ b/js/render.js
@@ -13,6 +13,7 @@ const {
   line1Div,
   line2Div,
   previewPlaceholder,
+  previewStatusText,
   qrCanvas,
   qrContentWrapper,
   qrContentInput,
@@ -49,6 +50,39 @@ const {
 } = elements;
 
 let qrRenderRequestId = 0;
+let previewStatusFrameId = null;
+let previewReadyState = false;
+
+function announcePreviewStatus(message) {
+  if (!previewStatusText) {
+    return;
+  }
+
+  if (previewStatusFrameId !== null) {
+    if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(previewStatusFrameId);
+    }
+    previewStatusFrameId = null;
+  }
+
+  previewStatusText.textContent = '';
+
+  const normalizedMessage = typeof message === 'string' ? message.trim() : '';
+  if (!normalizedMessage) {
+    return;
+  }
+
+  const setMessage = () => {
+    previewStatusText.textContent = normalizedMessage;
+    previewStatusFrameId = null;
+  };
+
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    previewStatusFrameId = window.requestAnimationFrame(setMessage);
+  } else {
+    setTimeout(setMessage, 0);
+  }
+}
 
 function setMessageVisibility(messageElement, message, show) {
   if (!messageElement) {
@@ -619,6 +653,12 @@ export function updatePreview() {
     labelInner.style.removeProperty('--label-gap');
     labelInner.style.removeProperty('--label-padding-y');
     labelInner.style.removeProperty('--label-padding-x');
+    if (previewReadyState) {
+      announcePreviewStatus('Preview cleared.');
+    } else {
+      announcePreviewStatus('');
+    }
+    previewReadyState = false;
     return;
   }
 
@@ -1128,6 +1168,8 @@ export function updatePreview() {
   labelInner.style.setProperty('--label-gap', `${gapPx}px`);
 
   applyTextFitting(primaryFontSize, secondaryFontSize);
+  previewReadyState = true;
+  announcePreviewStatus('Preview updated.');
 }
 
 export async function renderLabelCanvas() {

--- a/style.css
+++ b/style.css
@@ -25,6 +25,8 @@
   --field-invalid-ring: rgba(220, 53, 69, 0.45);
   --field-help-bg: rgba(148, 163, 184, 0.12);
   --field-help-border: rgba(148, 163, 184, 0.4);
+  --focus-outline-width: 2px;
+  --focus-outline-offset: 2px;
 }
 
 :root[data-theme='dark'] {
@@ -451,7 +453,8 @@ main {
 }
 
 .qr-info-icon:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
   box-shadow: 0 0 0 2px var(--qr-focus-ring);
 }
 
@@ -483,7 +486,8 @@ main {
 }
 
 .theme-toggle-button:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: calc(var(--focus-outline-offset) + 2px);
   box-shadow: 0 0 0 0.2rem var(--theme-toggle-focus-ring);
 }
 
@@ -506,24 +510,28 @@ main {
 .form-select:focus:not(.is-invalid) {
   border-color: var(--focus-ring-border);
   box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
 }
 
 .form-check-input:focus:not(.is-invalid) {
   border-color: var(--focus-ring-border);
   box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
 }
 
 .btn-check:focus-visible + .btn {
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
   box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
   border-color: var(--focus-ring-border);
   z-index: 1;
 }
 
 .form-range:focus-visible {
-  outline: none;
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
 }
 
 .form-range:focus-visible::-webkit-slider-thumb {


### PR DESCRIPTION
## Summary
- verify all form inputs and selects already include associated `<label for>` elements
- add a visually hidden live region that announces preview updates for assistive tech
- expand shared focus outline styles so highlights remain visible in light and dark themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce85596424832984aa1cd39effaba0