### PR TITLE
Add shareable label URLs and Web Share fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ include:
 * Optional QR code content with automatic library loading only when needed.
 * Download-and-print flows that use html2canvas to export the on-screen label
   preview.
+* Shareable label URLs with Web Share API support and clipboard fallback.
 
 The repository is structured as a traditional GitHub Pages site, making it easy
 to host the tool directly from the `main` branch.
@@ -66,6 +67,20 @@ updates.
 
 Any other static server (for example, `npx serve` or a local web server
 extension) will also work.
+
+## Sharing Labels
+
+Use the **Share** button next to Download and Print to generate a link that
+captures the current label configuration. The helper serializes every relevant
+state value—including hardware selections, measurements, toggles, QR content,
+and custom imagery—into a compact base64 payload stored in the `label` query
+parameter.
+
+When supported, the app invokes the Web Share API so the link can be sent via
+native share sheets on mobile and desktop. Browsers without Web Share support
+fall back to copying the link to the clipboard and display a confirmation
+message. Opening a shared URL pre-populates the form and preview so the label is
+ready to review, print, or export without additional input.
 
 ## Development Workflow and Version Control Safeguards
 

--- a/index.html
+++ b/index.html
@@ -704,6 +704,17 @@
         <span>Download</span>
       </button>
       <button
+        id="share-button"
+        class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+        type="button"
+        disabled
+        aria-label="Share a link to this label"
+        title="Share a link to this label"
+      >
+        <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
+        <span>Share</span>
+      </button>
+      <button
         id="print-button"
         class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
         type="button"

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,6 +1,42 @@
 import { state } from './state.js';
 import { findConnectorCategory } from './data.js';
 import { renderLabelCanvas } from './render.js';
+import { buildShareUrl } from './url-state.js';
+
+async function copyLinkToClipboard(link) {
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === 'function'
+  ) {
+    await navigator.clipboard.writeText(link);
+    return;
+  }
+
+  if (typeof document === 'undefined' || !document.body) {
+    throw new Error('Clipboard API not available');
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = link;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  let succeeded = false;
+  try {
+    succeeded = typeof document.execCommand === 'function' ? document.execCommand('copy') : false;
+  } catch {
+    succeeded = false;
+  }
+  document.body.removeChild(textarea);
+
+  if (!succeeded) {
+    throw new Error('Copy command was unsuccessful');
+  }
+}
 
 function sanitizeTitle(str) {
   if (!str) {
@@ -183,4 +219,39 @@ export function printLabel() {
         statusDiv.textContent = 'Unable to prepare the label for printing.';
       }
     });
+}
+
+export async function shareLabel() {
+  const shareUrl = buildShareUrl();
+  if (!shareUrl) {
+    alert('Unable to generate a share link right now.');
+    return;
+  }
+
+  const shareData = {
+    title: 'Gridfinity Label Maker',
+    text: 'Gridfinity label preset',
+    url: shareUrl
+  };
+
+  const canShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+  if (canShare) {
+    try {
+      await navigator.share(shareData);
+      return;
+    } catch (error) {
+      if (error && error.name === 'AbortError') {
+        return;
+      }
+      console.warn('Native share failed, falling back to clipboard', error);
+    }
+  }
+
+  try {
+    await copyLinkToClipboard(shareUrl);
+    alert('Share link copied to your clipboard.');
+  } catch (error) {
+    console.error('Unable to copy share link', error);
+    alert(`Unable to copy the share link automatically. Copy this URL instead:\n${shareUrl}`);
+  }
 }

--- a/js/controls.js
+++ b/js/controls.js
@@ -10,19 +10,124 @@ import {
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
+import { hydrateStateFromUrl } from './url-state.js';
+
+function applyStateToControls() {
+  const {
+    systemTypeRadios,
+    screwTypeRadios,
+    fuseTypeRadios,
+    fuseValueSelect,
+    glassSizeSelect,
+    glassSlowBlowCheckbox,
+    glassFastBlowCheckbox,
+    lengthInput,
+    notesInput,
+    customLine1Input,
+    customLine2Input,
+    standardSelect,
+    standardToggle,
+    imageToggle,
+    qrcodeToggle,
+    qrContentInput,
+    widthRange,
+    widthValueSpan,
+    heightRadios,
+    connectorCategorySelect,
+    threadSizeSelect,
+    bearingTypeSelect
+  } = elements;
+
+  if (Array.isArray(systemTypeRadios)) {
+    systemTypeRadios.forEach(radio => {
+      radio.checked = radio.value === state.systemType;
+    });
+  }
+  if (Array.isArray(screwTypeRadios)) {
+    screwTypeRadios.forEach(radio => {
+      radio.checked = radio.value === state.screwType;
+    });
+  }
+  if (Array.isArray(fuseTypeRadios)) {
+    fuseTypeRadios.forEach(radio => {
+      radio.checked = radio.value === state.fuseType;
+    });
+  }
+
+  if (fuseValueSelect) {
+    fuseValueSelect.value = state.fuseValue || '';
+  }
+  if (glassSizeSelect) {
+    glassSizeSelect.value = state.glassSize || '';
+  }
+  if (glassSlowBlowCheckbox) {
+    glassSlowBlowCheckbox.checked = state.glassSpeed.startsWith('Slow');
+  }
+  if (glassFastBlowCheckbox) {
+    glassFastBlowCheckbox.checked = state.glassSpeed.startsWith('Fast');
+  }
+
+  if (connectorCategorySelect) {
+    connectorCategorySelect.value = state.connectorCategory || '';
+  }
+  if (threadSizeSelect) {
+    threadSizeSelect.value = state.threadSize || '';
+  }
+  if (bearingTypeSelect) {
+    bearingTypeSelect.value = state.bearingType || '';
+  }
+
+  if (lengthInput) {
+    lengthInput.value = state.length || '';
+  }
+  if (notesInput) {
+    notesInput.value = state.notes || '';
+  }
+  if (customLine1Input) {
+    customLine1Input.value = state.customLine1 || '';
+  }
+  if (customLine2Input) {
+    customLine2Input.value = state.customLine2 || '';
+  }
+  if (standardSelect) {
+    standardSelect.value = state.standardCode || '';
+  }
+  if (standardToggle) {
+    standardToggle.checked = state.showStandard;
+  }
+  if (imageToggle) {
+    imageToggle.checked = state.showImage;
+  }
+  if (qrcodeToggle) {
+    qrcodeToggle.checked = state.showQr;
+  }
+  if (qrContentInput) {
+    qrContentInput.value = state.qrContent || '';
+  }
+  if (widthRange) {
+    widthRange.value = String(state.widthMm);
+  }
+  if (widthValueSpan) {
+    widthValueSpan.textContent = state.widthMm;
+  }
+  if (Array.isArray(heightRadios)) {
+    heightRadios.forEach(radio => {
+      radio.checked = Number.parseInt(radio.value, 10) === state.heightMm;
+    });
+  }
+}
 
 function init() {
   initTheme();
+  hydrateStateFromUrl();
   populateFuseValues();
   populateConnectorCategories();
   populateBearingOptions();
   updateCustomImageUi();
   onHardwareTypeChange();
+  applyStateToControls();
   initEventHandlers();
   updateDownloadState();
-  if (elements.widthValueSpan) {
-    elements.widthValueSpan.textContent = state.widthMm;
-  }
   updateQrContentVisibility();
   updatePreview();
 }

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -66,6 +66,7 @@ const qrCanvas = document.getElementById('qr-canvas');
 const qrContentWrapper = document.getElementById('qr-content-wrapper');
 const qrContentInput = document.getElementById('qr-content-input');
 const downloadButton = document.getElementById('download-button');
+const shareButton = document.getElementById('share-button');
 const printButton = document.getElementById('print-button');
 
 const hardwareTypeRadios = Array.from(document.querySelectorAll('input[name="hardware-type"]'));
@@ -158,6 +159,7 @@ export const elements = {
   qrContentWrapper,
   qrContentInput,
   downloadButton,
+  shareButton,
   printButton,
   hardwareTypeRadios,
   hardwareTypeSelect,

--- a/js/events.js
+++ b/js/events.js
@@ -12,7 +12,7 @@ import {
   clearStandardFilter
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
-import { downloadLabel, printLabel } from './actions.js';
+import { downloadLabel, printLabel, shareLabel } from './actions.js';
 
 const {
   hardwareTypeRadios,
@@ -44,6 +44,7 @@ const {
   widthValueSpan,
   heightRadios,
   downloadButton,
+  shareButton,
   printButton
 } = elements;
 
@@ -302,6 +303,11 @@ export function initEventHandlers() {
 
   if (downloadButton) {
     downloadButton.addEventListener('click', downloadLabel);
+  }
+  if (shareButton) {
+    shareButton.addEventListener('click', () => {
+      void shareLabel();
+    });
   }
   if (printButton) {
     printButton.addEventListener('click', printLabel);

--- a/js/forms.js
+++ b/js/forms.js
@@ -92,7 +92,17 @@ export function populateBearingOptions() {
     opt.dataset.description = option.description;
     bearingTypeSelect.appendChild(opt);
   });
-  bearingTypeSelect.value = state.bearingType || '';
+  const validCodes = new Set(bearingOptions.map(option => option.code));
+  const desired = typeof state.bearingType === 'string' ? state.bearingType : '';
+  if (desired && validCodes.has(desired)) {
+    bearingTypeSelect.value = desired;
+    const selectedOption = bearingOptions.find(option => option.code === desired);
+    state.bearingDetails = selectedOption ? selectedOption.description : state.bearingDetails;
+  } else {
+    bearingTypeSelect.value = '';
+    state.bearingType = '';
+    state.bearingDetails = '';
+  }
 }
 
 function ensureConnectorCategory() {
@@ -246,6 +256,7 @@ export function populateStandards() {
   if (!standardSelect) {
     return;
   }
+  const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
   standardSelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
@@ -261,7 +272,6 @@ export function populateStandards() {
     state.standard = '';
     state.standardCode = '';
     standardSelect.value = '';
-    standardSelect.selectedIndex = 0;
     updatePreview();
     return;
   }
@@ -277,7 +287,6 @@ export function populateStandards() {
     state.standard = '';
     state.standardCode = '';
     standardSelect.value = '';
-    standardSelect.selectedIndex = 0;
     updatePreview();
     return;
   }
@@ -310,34 +319,50 @@ export function populateStandards() {
     standardSelect.appendChild(placeholder);
     standardSelect.disabled = true;
     standardSelect.title = '';
-  } else {
-    placeholder.textContent = placeholderText;
-    placeholder.dataset.defaultText = placeholder.textContent;
-    placeholder.disabled = false;
-    placeholder.selected = true;
-    standardSelect.appendChild(placeholder);
-    standards.forEach(entry => {
-      const opt = document.createElement('option');
-      opt.value = entry.code;
-      if (state.hardwareType === 'Connector') {
-        const display = entry.name ? `${entry.code} — ${entry.name}` : entry.code;
-        opt.textContent = display;
-        opt.dataset.name = entry.name || entry.code;
-      } else {
-        opt.textContent = `${entry.code} — ${entry.name}`;
-        opt.dataset.name = entry.name;
-      }
-      standardSelect.appendChild(opt);
-    });
-    standardSelect.disabled = false;
-    standardSelect.title = titleText;
-    filterStandardOptions('');
+    state.standard = '';
+    state.standardCode = '';
+    updatePreview();
+    return;
   }
 
-  state.standard = '';
-  state.standardCode = '';
-  standardSelect.value = '';
-  standardSelect.selectedIndex = 0;
+  placeholder.textContent = placeholderText;
+  placeholder.dataset.defaultText = placeholderText;
+  placeholder.disabled = false;
+  placeholder.selected = true;
+  standardSelect.appendChild(placeholder);
+  standards.forEach(entry => {
+    const opt = document.createElement('option');
+    opt.value = entry.code;
+    if (state.hardwareType === 'Connector') {
+      const display = entry.name ? `${entry.code} — ${entry.name}` : entry.code;
+      opt.textContent = display;
+      opt.dataset.name = entry.name || entry.code;
+    } else {
+      opt.textContent = `${entry.code} — ${entry.name}`;
+      opt.dataset.name = entry.name;
+    }
+    standardSelect.appendChild(opt);
+  });
+  standardSelect.disabled = false;
+  standardSelect.title = titleText;
+
+  const availableOption = previousCode
+    ? Array.from(standardSelect.options).find(option => option.value === previousCode)
+    : null;
+
+  if (availableOption && availableOption.value) {
+    standardSelect.value = availableOption.value;
+    const displayName = availableOption.dataset.name || availableOption.textContent || '';
+    state.standardCode = availableOption.value;
+    state.standard = displayName;
+  } else {
+    standardSelect.value = '';
+    placeholder.selected = true;
+    state.standard = '';
+    state.standardCode = '';
+  }
+
+  filterStandardOptions('');
   updatePreview();
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -18,6 +18,7 @@ const {
   qrContentWrapper,
   qrContentInput,
   downloadButton,
+  shareButton,
   printButton,
   threadSizeSelect,
   threadSizeContainer,
@@ -590,6 +591,14 @@ export function updateDownloadState() {
     printButton.title = disabled
       ? 'Complete the label details to enable printing.'
       : printActionLabel;
+  }
+  if (shareButton) {
+    shareButton.disabled = disabled;
+    const shareActionLabel = 'Share a link to this label';
+    shareButton.setAttribute('aria-label', shareActionLabel);
+    shareButton.title = disabled
+      ? 'Complete the label details to enable sharing.'
+      : shareActionLabel;
   }
   applyValidationFeedback(disabled);
 }

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -18,8 +18,8 @@ export function populateThreadSizes() {
       const placeholder = document.createElement('option');
       placeholder.value = '';
       placeholder.textContent = 'Not applicable';
+      placeholder.selected = true;
       threadSizeSelect.appendChild(placeholder);
-      threadSizeSelect.value = '';
       threadSizeSelect.disabled = true;
     }
     state.threadSize = '';
@@ -27,26 +27,37 @@ export function populateThreadSizes() {
     updatePreview();
     return;
   }
-  if (threadSizeSelect) {
-    threadSizeSelect.disabled = false;
-  }
+
   const list = state.systemType === 'Metric' ? metricThreadSizes : imperialThreadSizes;
   if (!threadSizeSelect) {
+    state.threadSize = '';
+    updateDownloadState();
+    updatePreview();
     return;
   }
+
+  threadSizeSelect.disabled = false;
   threadSizeSelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
   placeholder.textContent = 'Select size…';
   threadSizeSelect.appendChild(placeholder);
+
+  const validSizes = new Set(list);
   list.forEach(size => {
     const opt = document.createElement('option');
     opt.value = size;
     opt.textContent = size;
     threadSizeSelect.appendChild(opt);
   });
-  state.threadSize = '';
-  threadSizeSelect.value = '';
+
+  const previous = typeof state.threadSize === 'string' ? state.threadSize.trim() : '';
+  const normalized = previous && validSizes.has(previous) ? previous : '';
+  state.threadSize = normalized;
+  threadSizeSelect.value = normalized;
+  if (!normalized) {
+    placeholder.selected = true;
+  }
   updateDownloadState();
   updatePreview();
 }

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -1,0 +1,442 @@
+import { state } from './state.js';
+import { elements } from './dom-elements.js';
+import {
+  metricThreadSizes,
+  imperialThreadSizes,
+  fuseValues,
+  bearingOptions,
+  connectorCatalog
+} from './data.js';
+
+export const SHARE_QUERY_PARAM = 'label';
+
+const FIELD_MAP = {
+  hardwareType: 'ht',
+  systemType: 'ms',
+  screwType: 'st',
+  fuseType: 'ft',
+  threadSize: 'ts',
+  length: 'ln',
+  fuseValue: 'fv',
+  glassSpeed: 'gs',
+  glassSize: 'gz',
+  notes: 'no',
+  standard: 'sd',
+  standardCode: 'sc',
+  showStandard: 'ss',
+  showImage: 'si',
+  showQr: 'sq',
+  qrContent: 'qc',
+  widthMm: 'w',
+  heightMm: 'h',
+  connectorCategory: 'cc',
+  componentCategory: 'cmp',
+  componentMount: 'cm',
+  bearingType: 'bt',
+  bearingDetails: 'bd',
+  customLine1: 'c1',
+  customLine2: 'c2',
+  customImageData: 'cid',
+  customImageName: 'cin'
+};
+
+const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) => {
+  acc[code] = key;
+  return acc;
+}, {});
+
+const hardwareTypeOptions = elements.hardwareTypeOptions || new Set();
+const screwTypeOptions = new Set(
+  Array.isArray(elements.screwTypeRadios) ? elements.screwTypeRadios.map(radio => radio.value) : []
+);
+const fuseTypeOptions = new Set(
+  Array.isArray(elements.fuseTypeRadios) ? elements.fuseTypeRadios.map(radio => radio.value) : []
+);
+const componentCategoryOptions = new Set(
+  Array.isArray(elements.componentCategoryRadios)
+    ? elements.componentCategoryRadios.map(radio => radio.value)
+    : []
+);
+const componentMountOptions = new Set(
+  Array.isArray(elements.componentMountRadios)
+    ? elements.componentMountRadios.map(radio => radio.value)
+    : []
+);
+const heightOptions = new Set(
+  Array.isArray(elements.heightRadios)
+    ? elements.heightRadios
+        .map(radio => Number.parseInt(radio.value, 10))
+        .filter(value => Number.isFinite(value))
+    : []
+);
+const glassSizeOptions = new Set(
+  elements.glassSizeSelect
+    ? Array.from(elements.glassSizeSelect.options)
+        .map(option => option.value)
+        .filter(value => value && value.trim().length > 0)
+    : []
+);
+const glassSpeedOptions = new Set(['Slow Blow (Time Delay)', 'Fast Blow']);
+const metricThreadSet = new Set(metricThreadSizes);
+const imperialThreadSet = new Set(imperialThreadSizes);
+const allThreadSizes = new Set([...metricThreadSet, ...imperialThreadSet]);
+const fuseValueOptions = new Set(fuseValues.map(value => String(value)));
+const connectorCategoryOptions = new Set(connectorCatalog.map(category => category.id));
+const bearingCodeOptions = new Set(bearingOptions.map(option => option.code));
+const systemTypeOptions = new Set(['Metric', 'Imperial']);
+
+function encodeToBase64Url(input) {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(input);
+  let binary = '';
+  encoded.forEach(byte => {
+    binary += String.fromCharCode(byte);
+  });
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeFromBase64Url(input) {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingNeeded = normalized.length % 4;
+  const padded =
+    paddingNeeded === 0
+      ? normalized
+      : normalized + '='.repeat((4 - paddingNeeded) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+
+function buildSharePayload(sourceState) {
+  const payload = {};
+  for (const [key, shortKey] of Object.entries(FIELD_MAP)) {
+    const value = sourceState[key];
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      payload[shortKey] = value;
+      continue;
+    }
+    if (typeof value === 'string') {
+      if (value.length > 0) {
+        payload[shortKey] = value;
+      }
+    }
+  }
+  return payload;
+}
+
+function sanitizeLength(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+  const str = String(value).trim();
+  if (!str) {
+    return '';
+  }
+  const numeric = Number.parseFloat(str);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return str;
+}
+
+function sanitizeThreadSize(value, hardwareType) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (
+    hardwareType === 'Fuse' ||
+    hardwareType === 'Connector' ||
+    hardwareType === 'Custom' ||
+    hardwareType === 'Bearing' ||
+    hardwareType === 'Component'
+  ) {
+    return '';
+  }
+  return allThreadSizes.has(trimmed) ? trimmed : '';
+}
+
+function sanitizeFuseValue(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+  const normalized = String(value).trim();
+  if (!normalized) {
+    return '';
+  }
+  return fuseValueOptions.has(normalized) ? normalized : '';
+}
+
+function sanitizeGlassSpeed(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return glassSpeedOptions.has(trimmed) ? trimmed : '';
+}
+
+function sanitizeGlassSize(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return glassSizeOptions.has(trimmed) ? trimmed : '';
+}
+
+function sanitizeNotes(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().slice(0, 500);
+}
+
+function sanitizeShortText(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.slice(0, 200);
+}
+
+function sanitizeQrContent(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().slice(0, 500);
+}
+
+function sanitizeCustomImageName(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.slice(0, 200);
+}
+
+function sanitizeWidth(value) {
+  const numeric = Number.parseInt(value, 10);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  const clamped = Math.min(Math.max(numeric, 37), 100);
+  return clamped;
+}
+
+function sanitizeHeight(value) {
+  const numeric = Number.parseInt(value, 10);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  return heightOptions.has(numeric) ? numeric : null;
+}
+
+function expandPayload(payload) {
+  const expanded = {};
+  for (const [shortKey, value] of Object.entries(payload)) {
+    const fullKey = REVERSE_FIELD_MAP[shortKey];
+    if (fullKey) {
+      expanded[fullKey] = value;
+    }
+  }
+  return expanded;
+}
+
+function applyExpandedPayload(expanded) {
+  if (typeof expanded.hardwareType === 'string' && hardwareTypeOptions.has(expanded.hardwareType)) {
+    state.hardwareType = expanded.hardwareType;
+  }
+  if (typeof expanded.systemType === 'string' && systemTypeOptions.has(expanded.systemType)) {
+    state.systemType = expanded.systemType;
+  }
+  if (typeof expanded.screwType === 'string' && screwTypeOptions.has(expanded.screwType)) {
+    state.screwType = expanded.screwType;
+  }
+  if (typeof expanded.fuseType === 'string' && fuseTypeOptions.has(expanded.fuseType)) {
+    state.fuseType = expanded.fuseType;
+  }
+  if (
+    typeof expanded.connectorCategory === 'string' &&
+    connectorCategoryOptions.has(expanded.connectorCategory)
+  ) {
+    state.connectorCategory = expanded.connectorCategory;
+  }
+  if (
+    typeof expanded.componentCategory === 'string' &&
+    componentCategoryOptions.has(expanded.componentCategory)
+  ) {
+    state.componentCategory = expanded.componentCategory;
+  }
+  if (
+    typeof expanded.componentMount === 'string' &&
+    componentMountOptions.has(expanded.componentMount)
+  ) {
+    state.componentMount = expanded.componentMount;
+  }
+  if (typeof expanded.bearingType === 'string') {
+    const trimmed = expanded.bearingType.trim();
+    if (!trimmed) {
+      state.bearingType = '';
+      state.bearingDetails = '';
+    } else if (bearingCodeOptions.has(trimmed)) {
+      state.bearingType = trimmed;
+    }
+  }
+
+  const sanitizedThread = sanitizeThreadSize(expanded.threadSize, state.hardwareType);
+  if (sanitizedThread !== null) {
+    state.threadSize = sanitizedThread;
+  }
+
+  if (state.hardwareType === 'Screw') {
+    const sanitizedLength = sanitizeLength(expanded.length);
+    if (sanitizedLength !== null) {
+      state.length = sanitizedLength;
+    }
+  } else {
+    state.length = '';
+  }
+
+  if (state.hardwareType === 'Fuse') {
+    const sanitizedFuse = sanitizeFuseValue(expanded.fuseValue);
+    if (sanitizedFuse !== null) {
+      state.fuseValue = sanitizedFuse;
+    }
+    if (state.fuseType === 'Glass') {
+      const sanitizedSpeed = sanitizeGlassSpeed(expanded.glassSpeed);
+      if (sanitizedSpeed !== null) {
+        state.glassSpeed = sanitizedSpeed;
+      }
+      const sanitizedSize = sanitizeGlassSize(expanded.glassSize);
+      if (sanitizedSize !== null) {
+        state.glassSize = sanitizedSize;
+      }
+    } else {
+      state.glassSpeed = '';
+      state.glassSize = '';
+    }
+  } else {
+    state.fuseValue = '';
+    state.glassSpeed = '';
+    state.glassSize = '';
+  }
+
+  if (typeof expanded.notes === 'string') {
+    state.notes = sanitizeNotes(expanded.notes);
+  }
+
+  if (typeof expanded.standardCode === 'string') {
+    state.standardCode = expanded.standardCode.trim().slice(0, 120);
+  }
+  if (typeof expanded.standard === 'string') {
+    state.standard = sanitizeShortText(expanded.standard);
+  }
+
+  if (typeof expanded.showStandard === 'boolean') {
+    state.showStandard = expanded.showStandard;
+  }
+  if (typeof expanded.showImage === 'boolean') {
+    state.showImage = expanded.showImage;
+  }
+  if (typeof expanded.showQr === 'boolean') {
+    state.showQr = expanded.showQr;
+  }
+  if (typeof expanded.qrContent === 'string') {
+    state.qrContent = sanitizeQrContent(expanded.qrContent);
+  }
+
+  const width = sanitizeWidth(expanded.widthMm);
+  if (width !== null) {
+    state.widthMm = width;
+  }
+  const height = sanitizeHeight(expanded.heightMm);
+  if (height !== null) {
+    state.heightMm = height;
+  }
+
+  if (typeof expanded.bearingDetails === 'string') {
+    state.bearingDetails = sanitizeShortText(expanded.bearingDetails);
+  }
+
+  if (typeof expanded.customLine1 === 'string') {
+    state.customLine1 = expanded.customLine1.slice(0, 120);
+  }
+  if (typeof expanded.customLine2 === 'string') {
+    state.customLine2 = expanded.customLine2.slice(0, 120);
+  }
+  if (typeof expanded.customImageData === 'string') {
+    state.customImageData = expanded.customImageData;
+  }
+  if (typeof expanded.customImageName === 'string') {
+    state.customImageName = sanitizeCustomImageName(expanded.customImageName);
+  }
+}
+
+export function serializeStateToQuery() {
+  try {
+    const payload = buildSharePayload(state);
+    if (Object.keys(payload).length === 0) {
+      return '';
+    }
+    const json = JSON.stringify(payload);
+    return encodeToBase64Url(json);
+  } catch (error) {
+    console.error('Failed to encode share state', error);
+    return '';
+  }
+}
+
+export function buildShareUrl() {
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+    return '';
+  }
+  const encoded = serializeStateToQuery();
+  if (!encoded) {
+    return '';
+  }
+  const url = new URL(window.location.href);
+  url.searchParams.set(SHARE_QUERY_PARAM, encoded);
+  return url.toString();
+}
+
+export function hydrateStateFromUrl() {
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+    return { hydrated: false };
+  }
+  let encoded = '';
+  try {
+    const currentUrl = new URL(window.location.href);
+    encoded = currentUrl.searchParams.get(SHARE_QUERY_PARAM) || '';
+  } catch (error) {
+    console.warn('Unable to inspect current URL for share parameter', error);
+    return { hydrated: false };
+  }
+  if (!encoded) {
+    return { hydrated: false };
+  }
+
+  try {
+    const json = decodeFromBase64Url(encoded);
+    const payload = JSON.parse(json);
+    if (!payload || typeof payload !== 'object') {
+      return { hydrated: false };
+    }
+    const expanded = expandPayload(payload);
+    applyExpandedPayload(expanded);
+    return { hydrated: true };
+  } catch (error) {
+    console.warn('Failed to hydrate state from share URL', error);
+    return { hydrated: false };
+  }
+}


### PR DESCRIPTION
## Summary
- add a Share action to the toolbar and disable it alongside Download/Print when the label is incomplete
- create a URL serializer/decoder to capture the full label state and hydrate it before form population
- integrate a Web Share API flow with clipboard fallback, wire the button, preserve prefilled selections, and document the feature

## Testing
- npm run lint
- manual Playwright sanity check covering share fallback and hydrated load

------
https://chatgpt.com/codex/tasks/task_e_68cf3c9520b8832993edf9d0b6f20cf8