### PR TITLE
Support bolt hardware type selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
                     aria-labelledby="hardware-type-label"
                   >
                     <option value="Screw">Screw</option>
+                    <option value="Bolt">Bolt</option>
                     <option value="Nut">Nut</option>
                     <option value="Heat Insert">Heat Insert</option>
                     <option value="Washer">Washer</option>
@@ -155,6 +156,17 @@
                       checked
                     />
                     <label class="btn btn-outline-primary w-100" for="hardware-type-screw">Screw</label>
+                  </div>
+                  <div class="col-12 col-sm-6 col-lg-3">
+                    <input
+                      type="radio"
+                      class="btn-check"
+                      name="hardware-type"
+                      id="hardware-type-bolt"
+                      value="Bolt"
+                      autocomplete="off"
+                    />
+                    <label class="btn btn-outline-primary w-100" for="hardware-type-bolt">Bolt</label>
                   </div>
                   <div class="col-12 col-sm-6 col-lg-3">
                     <input
@@ -384,35 +396,7 @@
                   class="validation-message text-danger small mt-2 d-none"
                 ></div>
               </div>
-              <div class="row g-3" id="screw-settings-row">
-                <div class="col-12 col-md-6" id="screw-type-container">
-                  <label class="form-label fw-semibold">Screw Type</label>
-                  <div class="row g-2" id="screw-type-group">
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="screw-type"
-                        id="screw-type-bolt"
-                        value="Bolt"
-                        autocomplete="off"
-                        checked
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="screw-type-bolt">Bolt</label>
-                    </div>
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="screw-type"
-                        id="screw-type-screw"
-                        value="Screw"
-                        autocomplete="off"
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="screw-type-screw">Screw</label>
-                    </div>
-                  </div>
-                </div>
+              <div class="row g-3" id="measurement-system-row">
                 <div class="col-12 col-md-6" id="measurement-system-container">
                   <label class="form-label fw-semibold">Measurement System</label>
                   <div class="row g-2" id="system-type-group">

--- a/js/controls.js
+++ b/js/controls.js
@@ -15,7 +15,6 @@ import { hydrateStateFromUrl } from './url-state.js';
 function applyStateToControls() {
   const {
     systemTypeRadios,
-    screwTypeRadios,
     fuseTypeRadios,
     fuseValueSelect,
     glassSizeSelect,
@@ -41,11 +40,6 @@ function applyStateToControls() {
   if (Array.isArray(systemTypeRadios)) {
     systemTypeRadios.forEach(radio => {
       radio.checked = radio.value === state.systemType;
-    });
-  }
-  if (Array.isArray(screwTypeRadios)) {
-    screwTypeRadios.forEach(radio => {
-      radio.checked = radio.value === state.screwType;
     });
   }
   if (Array.isArray(fuseTypeRadios)) {

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -2,7 +2,6 @@ const themeToggleButton = document.getElementById('theme-toggle');
 const themeToggleIcon = themeToggleButton ? themeToggleButton.querySelector('.theme-toggle-icon') : null;
 const themeToggleText = themeToggleButton ? themeToggleButton.querySelector('.theme-toggle-text') : null;
 
-const screwTypeContainer = document.getElementById('screw-type-container');
 const threadSizeContainer = document.getElementById('thread-size-container');
 const threadSizeSelect = document.getElementById('thread-size-select');
 const threadLengthRow = document.getElementById('thread-length-row');
@@ -82,7 +81,6 @@ const hardwareTypeOptions = new Set(
     .filter(Boolean)
 );
 const systemTypeRadios = Array.from(document.querySelectorAll('input[name="system-type"]'));
-const screwTypeRadios = Array.from(document.querySelectorAll('input[name="screw-type"]'));
 const fuseTypeRadios = Array.from(document.querySelectorAll('input[name="fuse-type"]'));
 const heightRadios = Array.from(document.querySelectorAll('input[name="label-height"]'));
 const componentCategoryRadios = Array.from(document.querySelectorAll('input[name="component-category"]'));
@@ -95,7 +93,6 @@ export const elements = {
   themeToggleButton,
   themeToggleIcon,
   themeToggleText,
-  screwTypeContainer,
   threadSizeContainer,
   threadSizeSelect,
   threadLengthRow,
@@ -165,7 +162,6 @@ export const elements = {
   hardwareTypeSelect,
   hardwareTypeOptions,
   systemTypeRadios,
-  screwTypeRadios,
   fuseTypeRadios,
   heightRadios,
   componentCategoryRadios,

--- a/js/events.js
+++ b/js/events.js
@@ -22,7 +22,6 @@ const {
   componentMountRadios,
   bearingTypeSelect,
   systemTypeRadios,
-  screwTypeRadios,
   fuseTypeRadios,
   threadSizeSelect,
   fuseValueSelect,
@@ -111,15 +110,6 @@ export function initEventHandlers() {
       if (radio.checked) {
         state.systemType = radio.value;
         populateThreadSizes();
-      }
-    });
-  });
-
-  screwTypeRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      if (radio.checked) {
-        state.screwType = radio.value;
-        populateStandards();
       }
     });
   });

--- a/js/forms.js
+++ b/js/forms.js
@@ -13,7 +13,6 @@ import { updatePreview, updateDownloadState } from './render.js';
 import { populateThreadSizes } from './threadSizes.js';
 
 const {
-  screwTypeContainer,
   threadSizeContainer,
   threadLengthRow,
   lengthContainer,
@@ -295,10 +294,7 @@ export function populateStandards() {
   let placeholderText = STANDARD_PLACEHOLDER_TEXT;
   let noOptionsText = 'No standards available';
   let titleText = 'Type to filter standards (Esc clears filter)';
-  if (state.hardwareType === 'Screw') {
-    const subset = hardwareCatalog[state.screwType];
-    standards = Array.isArray(subset) ? subset : [];
-  } else if (state.hardwareType === 'Connector') {
+  if (state.hardwareType === 'Connector') {
     const category = findConnectorCategory(state.connectorCategory);
     standards = category && Array.isArray(category.series) ? category.series : [];
     placeholderText = CONNECTOR_PLACEHOLDER_TEXT;
@@ -490,18 +486,15 @@ function syncHardwareTypeControls(nextType) {
 export function onHardwareTypeChange() {
   const type = state.hardwareType;
   syncHardwareTypeControls(type);
-  const showScrewFields = type === 'Screw';
+  const requiresThreadDetails = type === 'Bolt' || type === 'Screw';
   const showFuseFields = type === 'Fuse';
   const showConnectorFields = type === 'Connector';
   const showComponentFields = type === 'Component';
   const showCustomFields = type === 'Custom';
   const showBearingFields = type === 'Bearing';
 
-  if (screwTypeContainer) {
-    screwTypeContainer.style.display = showScrewFields ? '' : 'none';
-  }
   if (lengthContainer) {
-    lengthContainer.style.display = showScrewFields ? '' : 'none';
+    lengthContainer.style.display = requiresThreadDetails ? '' : 'none';
   }
 
   if (bearingOptionsContainer) {
@@ -581,7 +574,7 @@ export function onHardwareTypeChange() {
       showFuseFields || showConnectorFields || showCustomFields || showBearingFields || showComponentFields;
     threadLengthRow.classList.toggle(
       'single-column',
-      !showScrewFields &&
+      !requiresThreadDetails &&
         !showFuseFields &&
         !showConnectorFields &&
         !showCustomFields &&

--- a/js/render.js
+++ b/js/render.js
@@ -173,7 +173,7 @@ function formatRequirementSummary(requirements) {
 function applyValidationFeedback(disabled) {
   const requirements = [];
   const hardwareType = state.hardwareType;
-  const screwLabel = (state.screwType || 'screw').toLowerCase();
+  const hardwareLabel = typeof hardwareType === 'string' ? hardwareType.toLowerCase() : '';
 
   const needsThreadSize = !['Fuse', 'Connector', 'Custom', 'Bearing', 'Component'].includes(hardwareType);
   const threadValid = !needsThreadSize || Boolean(state.threadSize);
@@ -187,7 +187,7 @@ function applyValidationFeedback(disabled) {
     requirements.push('select a thread size');
   }
 
-  const needsLength = hardwareType === 'Screw';
+  const needsLength = hardwareType === 'Bolt' || hardwareType === 'Screw';
   const lengthValue = Number.parseFloat(state.length);
   const lengthValid = !needsLength || (Number.isFinite(lengthValue) && lengthValue > 0);
   updateInputFieldState({
@@ -197,7 +197,8 @@ function applyValidationFeedback(disabled) {
     valid: lengthValid
   });
   if (!lengthValid) {
-    requirements.push(`enter the ${screwLabel} length`);
+    const lengthDescription = hardwareLabel ? `${hardwareLabel} length` : 'length';
+    requirements.push(`enter the ${lengthDescription}`);
   }
 
   const needsFuseValue = hardwareType === 'Fuse';
@@ -301,10 +302,7 @@ function normalizeStandardCode(code) {
 }
 
 function getHardwareImageInfo() {
-  let catalogKey = state.hardwareType;
-  if (state.hardwareType === 'Screw') {
-    catalogKey = state.screwType;
-  }
+  const catalogKey = state.hardwareType;
   if (!catalogKey) {
     return null;
   }
@@ -328,7 +326,7 @@ function getHardwareImageInfo() {
   if (standardName && standardName.toLowerCase() !== code.toLowerCase()) {
     altPieces.push(standardName);
   }
-  if (state.screwType === 'Bolt') {
+  if (state.hardwareType === 'Bolt') {
     const baseSource = code || standardName || 'Bolt';
     const normalizedBase = baseSource.toLowerCase().trim().replace(/\s+/g, ' ');
     let boltLabel = normalizedBase
@@ -444,18 +442,29 @@ function getHardwareIcon(iconHeight) {
     return null;
   }
   const fallbackIcons = [];
-  if (type === 'Screw') {
-    const isBolt = state.screwType === 'Bolt';
-    const variantFolder = isBolt ? 'socket_head' : 'button_head';
-    const label = isBolt ? 'Bolt' : 'Screw';
+  if (type === 'Bolt') {
+    const folder = hardwareImageFolders[type];
+    if (folder) {
+      fallbackIcons.push(
+        {
+          src: `images/${folder}/socket_head/side.svg`,
+          alt: 'Bolt side profile illustration'
+        },
+        {
+          src: `images/${folder}/socket_head/head.svg`,
+          alt: 'Bolt head view illustration'
+        }
+      );
+    }
+  } else if (type === 'Screw') {
     fallbackIcons.push(
       {
-        src: `images/bolts/${variantFolder}/side.svg`,
-        alt: `${label} side profile illustration`
+        src: 'images/bolts/button_head/side.svg',
+        alt: 'Screw side profile illustration'
       },
       {
-        src: `images/bolts/${variantFolder}/head.svg`,
-        alt: `${label} head view illustration`
+        src: 'images/bolts/button_head/head.svg',
+        alt: 'Screw head view illustration'
       }
     );
   } else if (type === 'Nut') {
@@ -567,7 +576,7 @@ export function isLabelReady() {
   if (state.hardwareType === 'Component') {
     return Boolean(state.componentCategory && state.componentMount);
   }
-  if (state.hardwareType === 'Screw') {
+  if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
     return Boolean(state.threadSize && state.length);
   }
   return Boolean(state.threadSize);

--- a/js/state.js
+++ b/js/state.js
@@ -1,7 +1,6 @@
 export const state = {
   hardwareType: 'Screw',
   systemType: 'Metric',
-  screwType: 'Bolt',
   fuseType: 'Glass',
   threadSize: '',
   length: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -13,7 +13,6 @@ export const SHARE_QUERY_PARAM = 'label';
 const FIELD_MAP = {
   hardwareType: 'ht',
   systemType: 'ms',
-  screwType: 'st',
   fuseType: 'ft',
   threadSize: 'ts',
   length: 'ln',
@@ -46,9 +45,6 @@ const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) =>
 }, {});
 
 const hardwareTypeOptions = elements.hardwareTypeOptions || new Set();
-const screwTypeOptions = new Set(
-  Array.isArray(elements.screwTypeRadios) ? elements.screwTypeRadios.map(radio => radio.value) : []
-);
 const fuseTypeOptions = new Set(
   Array.isArray(elements.fuseTypeRadios) ? elements.fuseTypeRadios.map(radio => radio.value) : []
 );
@@ -260,9 +256,6 @@ function applyExpandedPayload(expanded) {
   if (typeof expanded.systemType === 'string' && systemTypeOptions.has(expanded.systemType)) {
     state.systemType = expanded.systemType;
   }
-  if (typeof expanded.screwType === 'string' && screwTypeOptions.has(expanded.screwType)) {
-    state.screwType = expanded.screwType;
-  }
   if (typeof expanded.fuseType === 'string' && fuseTypeOptions.has(expanded.fuseType)) {
     state.fuseType = expanded.fuseType;
   }
@@ -299,7 +292,7 @@ function applyExpandedPayload(expanded) {
     state.threadSize = sanitizedThread;
   }
 
-  if (state.hardwareType === 'Screw') {
+  if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
     const sanitizedLength = sanitizeLength(expanded.length);
     if (sanitizedLength !== null) {
       state.length = sanitizedLength;


### PR DESCRIPTION
## Summary
- expose Bolt as a top-level hardware type option in the UI and remove the redundant screw type picker
- refactor state, form logic, and URL handling so threaded catalog and validation rely on `hardwareType`
- update rendering validation and fallback imagery to treat bolts as first-class threaded hardware

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa2549af083299a9905f0791c23e5