### PR TITLE
Require standard before bolt/screw preview and restyle images

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -30,6 +30,8 @@ const {
   connectorCategoryContainer,
   notesInput,
   notesField,
+  standardSelect,
+  standardField,
   bearingTypeSelect,
   bearingOptionsContainer,
   componentCategoryContainer,
@@ -199,6 +201,21 @@ function applyValidationFeedback(disabled) {
   if (!lengthValid) {
     const lengthDescription = hardwareLabel ? `${hardwareLabel} length` : 'length';
     requirements.push(`enter the ${lengthDescription}`);
+  }
+
+  const standardRequired =
+    (hardwareType === 'Bolt' || hardwareType === 'Screw') && Boolean(standardSelect) && Boolean(standardField);
+  const needsStandard =
+    standardRequired && Boolean(hardwareImageFolders[hardwareType]) && !standardSelect.disabled;
+  const standardValid = !needsStandard || Boolean(state.standardCode);
+  updateInputFieldState({
+    input: standardSelect,
+    container: standardField,
+    messageElement: null,
+    valid: standardValid
+  });
+  if (!standardValid) {
+    requirements.push('choose a hardware standard');
   }
 
   const needsFuseValue = hardwareType === 'Fuse';
@@ -577,7 +594,7 @@ export function isLabelReady() {
     return Boolean(state.componentCategory && state.componentMount);
   }
   if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
-    return Boolean(state.threadSize && state.length);
+    return Boolean(state.threadSize && state.length && state.standardCode);
   }
   return Boolean(state.threadSize);
 }
@@ -662,6 +679,7 @@ export function updatePreview() {
       previewPlaceholder.setAttribute('aria-hidden', 'false');
     }
     labelInner.style.display = 'none';
+    labelInner.classList.remove('has-hardware-image');
     hardwareImageDiv.style.display = 'none';
     hardwareImageDiv.innerHTML = '';
     hardwareImageDiv.style.removeProperty('max-width');
@@ -804,7 +822,14 @@ export function updatePreview() {
 
       const photoInfo = getHardwareImageInfo();
       if (photoInfo && innerHeightPx > 0 && innerWidthPx > 0) {
-        const maxWidthForPhoto = Math.max(0, Math.min(innerHeightPx, innerWidthPx * 0.45));
+        let maxWidthForPhoto = Math.max(0, Math.min(innerHeightPx, innerWidthPx * 0.45));
+        if (photoInfo.type === 'boltSvg') {
+          const boltPreferredWidth = Math.max(0, Math.min(innerHeightPx * 1.4, innerWidthPx * 0.6));
+          maxWidthForPhoto = Math.max(maxWidthForPhoto, boltPreferredWidth);
+        } else {
+          const photoPreferredWidth = Math.max(0, Math.min(innerHeightPx * 1.2, innerWidthPx * 0.5));
+          maxWidthForPhoto = Math.max(maxWidthForPhoto, photoPreferredWidth);
+        }
         if (maxWidthForPhoto > 0) {
           hardwareImageDiv.style.display = 'flex';
           hardwareImageDiv.style.maxWidth = maxWidthForPhoto + 'px';
@@ -897,6 +922,10 @@ export function updatePreview() {
     hardwareImageDiv.style.removeProperty('min-height');
     hardwareWidthPx = 0;
     hardwareVisible = false;
+  }
+
+  if (labelInner) {
+    labelInner.classList.toggle('has-hardware-image', hardwareVisible);
   }
 
   if (state.hardwareType === 'Custom') {

--- a/style.css
+++ b/style.css
@@ -246,6 +246,12 @@ main {
   box-shadow: none;
 }
 
+.label-inner.has-hardware-image .hardware-icon:not(:empty) {
+  margin-inline-start: calc(-1 * var(--label-padding-inline-start));
+  margin-left: calc(-1 * var(--label-padding-inline-start));
+  justify-content: flex-start;
+}
+
 .hardware-icon svg {
   width: auto;
 }
@@ -267,23 +273,29 @@ main {
   filter: grayscale(100%);
 }
 
+.label-inner.has-hardware-image .text-block {
+  align-items: center;
+  text-align: center;
+}
+
 .bolt-image-group {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 0.75rem;
   max-height: 100%;
+  width: 100%;
 }
 
 .bolt-image-group img {
   display: block;
   max-height: 100%;
   width: auto;
+  flex: 1 1 0;
 }
 
 .bolt-side-view {
-  transform: rotate(90deg);
-  transform-origin: center;
+  transform: none;
 }
 
 .custom-image-preview {


### PR DESCRIPTION
## Summary
- block bolt and screw previews until a hardware standard is chosen so the correct artwork can load
- update validation to highlight the missing standard and keep the placeholder visible until selection
- enlarge hardware artwork, restore the side view orientation, and center text beside the bigger images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfc37203a4832981903b099f4aad8f