### PR TITLE
Fix download gating after selecting standard

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -237,6 +237,7 @@ export function initEventHandlers() {
         state.standard = '';
         state.standardCode = '';
       }
+      updateDownloadState();
       updatePreview();
     });
     standardSelect.addEventListener('keydown', handleStandardSelectKeydown);

--- a/js/forms.js
+++ b/js/forms.js
@@ -389,11 +389,12 @@ export function filterStandardOptions(query) {
 
   if (selectionCleared) {
     standardSelect.value = '';
-    if (state.standard) {
+    if (state.standard || state.standardCode) {
       state.standard = '';
       state.standardCode = '';
       updatePreview();
     }
+    updateDownloadState();
   }
 
   const placeholder = standardSelect.querySelector('option[value=""]');


### PR DESCRIPTION
## Summary
- trigger the download state update when a hardware standard is selected or cleared
- ensure clearing a filtered standard also refreshes validation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff2d8c27483298825621bab10f5cc