### PR TITLE
Align measurement system buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
                 <div class="col-12 col-md-6" id="measurement-system-container">
                   <label class="form-label fw-semibold">Measurement System</label>
                   <div class="row g-2" id="system-type-group">
-                    <div class="col-12 col-sm-6">
+                    <div class="col-6">
                       <input
                         type="radio"
                         class="btn-check"
@@ -430,7 +430,7 @@
                       />
                       <label class="btn btn-outline-secondary w-100" for="system-type-metric">Metric</label>
                     </div>
-                    <div class="col-12 col-sm-6">
+                    <div class="col-6">
                       <input
                         type="radio"
                         class="btn-check"


### PR DESCRIPTION
## Summary
- adjust the measurement system button columns so they display side-by-side on mobile screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff7e4d0e08329a11f6649c734a522