### PR TITLE
Adjust hero title sizing for mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ main {
 
 .title-section h1 {
   font-family: "Tagesschrift", sans-serif;
-  font-size: clamp(3.25rem, 6vw, 4.5rem);
+  font-size: clamp(1.35rem, 6vw, 4.5rem);
   line-height: 1.05;
 }
 


### PR DESCRIPTION
## Summary
- reduce the hero title's minimum clamp size so the "Gridfinity Label Maker" heading stays on one line on small viewports

## Testing
- npm run format *(fails: existing files need Prettier formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68d085bc21908329b81df881f8e181b5