### PR TITLE
Make hardware type dropdown universal

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
                 >
                   Hardware Type
                 </label>
-                <div class="d-sm-none">
+                <div>
                   <select
                     id="hardware-type-select"
                     class="form-select"
@@ -149,131 +149,6 @@
                     </optgroup>
                     <option value="Custom">Custom</option>
                   </select>
-                </div>
-                <div class="row g-2 d-none d-sm-flex" id="hardware-type-group">
-                  <div class="col-12">
-                    <div class="fw-semibold text-muted text-uppercase small mb-1">Hardware</div>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-bolt"
-                      value="Bolt"
-                      autocomplete="off"
-                      checked
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-bolt">Bolt</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-heat-insert"
-                      value="Heat Insert"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-heat-insert">Heat Insert</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-nut"
-                      value="Nut"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-nut">Nut</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-screw"
-                      value="Screw"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-screw">Screw</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-washer"
-                      value="Washer"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-washer">Washer</label>
-                  </div>
-                  <div class="col-12 mt-3">
-                    <div class="fw-semibold text-muted text-uppercase small mb-1">Electrical</div>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-fuse"
-                      value="Fuse"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-fuse">Fuse</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-connector"
-                      value="Connector"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-connector">Connector</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-component"
-                      value="Component"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-component">Component</label>
-                  </div>
-                  <div class="col-12 mt-3">
-                    <div class="fw-semibold text-muted text-uppercase small mb-1">Mechanical</div>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-bearing"
-                      value="Bearing"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-bearing">Bearing</label>
-                  </div>
-                  <div class="col-12 mt-3">
-                    <div class="fw-semibold text-muted text-uppercase small mb-1">Custom</div>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-3">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="hardware-type"
-                      id="hardware-type-custom"
-                      value="Custom"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-primary w-100" for="hardware-type-custom">Custom</label>
-                  </div>
                 </div>
               </div>
               <div id="custom-fields" class="d-none">


### PR DESCRIPTION
## Summary
- show the hardware type select control on every screen size so desktop matches mobile
- remove the radio button grid so hardware categories stay grouped within the dropdown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0b96986ec832982eb53243f52fdff