### PR TITLE
Refine bolt selection with separate head and drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Gridfinity Label Maker is a static web application for designing and printing
-labels sized for Gridfinity storage bins.  The app runs entirely in the browser
+labels sized for Gridfinity storage bins. The app runs entirely in the browser
 and relies on modular JavaScript, modern HTML, and layered CSS for styling.
 Bootstrap utilities provide responsive layout primitives, while lightweight
 third-party libraries are lazy-loaded to power optional QR code generation and
@@ -12,15 +12,15 @@ image export.
 Key capabilities exposed through `index.html` and the supporting scripts
 include:
 
-* Dark and light theme toggle with preference persistence.
-* Hardware presets that reconfigure the form for screws, nuts, inserts, fuses,
+- Dark and light theme toggle with preference persistence.
+- Hardware presets that reconfigure the form for screws, nuts, inserts, fuses,
   bearings, electronic components, and fully custom labels.
-* Contextual validation and helper messaging that keep the preview in sync with
+- Contextual validation and helper messaging that keep the preview in sync with
   selected options.
-* Optional QR code content with automatic library loading only when needed.
-* Download-and-print flows that use html2canvas to export the on-screen label
+- Optional QR code content with automatic library loading only when needed.
+- Download-and-print flows that use html2canvas to export the on-screen label
   preview.
-* Shareable label URLs with Web Share API support and clipboard fallback.
+- Shareable label URLs with Web Share API support and clipboard fallback.
 
 The repository is structured as a traditional GitHub Pages site, making it easy
 to host the tool directly from the `main` branch.
@@ -51,8 +51,8 @@ to host the tool directly from the `main` branch.
 
 ## Building the Project
 
-No build step is required.  All assets are committed in their final form and
-referenced directly from `index.html`.  When making changes, open the HTML file
+No build step is required. All assets are committed in their final form and
+referenced directly from `index.html`. When making changes, open the HTML file
 in a browser or serve the repository via a static file server to reflect your
 updates.
 
@@ -110,11 +110,11 @@ branch (or `/docs` folder if you choose to relocate the site assets).
 
 ## License
 
-This project is available under the terms of the MIT License.  See
+This project is available under the terms of the MIT License. See
 [`LICENSE`](LICENSE) for the full text.
 
 ## Change Log
 
 Release history is tracked in [`CHANGELOG.md`](CHANGELOG.md) using the
-[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.  Refer to
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention. Refer to
 that file for a detailed summary of notable updates.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['node_modules/', 'images/']
+    ignores: ['node_modules/', 'images/'],
   },
   {
     ...js.configs.recommended,
@@ -14,8 +14,8 @@ export default [
       sourceType: 'module',
       globals: {
         ...globals.browser,
-        ...globals.es2021
-      }
-    }
-  }
+        ...globals.es2021,
+      },
+    },
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -1,608 +1,763 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-bs-theme="light" data-theme="light">
-<head>
-  <meta charset="UTF-8">
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0, viewport-fit=cover"
-  />
-  <title>Gridfinity Label Maker</title>
-  <meta name="color-scheme" content="light dark" />
-  <meta name="supported-color-schemes" content="light dark" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-title" content="Gridfinity Label Maker" />
-  <meta
-    name="apple-mobile-web-app-status-bar-style"
-    content="default"
-    id="apple-mobile-web-app-status-bar-style"
-  />
-  <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
-  <meta name="description" content="Gridfinity Label Maker – design and print perfectly sized labels for Gridfinity storage bins.">
-  <link rel="manifest" href="manifest.json" />
-  <!--
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Gridfinity Label Maker</title>
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="Gridfinity Label Maker" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      id="apple-mobile-web-app-status-bar-style"
+    />
+    <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
+    <meta
+      name="description"
+      content="Gridfinity Label Maker – design and print perfectly sized labels for Gridfinity storage bins."
+    />
+    <link rel="manifest" href="manifest.json" />
+    <!--
     Standalone tool for generating and printing Gridfinity labels.  Styling
     now layers a lightweight Bootstrap 5 theme for modern form controls and
     layout utilities.  Two small third-party libraries are loaded on demand
     via CDN: html2canvas to capture the label preview as an image and qrcode
     to generate optional QR codes.
   -->
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-    crossorigin="anonymous"
-  />
-  <link rel="icon" type="image/x-icon" href="images/icons/favicon.ico" />
-  <link rel="apple-touch-icon" href="images/icons/apple-touch-icon.png" />
-  <link rel="apple-touch-icon" sizes="57x57" href="images/icons/apple-touch-icon-57x57.png" />
-  <link rel="apple-touch-icon" sizes="72x72" href="images/icons/apple-touch-icon-72x72.png" />
-  <link rel="apple-touch-icon" sizes="76x76" href="images/icons/apple-touch-icon-76x76.png" />
-  <link rel="apple-touch-icon" sizes="114x114" href="images/icons/apple-touch-icon-114x114.png" />
-  <link rel="apple-touch-icon" sizes="120x120" href="images/icons/apple-touch-icon-120x120.png" />
-  <link rel="apple-touch-icon" sizes="144x144" href="images/icons/apple-touch-icon-144x144.png" />
-  <link rel="apple-touch-icon" sizes="152x152" href="images/icons/apple-touch-icon-152x152.png" />
-  <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon-180x180.png" />
-  <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-    integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-  />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Tagesschrift&display=swap"
-    rel="stylesheet"
-  />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Barlow:wght@500;600;700&display=swap"
-    rel="stylesheet"
-  />
-  <script>
-    (function() {
-      const storageKey = 'gridfinity-theme-preference';
-      const themeColors = { light: '#f8fafc', dark: '#0f172a' };
-      const statusBarStyles = { light: 'default', dark: 'black-translucent' };
-      let theme = 'light';
-      try {
-        const storedTheme = localStorage.getItem(storageKey);
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-        if (storedTheme === 'light' || storedTheme === 'dark') {
-          theme = storedTheme;
-        } else if (prefersDark.matches) {
-          theme = 'dark';
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="icon" type="image/x-icon" href="images/icons/favicon.ico" />
+    <link rel="apple-touch-icon" href="images/icons/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="57x57" href="images/icons/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="images/icons/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="images/icons/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="images/icons/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="images/icons/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="images/icons/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="images/icons/apple-touch-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon-180x180.png" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Tagesschrift&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      (function () {
+        const storageKey = 'gridfinity-theme-preference';
+        const themeColors = { light: '#f8fafc', dark: '#0f172a' };
+        const statusBarStyles = { light: 'default', dark: 'black-translucent' };
+        let theme = 'light';
+        try {
+          const storedTheme = localStorage.getItem(storageKey);
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+          if (storedTheme === 'light' || storedTheme === 'dark') {
+            theme = storedTheme;
+          } else if (prefersDark.matches) {
+            theme = 'dark';
+          }
+        } catch (error) {
+          theme = 'light';
         }
-      } catch (error) {
-        theme = 'light';
-      }
-      document.documentElement.setAttribute('data-theme', theme);
-      document.documentElement.setAttribute('data-bs-theme', theme);
-      const themeColorMeta = document.getElementById('theme-color-meta');
-      if (themeColorMeta) {
-        themeColorMeta.setAttribute('content', themeColors[theme] || themeColors.light);
-      }
-      const statusBarMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
-      if (statusBarMeta) {
-        statusBarMeta.setAttribute('content', statusBarStyles[theme] || statusBarStyles.light);
-      }
-    })();
-  </script>
-  <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="style-print.css" media="print" />
-  <link rel="stylesheet" href="print.css" />
-  <script type="module" defer src="js/controls.js"></script>
-</head>
-<body>
-  <main class="container py-4">
-    <div class="theme-toggle-wrapper mb-3">
-      <button
-        type="button"
-        class="theme-toggle-button"
-        id="theme-toggle"
-        aria-pressed="false"
-        aria-label="Switch to dark mode"
-        title="Switch to dark mode"
-      >
-        <i class="fa-solid fa-moon theme-toggle-icon" aria-hidden="true"></i>
-        <span class="theme-toggle-text">Dark mode</span>
-      </button>
-    </div>
-    <header class="title-section text-center mb-4">
-      <h1 class="display-5 fw-semibold">Gridfinity Label Maker</h1>
-      <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
-    </header>
-    <div class="row g-4">
-      <section class="form-section col-lg-7">
-        <div class="card shadow-sm h-100">
-          <div class="card-body">
-            <h2 class="h5 mb-3 section-heading">Hardware Details</h2>
-            <div class="vstack gap-3">
-              <div>
-                <label
-                  class="form-label fw-semibold"
-                  for="hardware-type-select"
-                  id="hardware-type-label"
-                >
-                  Hardware Type
-                </label>
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        const themeColorMeta = document.getElementById('theme-color-meta');
+        if (themeColorMeta) {
+          themeColorMeta.setAttribute('content', themeColors[theme] || themeColors.light);
+        }
+        const statusBarMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
+        if (statusBarMeta) {
+          statusBarMeta.setAttribute('content', statusBarStyles[theme] || statusBarStyles.light);
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style-print.css" media="print" />
+    <link rel="stylesheet" href="print.css" />
+    <script type="module" defer src="js/controls.js"></script>
+  </head>
+  <body>
+    <main class="container py-4">
+      <div class="theme-toggle-wrapper mb-3">
+        <button
+          type="button"
+          class="theme-toggle-button"
+          id="theme-toggle"
+          aria-pressed="false"
+          aria-label="Switch to dark mode"
+          title="Switch to dark mode"
+        >
+          <i class="fa-solid fa-moon theme-toggle-icon" aria-hidden="true"></i>
+          <span class="theme-toggle-text">Dark mode</span>
+        </button>
+      </div>
+      <header class="title-section text-center mb-4">
+        <h1 class="display-5 fw-semibold">Gridfinity Label Maker</h1>
+        <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
+      </header>
+      <div class="row g-4">
+        <section class="form-section col-lg-7">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <h2 class="h5 mb-3 section-heading">Hardware Details</h2>
+              <div class="vstack gap-3">
                 <div>
-                  <select
-                    id="hardware-type-select"
-                    class="form-select"
-                    aria-labelledby="hardware-type-label"
+                  <label
+                    class="form-label fw-semibold"
+                    for="hardware-type-select"
+                    id="hardware-type-label"
                   >
-                    <optgroup label="Hardware">
-                      <option value="Bolt" selected>Bolt</option>
-                      <option value="Heat Insert">Heat Insert</option>
-                      <option value="Nut">Nut</option>
-                      <option value="Screw">Screw</option>
-                      <option value="Washer">Washer</option>
-                    </optgroup>
-                    <optgroup label="Electrical">
-                      <option value="Fuse">Fuse</option>
-                      <option value="Connector">Connector</option>
-                      <option value="Component">Component</option>
-                    </optgroup>
-                    <optgroup label="Mechanical">
-                      <option value="Bearing">Bearing</option>
-                    </optgroup>
-                    <option value="Custom">Custom</option>
-                  </select>
+                    Hardware Type
+                  </label>
+                  <div>
+                    <select
+                      id="hardware-type-select"
+                      class="form-select"
+                      aria-labelledby="hardware-type-label"
+                    >
+                      <optgroup label="Hardware">
+                        <option value="Bolt" selected>Bolt</option>
+                        <option value="Heat Insert">Heat Insert</option>
+                        <option value="Nut">Nut</option>
+                        <option value="Screw">Screw</option>
+                        <option value="Washer">Washer</option>
+                      </optgroup>
+                      <optgroup label="Electrical">
+                        <option value="Fuse">Fuse</option>
+                        <option value="Connector">Connector</option>
+                        <option value="Component">Component</option>
+                      </optgroup>
+                      <optgroup label="Mechanical">
+                        <option value="Bearing">Bearing</option>
+                      </optgroup>
+                      <option value="Custom">Custom</option>
+                    </select>
+                  </div>
                 </div>
-              </div>
-              <div id="custom-fields" class="d-none">
-                <label for="custom-image-input" class="form-label d-block fw-semibold">Custom Image</label>
-                <input type="file" class="form-control" id="custom-image-input" accept="image/*" />
-                <div class="form-text">Square images work best. PNG, JPG and SVG files are supported.</div>
-                <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
-                  <button type="button" class="btn btn-outline-secondary btn-sm" id="custom-image-clear" disabled>
-                    Remove image
-                  </button>
-                  <span id="custom-image-name" class="text-muted small d-none"></span>
-                </div>
-                <div class="mt-3" id="custom-line1-field">
-                  <label for="custom-line1-input" class="form-label fw-semibold">Top Line</label>
+                <div id="custom-fields" class="d-none">
+                  <label for="custom-image-input" class="form-label d-block fw-semibold"
+                    >Custom Image</label
+                  >
                   <input
-                    type="text"
+                    type="file"
                     class="form-control"
-                    id="custom-line1-input"
-                    placeholder="e.g., 5 mm Drill Bits"
-                    maxlength="60"
-                    aria-describedby="custom-line1-hint custom-line1-message"
+                    id="custom-image-input"
+                    accept="image/*"
                   />
-                  <div class="form-text" id="custom-line1-hint">Shown as the large title on the label.</div>
+                  <div class="form-text">
+                    Square images work best. PNG, JPG and SVG files are supported.
+                  </div>
+                  <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                    <button
+                      type="button"
+                      class="btn btn-outline-secondary btn-sm"
+                      id="custom-image-clear"
+                      disabled
+                    >
+                      Remove image
+                    </button>
+                    <span id="custom-image-name" class="text-muted small d-none"></span>
+                  </div>
+                  <div class="mt-3" id="custom-line1-field">
+                    <label for="custom-line1-input" class="form-label fw-semibold">Top Line</label>
+                    <input
+                      type="text"
+                      class="form-control"
+                      id="custom-line1-input"
+                      placeholder="e.g., 5 mm Drill Bits"
+                      maxlength="60"
+                      aria-describedby="custom-line1-hint custom-line1-message"
+                    />
+                    <div class="form-text" id="custom-line1-hint">
+                      Shown as the large title on the label.
+                    </div>
+                    <div
+                      id="custom-line1-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
+                  <div>
+                    <label for="custom-line2-input" class="form-label fw-semibold"
+                      >Bottom Line</label
+                    >
+                    <input
+                      type="text"
+                      class="form-control"
+                      id="custom-line2-input"
+                      placeholder="Description or name (optional)"
+                      maxlength="80"
+                    />
+                  </div>
+                </div>
+                <div id="connector-category-container" class="d-none">
+                  <label for="connector-category-select" class="form-label fw-semibold"
+                    >Connector Category</label
+                  >
+                  <select
+                    id="connector-category-select"
+                    class="form-select"
+                    aria-describedby="connector-category-message"
+                  ></select>
+                  <div id="connector-category-help" class="form-text d-none"></div>
                   <div
-                    id="custom-line1-message"
+                    id="connector-category-message"
                     class="validation-message text-danger small mt-2 d-none"
                   ></div>
                 </div>
-                <div>
-                  <label for="custom-line2-input" class="form-label fw-semibold">Bottom Line</label>
-                  <input
-                    type="text"
-                    class="form-control"
-                    id="custom-line2-input"
-                    placeholder="Description or name (optional)"
-                    maxlength="80"
-                  />
-                </div>
-              </div>
-              <div id="connector-category-container" class="d-none">
-                <label for="connector-category-select" class="form-label fw-semibold">Connector Category</label>
-                <select
-                  id="connector-category-select"
-                  class="form-select"
-                  aria-describedby="connector-category-message"
-                ></select>
-                <div id="connector-category-help" class="form-text d-none"></div>
-                <div
-                  id="connector-category-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
-              <div id="component-category-container" class="d-none">
-                <span class="form-label d-block fw-semibold">Component Type</span>
-                <div class="row g-2" id="component-category-group">
-                  <div class="col-12 col-sm-6 col-lg-4">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="component-category"
-                      id="component-type-resistor"
-                      value="Resistor"
-                      autocomplete="off"
-                      checked
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="component-type-resistor">Resistor</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-4">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="component-category"
-                      id="component-type-capacitor"
-                      value="Capacitor"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="component-type-capacitor">Capacitor</label>
-                  </div>
-                  <div class="col-12 col-sm-6 col-lg-4">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="component-category"
-                      id="component-type-diode"
-                      value="Diode"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="component-type-diode">Diode</label>
-                  </div>
-                </div>
-                <div
-                  id="component-category-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
-              <div id="component-mount-container" class="d-none">
-                <span class="form-label d-block fw-semibold">Mounting Style</span>
-                <div class="row g-2" id="component-mount-group">
-                  <div class="col-12 col-sm-6">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="component-mount"
-                      id="component-mount-through-hole"
-                      value="Through-Hole"
-                      autocomplete="off"
-                      checked
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="component-mount-through-hole">Through-Hole</label>
-                  </div>
-                  <div class="col-12 col-sm-6">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="component-mount"
-                      id="component-mount-smd"
-                      value="SMD"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="component-mount-smd">SMD</label>
-                  </div>
-                </div>
-                <div
-                  id="component-mount-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
-              <div id="bearing-options-container" class="d-none">
-                <label for="bearing-type-select" class="form-label fw-semibold">Bearing Selection</label>
-                <select
-                  id="bearing-type-select"
-                  class="form-select"
-                  aria-describedby="bearing-type-message"
-                ></select>
-                <div class="form-text">Common miniature and deep-groove bearings used in hobby projects.</div>
-                <div
-                  id="bearing-type-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
-              <div class="row g-3" id="measurement-system-row">
-                <div class="col-12 col-md-6" id="measurement-system-container">
-                  <label class="form-label fw-semibold">Measurement System</label>
-                  <div class="row g-2" id="system-type-group">
-                    <div class="col-6">
+                <div id="component-category-container" class="d-none">
+                  <span class="form-label d-block fw-semibold">Component Type</span>
+                  <div class="row g-2" id="component-category-group">
+                    <div class="col-12 col-sm-6 col-lg-4">
                       <input
                         type="radio"
                         class="btn-check"
-                        name="system-type"
-                        id="system-type-metric"
-                        value="Metric"
+                        name="component-category"
+                        id="component-type-resistor"
+                        value="Resistor"
                         autocomplete="off"
                         checked
                       />
-                      <label class="btn btn-outline-secondary w-100" for="system-type-metric">Metric</label>
+                      <label class="btn btn-outline-secondary w-100" for="component-type-resistor"
+                        >Resistor</label
+                      >
                     </div>
-                    <div class="col-6">
+                    <div class="col-12 col-sm-6 col-lg-4">
                       <input
                         type="radio"
                         class="btn-check"
-                        name="system-type"
-                        id="system-type-imperial"
-                        value="Imperial"
+                        name="component-category"
+                        id="component-type-capacitor"
+                        value="Capacitor"
                         autocomplete="off"
                       />
-                      <label class="btn btn-outline-secondary w-100" for="system-type-imperial">Imperial</label>
+                      <label class="btn btn-outline-secondary w-100" for="component-type-capacitor"
+                        >Capacitor</label
+                      >
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-4">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="component-category"
+                        id="component-type-diode"
+                        value="Diode"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="component-type-diode"
+                        >Diode</label
+                      >
+                    </div>
+                  </div>
+                  <div
+                    id="component-category-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
+                </div>
+                <div id="component-mount-container" class="d-none">
+                  <span class="form-label d-block fw-semibold">Mounting Style</span>
+                  <div class="row g-2" id="component-mount-group">
+                    <div class="col-12 col-sm-6">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="component-mount"
+                        id="component-mount-through-hole"
+                        value="Through-Hole"
+                        autocomplete="off"
+                        checked
+                      />
+                      <label
+                        class="btn btn-outline-secondary w-100"
+                        for="component-mount-through-hole"
+                        >Through-Hole</label
+                      >
+                    </div>
+                    <div class="col-12 col-sm-6">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="component-mount"
+                        id="component-mount-smd"
+                        value="SMD"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="component-mount-smd"
+                        >SMD</label
+                      >
+                    </div>
+                  </div>
+                  <div
+                    id="component-mount-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
+                </div>
+                <div id="bearing-options-container" class="d-none">
+                  <label for="bearing-type-select" class="form-label fw-semibold"
+                    >Bearing Selection</label
+                  >
+                  <select
+                    id="bearing-type-select"
+                    class="form-select"
+                    aria-describedby="bearing-type-message"
+                  ></select>
+                  <div class="form-text">
+                    Common miniature and deep-groove bearings used in hobby projects.
+                  </div>
+                  <div
+                    id="bearing-type-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
+                </div>
+                <div class="row g-3" id="measurement-system-row">
+                  <div class="col-12 col-md-6" id="measurement-system-container">
+                    <label class="form-label fw-semibold">Measurement System</label>
+                    <div class="row g-2" id="system-type-group">
+                      <div class="col-6">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="system-type"
+                          id="system-type-metric"
+                          value="Metric"
+                          autocomplete="off"
+                          checked
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="system-type-metric"
+                          >Metric</label
+                        >
+                      </div>
+                      <div class="col-6">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="system-type"
+                          id="system-type-imperial"
+                          value="Imperial"
+                          autocomplete="off"
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="system-type-imperial"
+                          >Imperial</label
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="row g-3" id="thread-length-row">
+                  <div class="col-12 col-sm-6 thread-length-field" id="thread-size-container">
+                    <label for="thread-size-select" class="form-label fw-semibold"
+                      >Thread Size</label
+                    >
+                    <select
+                      id="thread-size-select"
+                      class="form-select"
+                      aria-describedby="thread-size-message"
+                    ></select>
+                    <div
+                      id="thread-size-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
+                  <div class="col-12 col-sm-6 thread-length-field" id="length-container">
+                    <label for="length-input" class="form-label fw-semibold">Length</label>
+                    <input
+                      type="number"
+                      id="length-input"
+                      class="form-control"
+                      placeholder="e.g., 10"
+                      min="1"
+                      aria-describedby="length-message"
+                    />
+                    <div
+                      id="length-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
+                </div>
+                <div id="fuse-type-container" class="d-none">
+                  <label class="form-label fw-semibold">Fuse Type</label>
+                  <div class="row g-2" id="fuse-type-group">
+                    <div class="col-12 col-sm-6">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="fuse-type"
+                        id="fuse-type-glass"
+                        value="Glass"
+                        autocomplete="off"
+                        checked
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="fuse-type-glass"
+                        >Glass Fuse</label
+                      >
+                    </div>
+                    <div class="col-12 col-sm-6">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="fuse-type"
+                        id="fuse-type-blade"
+                        value="Blade"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="fuse-type-blade"
+                        >Blade Fuse</label
+                      >
+                    </div>
+                  </div>
+                </div>
+                <div id="fuse-value-container" class="d-none">
+                  <label for="fuse-value-select" class="form-label fw-semibold"
+                    >Fuse Value (amps)</label
+                  >
+                  <select
+                    id="fuse-value-select"
+                    class="form-select"
+                    aria-describedby="fuse-value-message"
+                  ></select>
+                  <div
+                    id="fuse-value-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
+                </div>
+                <div id="glass-options-container" class="d-none">
+                  <span class="form-label d-block fw-semibold">Glass Fuse Options</span>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
+                    <label class="form-check-label" for="glass-slow-blow"
+                      >Slow-blow (time delay)</label
+                    >
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="glass-fast-blow" />
+                    <label class="form-check-label" for="glass-fast-blow">Fast-blow</label>
+                  </div>
+                  <div class="mt-2">
+                    <label for="glass-size-select" class="form-label fw-semibold"
+                      >Glass Fuse Size</label
+                    >
+                    <select id="glass-size-select" class="form-select">
+                      <option value="">Select size…</option>
+                      <option value="5 × 20 mm">5 × 20 mm</option>
+                      <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
+                        6.3 × 32 mm (1/4″ × 1-1/4″)
+                      </option>
+                    </select>
+                    <div class="form-text">
+                      Standard glass fuse sizes: 5 × 20 mm and 6.3 × 32 mm.
+                    </div>
+                  </div>
+                </div>
+                <div id="standard-field">
+                  <label
+                    for="standard-select"
+                    class="form-label fw-semibold"
+                    id="standard-field-label"
+                    >Hardware Standard</label
+                  >
+                  <select id="standard-select" class="form-select"></select>
+                  <div id="bolt-standard-group" class="row g-2 d-none" aria-hidden="true">
+                    <div id="bolt-drive-field" class="col-12 col-sm-6">
+                      <label for="bolt-drive-select" class="form-label">Drive</label>
+                      <select id="bolt-drive-select" class="form-select"></select>
+                      <div
+                        id="bolt-drive-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div id="bolt-head-field" class="col-12 col-sm-6">
+                      <label for="bolt-head-select" class="form-label">Head</label>
+                      <select id="bolt-head-select" class="form-select"></select>
+                      <div
+                        id="bolt-head-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                  </div>
+                </div>
+                <div id="notes-field">
+                  <label for="notes-input" class="form-label fw-semibold">Optional Notes</label>
+                  <input
+                    type="text"
+                    id="notes-input"
+                    class="form-control"
+                    placeholder="Notes (optional)"
+                    aria-describedby="connector-notes-hint connector-notes-message"
+                  />
+                  <div id="connector-notes-hint" class="form-text d-none">
+                    Provide the connector series, pin count, wire size, and terminal style when
+                    labelling connectors.
+                  </div>
+                  <div
+                    id="connector-notes-message"
+                    class="validation-message text-danger small mt-2 d-none"
+                  ></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section class="settings-section col-lg-5">
+          <div class="card shadow-sm h-100">
+            <div class="card-body">
+              <h2 class="h5 mb-3 section-heading">
+                <i class="fa-solid fa-gear me-2" aria-hidden="true"></i>
+                <span>Label Settings</span>
+              </h2>
+              <div class="vstack gap-3">
+                <div
+                  class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary"
+                >
+                  <label
+                    class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                    for="standard-toggle"
+                  >
+                    <i class="fa-solid fa-book text-secondary fs-5" aria-hidden="true"></i>
+                    <span>Standard Reference</span>
+                  </label>
+                  <div class="form-check form-switch m-0 ps-0">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
+                      id="standard-toggle"
+                      checked
+                    />
+                  </div>
+                </div>
+                <div
+                  class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary"
+                >
+                  <label
+                    class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                    for="image-toggle"
+                  >
+                    <i class="fa-solid fa-image text-secondary fs-5" aria-hidden="true"></i>
+                    <span>Image</span>
+                  </label>
+                  <div class="form-check form-switch m-0 ps-0">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
+                      id="image-toggle"
+                      checked
+                    />
+                  </div>
+                </div>
+                <div
+                  class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary"
+                >
+                  <label
+                    class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
+                    for="qrcode-toggle"
+                  >
+                    <i class="fa-solid fa-qrcode text-secondary fs-5" aria-hidden="true"></i>
+                    <span>QR Code</span>
+                  </label>
+                  <div class="form-check form-switch m-0 ps-0">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
+                      id="qrcode-toggle"
+                    />
+                  </div>
+                </div>
+                <div id="qr-content-wrapper" class="p-3 rounded-4 border bg-body-secondary d-none">
+                  <label
+                    for="qr-content-input"
+                    class="form-label fw-semibold mb-2 d-flex align-items-center gap-2"
+                  >
+                    QR Code Content
+                    <span
+                      class="qr-info-icon"
+                      tabindex="0"
+                      role="img"
+                      aria-label="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
+                      data-tooltip="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
+                    >
+                      <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+                    </span>
+                  </label>
+                  <input
+                    type="url"
+                    inputmode="url"
+                    id="qr-content-input"
+                    class="form-control"
+                    placeholder="URL or text for QR code"
+                    autocomplete="off"
+                    spellcheck="false"
+                    disabled
+                  />
+                </div>
+                <div>
+                  <label for="width-range" class="form-label fw-semibold"
+                    >Label Width <span id="width-value">55</span> mm</label
+                  >
+                  <input
+                    type="range"
+                    class="form-range"
+                    id="width-range"
+                    min="37"
+                    max="100"
+                    value="55"
+                  />
+                  <div class="d-flex justify-content-between text-muted small">
+                    <span>37&nbsp;mm</span><span>100&nbsp;mm</span>
+                  </div>
+                </div>
+                <div>
+                  <span class="form-label d-block fw-semibold">Label Height</span>
+                  <div class="row row-cols-2 g-2 height-options">
+                    <div class="col">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="label-height"
+                        id="height-9"
+                        value="9"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="height-9"
+                        >9&nbsp;mm</label
+                      >
+                    </div>
+                    <div class="col">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="label-height"
+                        id="height-12"
+                        value="12"
+                        autocomplete="off"
+                        checked
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="height-12"
+                        >12&nbsp;mm</label
+                      >
+                    </div>
+                    <div class="col">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="label-height"
+                        id="height-18"
+                        value="18"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="height-18"
+                        >18&nbsp;mm</label
+                      >
+                    </div>
+                    <div class="col">
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="label-height"
+                        id="height-24"
+                        value="24"
+                        autocomplete="off"
+                      />
+                      <label class="btn btn-outline-secondary w-100" for="height-24"
+                        >24&nbsp;mm</label
+                      >
                     </div>
                   </div>
                 </div>
               </div>
-              <div class="row g-3" id="thread-length-row">
-                <div class="col-12 col-sm-6 thread-length-field" id="thread-size-container">
-                  <label for="thread-size-select" class="form-label fw-semibold">Thread Size</label>
-                  <select
-                    id="thread-size-select"
-                    class="form-select"
-                    aria-describedby="thread-size-message"
-                  ></select>
-                  <div
-                    id="thread-size-message"
-                    class="validation-message text-danger small mt-2 d-none"
-                  ></div>
-                </div>
-                <div class="col-12 col-sm-6 thread-length-field" id="length-container">
-                  <label for="length-input" class="form-label fw-semibold">Length</label>
-                  <input
-                    type="number"
-                    id="length-input"
-                    class="form-control"
-                    placeholder="e.g., 10"
-                    min="1"
-                    aria-describedby="length-message"
-                  />
-                  <div
-                    id="length-message"
-                    class="validation-message text-danger small mt-2 d-none"
-                  ></div>
-                </div>
-              </div>
-              <div id="fuse-type-container" class="d-none">
-                <label class="form-label fw-semibold">Fuse Type</label>
-                <div class="row g-2" id="fuse-type-group">
-                  <div class="col-12 col-sm-6">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="fuse-type"
-                      id="fuse-type-glass"
-                      value="Glass"
-                      autocomplete="off"
-                      checked
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="fuse-type-glass">Glass Fuse</label>
-                  </div>
-                  <div class="col-12 col-sm-6">
-                    <input
-                      type="radio"
-                      class="btn-check"
-                      name="fuse-type"
-                      id="fuse-type-blade"
-                      value="Blade"
-                      autocomplete="off"
-                    />
-                    <label class="btn btn-outline-secondary w-100" for="fuse-type-blade">Blade Fuse</label>
-                  </div>
-                </div>
-              </div>
-              <div id="fuse-value-container" class="d-none">
-                <label for="fuse-value-select" class="form-label fw-semibold">Fuse Value (amps)</label>
-                <select
-                  id="fuse-value-select"
-                  class="form-select"
-                  aria-describedby="fuse-value-message"
-                ></select>
-                <div
-                  id="fuse-value-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
-              <div id="glass-options-container" class="d-none">
-                <span class="form-label d-block fw-semibold">Glass Fuse Options</span>
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
-                  <label class="form-check-label" for="glass-slow-blow">Slow-blow (time delay)</label>
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="glass-fast-blow" />
-                  <label class="form-check-label" for="glass-fast-blow">Fast-blow</label>
-                </div>
-                <div class="mt-2">
-                  <label for="glass-size-select" class="form-label fw-semibold">Glass Fuse Size</label>
-                  <select id="glass-size-select" class="form-select">
-                    <option value="">Select size…</option>
-                    <option value="5 × 20 mm">5 × 20 mm</option>
-                    <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">6.3 × 32 mm (1/4″ × 1-1/4″)</option>
-                  </select>
-                  <div class="form-text">Standard glass fuse sizes: 5 × 20 mm and 6.3 × 32 mm.</div>
-                </div>
-              </div>
-              <div id="standard-field">
-                <label for="standard-select" class="form-label fw-semibold">Hardware Standard</label>
-                <select id="standard-select" class="form-select"></select>
-              </div>
-              <div id="notes-field">
-                <label for="notes-input" class="form-label fw-semibold">Optional Notes</label>
-                <input
-                  type="text"
-                  id="notes-input"
-                  class="form-control"
-                  placeholder="Notes (optional)"
-                  aria-describedby="connector-notes-hint connector-notes-message"
-                />
-                <div id="connector-notes-hint" class="form-text d-none">
-                  Provide the connector series, pin count, wire size, and terminal style when labelling connectors.
-                </div>
-                <div
-                  id="connector-notes-message"
-                  class="validation-message text-danger small mt-2 d-none"
-                ></div>
-              </div>
             </div>
           </div>
-        </div>
-      </section>
-      <section class="settings-section col-lg-5">
-        <div class="card shadow-sm h-100">
-          <div class="card-body">
-            <h2 class="h5 mb-3 section-heading">
-              <i class="fa-solid fa-gear me-2" aria-hidden="true"></i>
-              <span>Label Settings</span>
-            </h2>
-            <div class="vstack gap-3">
-              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <label
-                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
-                  for="standard-toggle"
-                >
-                  <i class="fa-solid fa-book text-secondary fs-5" aria-hidden="true"></i>
-                  <span>Standard Reference</span>
-                </label>
-                <div class="form-check form-switch m-0 ps-0">
-                  <input class="form-check-input" type="checkbox" role="switch" id="standard-toggle" checked />
-                </div>
-              </div>
-              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <label
-                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
-                  for="image-toggle"
-                >
-                  <i class="fa-solid fa-image text-secondary fs-5" aria-hidden="true"></i>
-                  <span>Image</span>
-                </label>
-                <div class="form-check form-switch m-0 ps-0">
-                  <input class="form-check-input" type="checkbox" role="switch" id="image-toggle" checked />
-                </div>
-              </div>
-              <div class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary">
-                <label
-                  class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
-                  for="qrcode-toggle"
-                >
-                  <i class="fa-solid fa-qrcode text-secondary fs-5" aria-hidden="true"></i>
-                  <span>QR Code</span>
-                </label>
-                <div class="form-check form-switch m-0 ps-0">
-                  <input class="form-check-input" type="checkbox" role="switch" id="qrcode-toggle" />
-                </div>
-              </div>
-              <div id="qr-content-wrapper" class="p-3 rounded-4 border bg-body-secondary d-none">
-                <label for="qr-content-input" class="form-label fw-semibold mb-2 d-flex align-items-center gap-2">
-                  QR Code Content
-                  <span
-                    class="qr-info-icon"
-                    tabindex="0"
-                    role="img"
-                    aria-label="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
-                    data-tooltip="Long URLs will be automatically shortened for better QR code readability. This makes the QR code simpler and easier to scan on small labels."
-                  >
-                    <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
-                  </span>
-                </label>
-                <input
-                  type="url"
-                  inputmode="url"
-                  id="qr-content-input"
-                  class="form-control"
-                  placeholder="URL or text for QR code"
-                  autocomplete="off"
-                  spellcheck="false"
-                  disabled
-                />
-              </div>
-              <div>
-                <label for="width-range" class="form-label fw-semibold">Label Width <span id="width-value">55</span> mm</label>
-                <input type="range" class="form-range" id="width-range" min="37" max="100" value="55" />
-                <div class="d-flex justify-content-between text-muted small"><span>37&nbsp;mm</span><span>100&nbsp;mm</span></div>
-              </div>
-              <div>
-                <span class="form-label d-block fw-semibold">Label Height</span>
-                <div class="row row-cols-2 g-2 height-options">
-                  <div class="col">
-                    <input type="radio" class="btn-check" name="label-height" id="height-9" value="9" autocomplete="off" />
-                    <label class="btn btn-outline-secondary w-100" for="height-9">9&nbsp;mm</label>
-                  </div>
-                  <div class="col">
-                    <input type="radio" class="btn-check" name="label-height" id="height-12" value="12" autocomplete="off" checked />
-                    <label class="btn btn-outline-secondary w-100" for="height-12">12&nbsp;mm</label>
-                  </div>
-                  <div class="col">
-                    <input type="radio" class="btn-check" name="label-height" id="height-18" value="18" autocomplete="off" />
-                    <label class="btn btn-outline-secondary w-100" for="height-18">18&nbsp;mm</label>
-                  </div>
-                  <div class="col">
-                    <input type="radio" class="btn-check" name="label-height" id="height-24" value="24" autocomplete="off" />
-                    <label class="btn btn-outline-secondary w-100" for="height-24">24&nbsp;mm</label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-    </div>
-    <section class="preview-section card shadow-sm mt-4">
-      <div class="card-body">
-        <h2 class="h5 mb-3 section-heading">Label Preview</h2>
-        <div class="size-info text-muted small mb-3">
-          <span
-            id="preview-status-text"
-            class="visually-hidden"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          ></span>
-          <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
-          <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
-        </div>
-        <div id="preview-container" class="label-preview">
-          <div id="preview-placeholder" class="preview-placeholder">
-            <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
-            <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
-          </div>
-          <div id="label-inner" class="label-inner" style="display: none;">
-            <div id="hardware-image" class="hardware-icon"></div>
-            <div id="preview-text" class="text-block">
-              <div id="line1" class="text-line"></div>
-              <div id="line2" class="text-line small"></div>
-            </div>
-            <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
-          </div>
-        </div>
+        </section>
       </div>
-    </section>
-    <div
-      id="form-status-message"
-      class="alert alert-warning d-none mt-4"
-      role="status"
-      aria-live="polite"
-    ></div>
-    <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
-      <button
-        id="download-button"
-        class="btn btn-primary btn-lg px-4 d-inline-flex align-items-center"
-        type="button"
-        disabled
-        aria-label="Download label as a PNG image"
-        title="Download label as a PNG image"
-      >
-        <i class="fa-solid fa-download me-2" aria-hidden="true"></i>
-        <span>Download</span>
-      </button>
-      <button
-        id="share-button"
-        class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
-        type="button"
-        disabled
-        aria-label="Share a link to this label"
-        title="Share a link to this label"
-      >
-        <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
-        <span>Share</span>
-      </button>
-      <button
-        id="print-button"
-        class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
-        type="button"
-        disabled
-        aria-label="Open a print-ready preview of the label"
-        title="Open a print-ready preview of the label"
-      >
-        <i class="fa-solid fa-print me-2" aria-hidden="true"></i>
-        <span>Print</span>
-      </button>
-    </div>
-  </main>
-</body>
+      <section class="preview-section card shadow-sm mt-4">
+        <div class="card-body">
+          <h2 class="h5 mb-3 section-heading">Label Preview</h2>
+          <div class="size-info text-muted small mb-3">
+            <span
+              id="preview-status-text"
+              class="visually-hidden"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            ></span>
+            <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
+            <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+          </div>
+          <div id="preview-container" class="label-preview">
+            <div id="preview-placeholder" class="preview-placeholder">
+              <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
+              <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
+            </div>
+            <div id="label-inner" class="label-inner" style="display: none">
+              <div id="hardware-image" class="hardware-icon"></div>
+              <div id="preview-text" class="text-block">
+                <div id="line1" class="text-line"></div>
+                <div id="line2" class="text-line small"></div>
+                <div id="line3" class="text-line small"></div>
+              </div>
+              <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div
+        id="form-status-message"
+        class="alert alert-warning d-none mt-4"
+        role="status"
+        aria-live="polite"
+      ></div>
+      <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
+        <button
+          id="download-button"
+          class="btn btn-primary btn-lg px-4 d-inline-flex align-items-center"
+          type="button"
+          disabled
+          aria-label="Download label as a PNG image"
+          title="Download label as a PNG image"
+        >
+          <i class="fa-solid fa-download me-2" aria-hidden="true"></i>
+          <span>Download</span>
+        </button>
+        <button
+          id="share-button"
+          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+          type="button"
+          disabled
+          aria-label="Share a link to this label"
+          title="Share a link to this label"
+        >
+          <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
+          <span>Share</span>
+        </button>
+        <button
+          id="print-button"
+          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+          type="button"
+          disabled
+          aria-label="Open a print-ready preview of the label"
+          title="Open a print-ready preview of the label"
+        >
+          <i class="fa-solid fa-print me-2" aria-hidden="true"></i>
+          <span>Print</span>
+        </button>
+      </div>
+    </main>
+  </body>
 </html>

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,5 +1,5 @@
 import { state } from './state.js';
-import { findConnectorCategory } from './data.js';
+import { findConnectorCategory, boltHeadMap, boltDriveMap } from './data.js';
 import { renderLabelCanvas } from './render.js';
 import { buildShareUrl } from './url-state.js';
 
@@ -108,30 +108,43 @@ export function downloadLabel() {
         if (state.showStandard && state.bearingDetails) {
           fileParts.push(state.bearingDetails);
         }
+      } else if (state.hardwareType === 'Bolt') {
+        if (state.threadSize) {
+          fileParts.push(state.threadSize);
+        }
+        if (state.length) {
+          fileParts.push(`x${state.length}`);
+        }
+        const headEntry = boltHeadMap.get((state.boltHead || '').trim());
+        const driveEntry = boltDriveMap.get((state.boltDrive || '').trim());
+        if (headEntry && headEntry.label) {
+          fileParts.push(headEntry.label);
+        }
+        if (driveEntry && driveEntry.label) {
+          fileParts.push(driveEntry.label);
+        }
       } else {
         if (state.threadSize) {
           fileParts.push(state.threadSize);
         }
-        if ((state.hardwareType === 'Screw' || state.hardwareType === 'Bolt') && state.length) {
+        if (state.hardwareType === 'Screw' && state.length) {
           fileParts.push(`x${state.length}`);
         }
       }
-      if (state.standardCode) {
-        fileParts.push(state.standardCode);
-      }
-      if (state.standard && state.standard !== state.standardCode) {
-        fileParts.push(state.standard);
+      if (state.hardwareType !== 'Bolt') {
+        if (state.standardCode) {
+          fileParts.push(state.standardCode);
+        }
+        if (state.standard && state.standard !== state.standardCode) {
+          fileParts.push(state.standard);
+        }
       }
       const rawTitle = fileParts.filter(Boolean).join(' ');
       const sanitizedTitle = sanitizeTitle(rawTitle) || 'label';
       const widthMm =
-        Number.isFinite(state.widthMm) && state.widthMm > 0
-          ? Math.round(state.widthMm)
-          : 1;
+        Number.isFinite(state.widthMm) && state.widthMm > 0 ? Math.round(state.widthMm) : 1;
       const heightMm =
-        Number.isFinite(state.heightMm) && state.heightMm > 0
-          ? Math.round(state.heightMm)
-          : 1;
+        Number.isFinite(state.heightMm) && state.heightMm > 0 ? Math.round(state.heightMm) : 1;
       const timestamp = formatTimestamp(new Date());
       link.download = `gridfinity-label_${sanitizedTitle}_${widthMm}x${heightMm}mm_${timestamp}.png`;
       document.body.appendChild(link);
@@ -231,7 +244,7 @@ export async function shareLabel() {
   const shareData = {
     title: 'Gridfinity Label Maker',
     text: 'Gridfinity label preset',
-    url: shareUrl
+    url: shareUrl,
   };
 
   const canShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';

--- a/js/controls.js
+++ b/js/controls.js
@@ -6,7 +6,7 @@ import {
   populateConnectorCategories,
   populateBearingOptions,
   updateCustomImageUi,
-  onHardwareTypeChange
+  onHardwareTypeChange,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
@@ -25,6 +25,8 @@ function applyStateToControls() {
     customLine1Input,
     customLine2Input,
     standardSelect,
+    boltHeadSelect,
+    boltDriveSelect,
     standardToggle,
     imageToggle,
     qrcodeToggle,
@@ -34,7 +36,7 @@ function applyStateToControls() {
     heightRadios,
     connectorCategorySelect,
     threadSizeSelect,
-    bearingTypeSelect
+    bearingTypeSelect,
   } = elements;
 
   if (Array.isArray(systemTypeRadios)) {
@@ -85,6 +87,12 @@ function applyStateToControls() {
   }
   if (standardSelect) {
     standardSelect.value = state.standardCode || '';
+  }
+  if (boltHeadSelect) {
+    boltHeadSelect.value = state.boltHead || '';
+  }
+  if (boltDriveSelect) {
+    boltDriveSelect.value = state.boltDrive || '';
   }
   if (standardToggle) {
     standardToggle.checked = state.showStandard;

--- a/js/data.js
+++ b/js/data.js
@@ -1,17 +1,97 @@
 export const metricThreadSizes = [
-  'M1', 'M1.2', 'M1.4', 'M1.6', 'M2', 'M2.5', 'M3', 'M3.5', 'M4',
-  'M5', 'M6', 'M7', 'M8', 'M10', 'M12', 'M14', 'M16', 'M18', 'M20',
-  'M22', 'M24', 'M30'
+  'M1',
+  'M1.2',
+  'M1.4',
+  'M1.6',
+  'M2',
+  'M2.5',
+  'M3',
+  'M3.5',
+  'M4',
+  'M5',
+  'M6',
+  'M7',
+  'M8',
+  'M10',
+  'M12',
+  'M14',
+  'M16',
+  'M18',
+  'M20',
+  'M22',
+  'M24',
+  'M30',
 ];
 
 export const imperialThreadSizes = [
-  '#4-40', '#6-32', '#8-32', '#10-24', '1/4-20', '5/16-18', '3/8-16', '7/16-14', '1/2-13'
+  '#4-40',
+  '#6-32',
+  '#8-32',
+  '#10-24',
+  '1/4-20',
+  '5/16-18',
+  '3/8-16',
+  '7/16-14',
+  '1/2-13',
 ];
 
 export const fuseValues = [
-  '0.25', '0.5', '0.75', '1', '1.5', '2', '2.5', '3', '4', '5', '6', '7.5', '8', '10', '12',
-  '15', '20', '25', '30', '40'
+  '0.25',
+  '0.5',
+  '0.75',
+  '1',
+  '1.5',
+  '2',
+  '2.5',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7.5',
+  '8',
+  '10',
+  '12',
+  '15',
+  '20',
+  '25',
+  '30',
+  '40',
 ];
+
+export const boltHeadOptions = [
+  { id: 'button_head', label: 'Button Head', image: 'button_head' },
+  { id: 'cap_head', label: 'Socket Cap', image: 'cap_head' },
+  { id: 'capstan_head', label: 'Capstan Head', image: 'capstan_head' },
+  { id: 'captive_shaft', label: 'Captive Shaft', image: 'captive_shaft' },
+  { id: 'carriage_head', label: 'Carriage Bolt', image: 'carriage_head' },
+  { id: 'cheese_head', label: 'Cheese Head', image: 'cheese_head' },
+  { id: 'countersunk_head', label: 'Countersunk', image: 'countersunk_head' },
+  { id: 'eye_hook_head', label: 'Eye Bolt', image: 'eye_hook_head' },
+  { id: 'fillister_head', label: 'Fillister Head', image: 'fillister_head' },
+  { id: 'flanged_head', label: 'Flanged Hex', image: 'flanged_head' },
+  { id: 'grub_headless', label: 'Set Screw', image: 'grub_headless' },
+  { id: 'hand_grip_head', label: 'Hand Grip', image: 'hand_grip_head' },
+  { id: 'hexagon_head', label: 'Hex Bolt', image: 'hexagon_head' },
+  { id: 'mushroom_truss_head', label: 'Mushroom Truss', image: 'mushroom_truss_head' },
+  { id: 'pan_head', label: 'Pan Head', image: 'pan_head' },
+  { id: 'raised_countersunk_head', label: 'Raised Countersunk', image: 'raised_countersunk_head' },
+  { id: 'security_head', label: 'Security Button', image: 'security_head' },
+  { id: 'shoulder_head', label: 'Shoulder Bolt', image: 'shoulder_head' },
+];
+
+export const boltDriveOptions = [
+  { id: 'flat', label: 'Slotted', image: 'flat' },
+  { id: 'hex', label: 'Hex', image: 'hex' },
+  { id: 'hex_bolt', label: 'Hex Bolt', image: 'hex_bolt' },
+  { id: 'philips', label: 'Phillips', image: 'philips' },
+  { id: 'security_hex', label: 'Security Hex', image: 'security_hex' },
+  { id: 'security_torx', label: 'Security Torx', image: 'security_torx' },
+  { id: 'square', label: 'Square', image: 'square' },
+  { id: 'torx', label: 'Torx', image: 'torx' },
+];
+
+export const boltHeadMap = new Map(boltHeadOptions.map(option => [option.id, option]));
+export const boltDriveMap = new Map(boltDriveOptions.map(option => [option.id, option]));
 
 export const bearingOptions = [
   { code: '608ZZ', description: '8 × 22 × 7 mm, metal shields' },
@@ -20,126 +100,11 @@ export const bearingOptions = [
   { code: '6200ZZ', description: '10 × 30 × 9 mm, deep groove' },
   { code: '6900ZZ', description: '10 × 22 × 6 mm, thin section' },
   { code: '6701ZZ', description: '12 × 18 × 4 mm, thin section' },
-  { code: 'MR85-2RS', description: '5 × 8 × 2.5 mm, rubber seals' }
+  { code: 'MR85-2RS', description: '5 × 8 × 2.5 mm, rubber seals' },
 ];
 
 export const hardwareCatalog = {
-  Bolt: [
-    {
-      code: 'Button Head + Hex Socket',
-      name: 'Button head cap screw with internal hex drive',
-      headImage: 'button_head',
-      driveImage: 'hex'
-    },
-    {
-      code: 'Socket Cap + Hex Socket',
-      name: 'Socket cap screw with internal hex drive',
-      headImage: 'cap_head',
-      driveImage: 'hex'
-    },
-    {
-      code: 'Capstan Head + Slotted',
-      name: 'Capstan head screw with slotted drive',
-      headImage: 'capstan_head',
-      driveImage: 'flat'
-    },
-    {
-      code: 'Captive Shaft + Slotted',
-      name: 'Captive shaft screw with slotted drive',
-      headImage: 'captive_shaft',
-      driveImage: 'flat'
-    },
-    {
-      code: 'Carriage Bolt + Square Neck',
-      name: 'Carriage bolt with square neck profile',
-      headImage: 'carriage_head',
-      driveImage: 'square'
-    },
-    {
-      code: 'Cheese Head + Slotted',
-      name: 'Cheese head screw with slotted drive',
-      headImage: 'cheese_head',
-      driveImage: 'flat'
-    },
-    {
-      code: 'Countersunk + Phillips',
-      name: 'Countersunk screw with Phillips drive',
-      headImage: 'countersunk_head',
-      driveImage: 'philips'
-    },
-    {
-      code: 'Eye Bolt + Square Drive',
-      name: 'Eye bolt with square drive detail',
-      headImage: 'eye_hook_head',
-      driveImage: 'square'
-    },
-    {
-      code: 'Fillister Head + Slotted',
-      name: 'Fillister head screw with slotted drive',
-      headImage: 'fillister_head',
-      driveImage: 'flat'
-    },
-    {
-      code: 'Flanged Hex + External Hex',
-      name: 'Flanged hex bolt with external hex drive',
-      headImage: 'flanged_head',
-      driveImage: 'hex_bolt'
-    },
-    {
-      code: 'Set Screw + Hex Socket',
-      name: 'Set screw with internal hex drive',
-      headImage: 'grub_headless',
-      driveImage: 'hex'
-    },
-    {
-      code: 'Hand Grip + Hex Socket',
-      name: 'Hand grip screw with internal hex drive',
-      headImage: 'hand_grip_head',
-      driveImage: 'hex'
-    },
-    {
-      code: 'Hex Bolt + External Hex',
-      name: 'Hex bolt with external hex drive',
-      headImage: 'hexagon_head',
-      driveImage: 'hex_bolt'
-    },
-    {
-      code: 'Mushroom Truss + Torx',
-      name: 'Mushroom truss screw with Torx drive',
-      headImage: 'mushroom_truss_head',
-      driveImage: 'torx'
-    },
-    {
-      code: 'Pan Head + Phillips',
-      name: 'Pan head screw with Phillips drive',
-      headImage: 'pan_head',
-      driveImage: 'philips'
-    },
-    {
-      code: 'Raised Countersunk + Phillips',
-      name: 'Raised countersunk screw with Phillips drive',
-      headImage: 'raised_countersunk_head',
-      driveImage: 'philips'
-    },
-    {
-      code: 'Security Button + Security Torx',
-      name: 'Security button screw with tamper-resistant Torx drive',
-      headImage: 'security_head',
-      driveImage: 'security_torx'
-    },
-    {
-      code: 'Security Button + Security Hex',
-      name: 'Security button screw with tamper-resistant hex drive',
-      headImage: 'security_head',
-      driveImage: 'security_hex'
-    },
-    {
-      code: 'Shoulder Bolt + Hex Socket',
-      name: 'Shoulder bolt with internal hex drive',
-      headImage: 'shoulder_head',
-      driveImage: 'hex'
-    }
-  ],
+  Bolt: [],
   Screw: [
     { code: 'DIN 571', name: 'Coach Screw (Wood Screw)' },
     { code: 'DIN 7995', name: 'Cross Recessed Pan Head Wood Screw' },
@@ -147,7 +112,7 @@ export const hardwareCatalog = {
     { code: 'DIN 7997', name: 'Cross Recessed Raised Countersunk Head Wood Screw' },
     { code: 'DIN 95', name: 'Round Head Wood Screw' },
     { code: 'DIN 96', name: 'Raised Countersunk Head Wood Screw' },
-    { code: 'DIN 97', name: 'Countersunk Head Wood Screw' }
+    { code: 'DIN 97', name: 'Countersunk Head Wood Screw' },
   ],
   Nut: [
     { code: 'DIN 1478', name: 'Wing Nut' },
@@ -193,7 +158,7 @@ export const hardwareCatalog = {
     { code: 'DIN 982', name: 'Prevailing Torque Type Hexagon Nut' },
     { code: 'DIN 985', name: 'Prevailing Torque Type Hexagon Nut' },
     { code: 'DIN 986', name: 'Prevailing Torque Type Hexagon Thin Nut' },
-    { code: 'ISO 7040', name: 'Prevailing Torque Type Hexagon Nut' }
+    { code: 'ISO 7040', name: 'Prevailing Torque Type Hexagon Nut' },
   ],
   Washer: [
     { code: 'DIN 1052', name: 'Washer for Wood Construction' },
@@ -230,7 +195,7 @@ export const hardwareCatalog = {
     { code: 'DIN 7989', name: 'Plain Washer' },
     { code: 'DIN 9021', name: 'Plain Washer' },
     { code: 'DIN 93', name: 'Tab Washer' },
-    { code: 'DIN 988', name: 'Shim Ring' }
+    { code: 'DIN 988', name: 'Shim Ring' },
   ],
   'Heat Insert': [],
   Bearing: [],
@@ -238,15 +203,15 @@ export const hardwareCatalog = {
   Fuse: [
     { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
     { code: 'IEC 60127-3', name: 'Fast-Acting Cartridge Fuse' },
-    { code: 'UL 248-14', name: 'Supplementary Fuse' }
-  ]
+    { code: 'UL 248-14', name: 'Supplementary Fuse' },
+  ],
 };
 
 export const hardwareImageFolders = {
   Bolt: 'bolts',
   Screw: 'screws',
   Nut: 'nuts',
-  Washer: 'washers'
+  Washer: 'washers',
 };
 
 export const connectorCatalog = [
@@ -264,7 +229,10 @@ export const connectorCatalog = [
       { code: 'Yellow Fork Terminal', name: '12–10 AWG (4.0–6.0 mm²) Spade' },
       { code: 'Red Locking Fork Terminal', name: '22–16 AWG (0.5–1.5 mm²) Locking Tongue Spade' },
       { code: 'Blue Locking Fork Terminal', name: '16–14 AWG (1.5–2.5 mm²) Locking Tongue Spade' },
-      { code: 'Yellow Locking Fork Terminal', name: '12–10 AWG (4.0–6.0 mm²) Locking Tongue Spade' },
+      {
+        code: 'Yellow Locking Fork Terminal',
+        name: '12–10 AWG (4.0–6.0 mm²) Locking Tongue Spade',
+      },
       { code: 'Red Butt Splice', name: '22–16 AWG (0.5–1.5 mm²) Straight Splice' },
       { code: 'Blue Butt Splice', name: '16–14 AWG (1.5–2.5 mm²) Straight Splice' },
       { code: 'Yellow Butt Splice', name: '12–10 AWG (4.0–6.0 mm²) Straight Splice' },
@@ -293,8 +261,8 @@ export const connectorCatalog = [
       { code: 'Yellow Pin Terminal', name: '12–10 AWG (4.0–6.0 mm²) Pin' },
       { code: 'Red Closed-End Connector', name: '22–16 AWG (0.5–1.5 mm²) Pigtail Cap' },
       { code: 'Blue Closed-End Connector', name: '16–14 AWG (1.5–2.5 mm²) Pigtail Cap' },
-      { code: 'Yellow Closed-End Connector', name: '12–10 AWG (4.0–6.0 mm²) Pigtail Cap' }
-    ]
+      { code: 'Yellow Closed-End Connector', name: '12–10 AWG (4.0–6.0 mm²) Pigtail Cap' },
+    ],
   },
   {
     id: 'molex',
@@ -309,8 +277,8 @@ export const connectorCatalog = [
       { code: 'Molex Mega-Fit', name: '5.7 mm pitch high-current connector' },
       { code: 'Molex SL Series', name: '2.54 mm pitch crimp housing (SL)' },
       { code: 'Molex Nano-Fit', name: '2.50 mm pitch fully isolated terminals' },
-      { code: 'Molex Sabre', name: '7.50 mm pitch high-power connector' }
-    ]
+      { code: 'Molex Sabre', name: '7.50 mm pitch high-power connector' },
+    ],
   },
   {
     id: 'jst',
@@ -327,8 +295,8 @@ export const connectorCatalog = [
       { code: 'JST-VH', name: '3.96 mm wire-to-board plug (VH series)' },
       { code: 'JST-SM', name: '2.54 mm wire-to-wire plug (SM series)' },
       { code: 'JST-JWPF', name: '2.0 mm sealed connector (JWPF series)' },
-      { code: 'JST-RCY', name: '2.54 mm battery connector (RCY series)' }
-    ]
+      { code: 'JST-RCY', name: '2.54 mm battery connector (RCY series)' },
+    ],
   },
   {
     id: 'bootlace-ferrule',
@@ -342,11 +310,20 @@ export const connectorCatalog = [
       { code: 'Bootlace Ferrule 1.5 mm²', name: 'Insulated ferrule per DIN 46228-4' },
       { code: 'Bootlace Ferrule 2.5 mm²', name: 'Insulated ferrule per DIN 46228-4' },
       { code: 'Bootlace Ferrule 4.0 mm²', name: 'Insulated ferrule per DIN 46228-4' },
-      { code: 'Twin Bootlace Ferrule 2 × 1.5 mm²', name: 'Twin entry insulated ferrule per DIN 46228-4' },
-      { code: 'Twin Bootlace Ferrule 2 × 2.5 mm²', name: 'Twin entry insulated ferrule per DIN 46228-4' },
-      { code: 'Uninsulated Bootlace Ferrule 1.0 mm²', name: 'Plain copper ferrule per DIN 46228-1' }
-    ]
-  }
+      {
+        code: 'Twin Bootlace Ferrule 2 × 1.5 mm²',
+        name: 'Twin entry insulated ferrule per DIN 46228-4',
+      },
+      {
+        code: 'Twin Bootlace Ferrule 2 × 2.5 mm²',
+        name: 'Twin entry insulated ferrule per DIN 46228-4',
+      },
+      {
+        code: 'Uninsulated Bootlace Ferrule 1.0 mm²',
+        name: 'Plain copper ferrule per DIN 46228-1',
+      },
+    ],
+  },
 ];
 
 export const pxPerMm = 6;

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -1,6 +1,10 @@
 const themeToggleButton = document.getElementById('theme-toggle');
-const themeToggleIcon = themeToggleButton ? themeToggleButton.querySelector('.theme-toggle-icon') : null;
-const themeToggleText = themeToggleButton ? themeToggleButton.querySelector('.theme-toggle-text') : null;
+const themeToggleIcon = themeToggleButton
+  ? themeToggleButton.querySelector('.theme-toggle-icon')
+  : null;
+const themeToggleText = themeToggleButton
+  ? themeToggleButton.querySelector('.theme-toggle-text')
+  : null;
 
 const threadSizeContainer = document.getElementById('thread-size-container');
 const threadSizeSelect = document.getElementById('thread-size-select');
@@ -40,11 +44,19 @@ const customLine1Field = document.getElementById('custom-line1-field');
 const customLine1Message = document.getElementById('custom-line1-message');
 const notesField = document.getElementById('notes-field');
 const standardField = document.getElementById('standard-field');
+const standardFieldLabel = document.getElementById('standard-field-label');
+const boltStandardGroup = document.getElementById('bolt-standard-group');
+const boltHeadField = document.getElementById('bolt-head-field');
+const boltDriveField = document.getElementById('bolt-drive-field');
+const boltHeadSelect = document.getElementById('bolt-head-select');
+const boltDriveSelect = document.getElementById('bolt-drive-select');
+const boltHeadMessage = document.getElementById('bolt-head-message');
+const boltDriveMessage = document.getElementById('bolt-drive-message');
 const notesLabel = document.querySelector('label[for="notes-input"]');
 const defaultNotesLabel = notesLabel ? notesLabel.textContent : '';
 const defaultNotesPlaceholder = notesInput ? notesInput.getAttribute('placeholder') || '' : '';
 const standardSelect = document.getElementById('standard-select');
-const standardLabel = document.querySelector('label[for="standard-select"]');
+const standardLabel = standardFieldLabel;
 const defaultStandardLabel = standardLabel ? standardLabel.textContent : '';
 const standardToggle = document.getElementById('standard-toggle');
 const imageToggle = document.getElementById('image-toggle');
@@ -61,6 +73,7 @@ const hardwareImageDiv = document.getElementById('hardware-image');
 const textBlockDiv = document.getElementById('preview-text');
 const line1Div = document.getElementById('line1');
 const line2Div = document.getElementById('line2');
+const line3Div = document.getElementById('line3');
 const qrCanvas = document.getElementById('qr-canvas');
 const qrContentWrapper = document.getElementById('qr-content-wrapper');
 const qrContentInput = document.getElementById('qr-content-input');
@@ -74,16 +87,16 @@ const hardwareTypeOptions = new Set(
   hardwareTypeRadios
     .map(radio => radio.value)
     .concat(
-      hardwareTypeSelect
-        ? Array.from(hardwareTypeSelect.options, option => option.value)
-        : []
+      hardwareTypeSelect ? Array.from(hardwareTypeSelect.options, option => option.value) : [],
     )
-    .filter(Boolean)
+    .filter(Boolean),
 );
 const systemTypeRadios = Array.from(document.querySelectorAll('input[name="system-type"]'));
 const fuseTypeRadios = Array.from(document.querySelectorAll('input[name="fuse-type"]'));
 const heightRadios = Array.from(document.querySelectorAll('input[name="label-height"]'));
-const componentCategoryRadios = Array.from(document.querySelectorAll('input[name="component-category"]'));
+const componentCategoryRadios = Array.from(
+  document.querySelectorAll('input[name="component-category"]'),
+);
 const componentMountRadios = Array.from(document.querySelectorAll('input[name="component-mount"]'));
 const componentCategoryMessage = document.getElementById('component-category-message');
 const componentMountMessage = document.getElementById('component-mount-message');
@@ -131,6 +144,14 @@ export const elements = {
   customLine1Message,
   notesField,
   standardField,
+  standardFieldLabel,
+  boltStandardGroup,
+  boltHeadField,
+  boltDriveField,
+  boltHeadSelect,
+  boltDriveSelect,
+  boltHeadMessage,
+  boltDriveMessage,
   notesLabel,
   defaultNotesLabel,
   defaultNotesPlaceholder,
@@ -152,6 +173,7 @@ export const elements = {
   textBlockDiv,
   line1Div,
   line2Div,
+  line3Div,
   qrCanvas,
   qrContentWrapper,
   qrContentInput,
@@ -168,5 +190,5 @@ export const elements = {
   componentMountRadios,
   componentCategoryMessage,
   componentMountMessage,
-  formStatusMessage
+  formStatusMessage,
 };

--- a/js/events.js
+++ b/js/events.js
@@ -9,7 +9,7 @@ import {
   handleCustomImageFile,
   clearCustomImage,
   handleStandardSelectKeydown,
-  clearStandardFilter
+  clearStandardFilter,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -34,6 +34,8 @@ const {
   customLine2Input,
   customImageInput,
   customImageClearButton,
+  boltHeadSelect,
+  boltDriveSelect,
   standardSelect,
   standardToggle,
   imageToggle,
@@ -44,7 +46,7 @@ const {
   heightRadios,
   downloadButton,
   shareButton,
-  printButton
+  printButton,
 } = elements;
 
 export function initEventHandlers() {
@@ -99,7 +101,10 @@ export function initEventHandlers() {
       const value = bearingTypeSelect.value;
       const selectedOption = bearingTypeSelect.selectedOptions[0];
       state.bearingType = value;
-      state.bearingDetails = selectedOption && selectedOption.dataset.description ? selectedOption.dataset.description : '';
+      state.bearingDetails =
+        selectedOption && selectedOption.dataset.description
+          ? selectedOption.dataset.description
+          : '';
       updateDownloadState();
       updatePreview();
     });
@@ -215,7 +220,8 @@ export function initEventHandlers() {
 
   if (customImageInput) {
     customImageInput.addEventListener('change', () => {
-      const file = customImageInput.files && customImageInput.files[0] ? customImageInput.files[0] : null;
+      const file =
+        customImageInput.files && customImageInput.files[0] ? customImageInput.files[0] : null;
       handleCustomImageFile(file);
     });
   }
@@ -242,6 +248,22 @@ export function initEventHandlers() {
     });
     standardSelect.addEventListener('keydown', handleStandardSelectKeydown);
     standardSelect.addEventListener('blur', clearStandardFilter);
+  }
+
+  if (boltHeadSelect) {
+    boltHeadSelect.addEventListener('change', () => {
+      state.boltHead = boltHeadSelect.value;
+      updateDownloadState();
+      updatePreview();
+    });
+  }
+
+  if (boltDriveSelect) {
+    boltDriveSelect.addEventListener('change', () => {
+      state.boltDrive = boltDriveSelect.value;
+      updateDownloadState();
+      updatePreview();
+    });
   }
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -3,11 +3,13 @@ import { elements } from './dom-elements.js';
 import {
   fuseValues,
   bearingOptions,
+  boltHeadOptions,
+  boltDriveOptions,
   hardwareCatalog,
   connectorCatalog,
   STANDARD_PLACEHOLDER_TEXT,
   CONNECTOR_PLACEHOLDER_TEXT,
-  findConnectorCategory
+  findConnectorCategory,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 import { populateThreadSizes } from './threadSizes.js';
@@ -39,6 +41,9 @@ const {
   customImageNameDisplay,
   notesField,
   standardField,
+  boltStandardGroup,
+  boltHeadSelect,
+  boltDriveSelect,
   notesLabel,
   defaultNotesLabel,
   defaultNotesPlaceholder,
@@ -50,7 +55,7 @@ const {
   hardwareTypeOptions,
   systemTypeRadios,
   componentCategoryRadios,
-  componentMountRadios
+  componentMountRadios,
 } = elements;
 
 export function populateConnectorCategories() {
@@ -141,7 +146,8 @@ export function updateConnectorCategoryUi() {
       connectorCategoryHelp.classList.add('d-none');
     }
   }
-  const example = category && category.example ? category.example : 'e.g., 3-pin JST-PH plug, 26 AWG leads';
+  const example =
+    category && category.example ? category.example : 'e.g., 3-pin JST-PH plug, 26 AWG leads';
   notesInput.placeholder = example;
 }
 
@@ -251,11 +257,93 @@ export function handleCustomImageFile(file) {
   reader.readAsDataURL(file);
 }
 
+function populateBoltOptions() {
+  if (!boltHeadSelect || !boltDriveSelect) {
+    return;
+  }
+
+  const previousHead = typeof state.boltHead === 'string' ? state.boltHead : '';
+  const previousDrive = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+
+  boltHeadSelect.innerHTML = '';
+  boltDriveSelect.innerHTML = '';
+
+  const headPlaceholder = document.createElement('option');
+  headPlaceholder.value = '';
+  headPlaceholder.textContent = 'Select head…';
+  headPlaceholder.disabled = true;
+  headPlaceholder.selected = !previousHead;
+  boltHeadSelect.appendChild(headPlaceholder);
+
+  const drivePlaceholder = document.createElement('option');
+  drivePlaceholder.value = '';
+  drivePlaceholder.textContent = 'Select drive…';
+  drivePlaceholder.disabled = true;
+  drivePlaceholder.selected = !previousDrive;
+  boltDriveSelect.appendChild(drivePlaceholder);
+
+  boltHeadOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    boltHeadSelect.appendChild(opt);
+  });
+
+  boltDriveOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    boltDriveSelect.appendChild(opt);
+  });
+
+  const validHeadIds = new Set(boltHeadOptions.map(option => option.id));
+  const validDriveIds = new Set(boltDriveOptions.map(option => option.id));
+
+  if (previousHead && validHeadIds.has(previousHead)) {
+    boltHeadSelect.value = previousHead;
+  } else {
+    boltHeadSelect.value = '';
+    state.boltHead = '';
+  }
+
+  if (previousDrive && validDriveIds.has(previousDrive)) {
+    boltDriveSelect.value = previousDrive;
+  } else {
+    boltDriveSelect.value = '';
+    state.boltDrive = '';
+  }
+
+  boltHeadSelect.disabled = false;
+  boltHeadSelect.title = 'Select head style';
+  boltHeadSelect.setAttribute('aria-required', 'true');
+
+  boltDriveSelect.disabled = false;
+  boltDriveSelect.title = 'Select drive style';
+  boltDriveSelect.setAttribute('aria-required', 'true');
+}
+
 export function populateStandards() {
+  const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
+
+  if (state.hardwareType === 'Bolt') {
+    standardFilterState.query = '';
+    if (standardSelect) {
+      standardSelect.innerHTML = '';
+      standardSelect.disabled = true;
+      standardSelect.title = '';
+      standardSelect.value = '';
+    }
+    state.standard = '';
+    state.standardCode = '';
+    populateBoltOptions();
+    updatePreview();
+    return;
+  }
+
   if (!standardSelect) {
     return;
   }
-  const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
+
   standardSelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
@@ -493,6 +581,7 @@ export function onHardwareTypeChange() {
   const showComponentFields = type === 'Component';
   const showCustomFields = type === 'Custom';
   const showBearingFields = type === 'Bearing';
+  const showBoltFields = type === 'Bolt';
 
   if (lengthContainer) {
     lengthContainer.style.display = requiresThreadDetails ? '' : 'none';
@@ -561,18 +650,33 @@ export function onHardwareTypeChange() {
 
   if (measurementSystemContainer) {
     const hideMeasurementSystem =
-      showFuseFields || showConnectorFields || showCustomFields || showBearingFields || showComponentFields;
+      showFuseFields ||
+      showConnectorFields ||
+      showCustomFields ||
+      showBearingFields ||
+      showComponentFields;
     measurementSystemContainer.style.display = hideMeasurementSystem ? 'none' : '';
-    measurementSystemContainer.setAttribute('aria-hidden', hideMeasurementSystem ? 'true' : 'false');
+    measurementSystemContainer.setAttribute(
+      'aria-hidden',
+      hideMeasurementSystem ? 'true' : 'false',
+    );
   }
   systemTypeRadios.forEach(radio => {
     radio.disabled =
-      showFuseFields || showConnectorFields || showCustomFields || showBearingFields || showComponentFields;
+      showFuseFields ||
+      showConnectorFields ||
+      showCustomFields ||
+      showBearingFields ||
+      showComponentFields;
   });
 
   if (threadLengthRow) {
     const hideThreadLength =
-      showFuseFields || showConnectorFields || showCustomFields || showBearingFields || showComponentFields;
+      showFuseFields ||
+      showConnectorFields ||
+      showCustomFields ||
+      showBearingFields ||
+      showComponentFields;
     threadLengthRow.classList.toggle(
       'single-column',
       !requiresThreadDetails &&
@@ -580,13 +684,17 @@ export function onHardwareTypeChange() {
         !showConnectorFields &&
         !showCustomFields &&
         !showBearingFields &&
-        !showComponentFields
+        !showComponentFields,
     );
     threadLengthRow.style.display = hideThreadLength ? 'none' : '';
   }
   if (threadSizeContainer) {
     threadSizeContainer.style.display =
-      showFuseFields || showConnectorFields || showCustomFields || showBearingFields || showComponentFields
+      showFuseFields ||
+      showConnectorFields ||
+      showCustomFields ||
+      showBearingFields ||
+      showComponentFields
         ? 'none'
         : '';
   }
@@ -618,13 +726,46 @@ export function onHardwareTypeChange() {
     }
   }
   if (standardField) {
-    standardField.classList.toggle('d-none', showCustomFields || showBearingFields || showComponentFields);
+    standardField.classList.toggle(
+      'd-none',
+      showCustomFields || showBearingFields || showComponentFields,
+    );
   }
   if (standardLabel) {
     if (showConnectorFields) {
       standardLabel.textContent = 'Connector Series';
     } else {
       standardLabel.textContent = defaultStandardLabel;
+    }
+    standardLabel.setAttribute('for', showBoltFields ? 'bolt-head-select' : 'standard-select');
+  }
+  if (standardSelect) {
+    standardSelect.classList.toggle('d-none', showBoltFields);
+    if (showBoltFields) {
+      standardSelect.disabled = true;
+      standardSelect.setAttribute('aria-hidden', 'true');
+      standardSelect.setAttribute('aria-required', 'false');
+    } else {
+      standardSelect.setAttribute('aria-hidden', 'false');
+      standardSelect.removeAttribute('aria-required');
+    }
+  }
+  if (boltStandardGroup) {
+    boltStandardGroup.classList.toggle('d-none', !showBoltFields);
+    boltStandardGroup.setAttribute('aria-hidden', showBoltFields ? 'false' : 'true');
+  }
+  if (boltHeadSelect) {
+    boltHeadSelect.disabled = !showBoltFields;
+    if (!showBoltFields) {
+      boltHeadSelect.removeAttribute('aria-required');
+      boltHeadSelect.title = '';
+    }
+  }
+  if (boltDriveSelect) {
+    boltDriveSelect.disabled = !showBoltFields;
+    if (!showBoltFields) {
+      boltDriveSelect.removeAttribute('aria-required');
+      boltDriveSelect.title = '';
     }
   }
   if (notesInput) {
@@ -674,4 +815,3 @@ export function applyHardwareTypeSelection(nextType) {
   state.hardwareType = trimmed;
   onHardwareTypeChange();
 }
-

--- a/js/lazy-loaders.js
+++ b/js/lazy-loaders.js
@@ -48,7 +48,7 @@ function loadScript(src, globalName) {
 export function loadHtml2Canvas() {
   return loadScript(
     'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js',
-    'html2canvas'
+    'html2canvas',
   );
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -1,6 +1,12 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
-import { pxPerMm, hardwareCatalog, hardwareImageFolders, findConnectorCategory } from './data.js';
+import {
+  pxPerMm,
+  hardwareImageFolders,
+  findConnectorCategory,
+  boltHeadMap,
+  boltDriveMap,
+} from './data.js';
 import { loadHtml2Canvas, loadQrCodeLibrary } from './lazy-loaders.js';
 
 const {
@@ -12,6 +18,7 @@ const {
   textBlockDiv,
   line1Div,
   line2Div,
+  line3Div,
   previewPlaceholder,
   previewStatusText,
   qrCanvas,
@@ -32,6 +39,12 @@ const {
   notesField,
   standardSelect,
   standardField,
+  boltHeadSelect,
+  boltDriveSelect,
+  boltHeadField,
+  boltDriveField,
+  boltHeadMessage,
+  boltDriveMessage,
   bearingTypeSelect,
   bearingOptionsContainer,
   componentCategoryContainer,
@@ -49,7 +62,7 @@ const {
   componentCategoryMessage,
   componentMountMessage,
   customLine1Message,
-  formStatusMessage
+  formStatusMessage,
 } = elements;
 
 // Derived from the hardware label spec: a 37 × 12 mm label yields a 33 × 10 mm
@@ -237,7 +250,13 @@ function deriveTrimmedSvgMarkup(svgText) {
     return null;
   }
   container.removeChild(measuringSvg);
-  if (!bbox || !Number.isFinite(bbox.width) || !Number.isFinite(bbox.height) || bbox.width <= 0 || bbox.height <= 0) {
+  if (
+    !bbox ||
+    !Number.isFinite(bbox.width) ||
+    !Number.isFinite(bbox.height) ||
+    bbox.width <= 0 ||
+    bbox.height <= 0
+  ) {
     return null;
   }
   const marginRatio = 0.02;
@@ -248,7 +267,7 @@ function deriveTrimmedSvgMarkup(svgText) {
   trimmedSvg.removeAttribute('height');
   trimmedSvg.setAttribute(
     'viewBox',
-    `${bbox.x - marginX} ${bbox.y - marginY} ${bbox.width + marginX * 2} ${bbox.height + marginY * 2}`
+    `${bbox.x - marginX} ${bbox.y - marginY} ${bbox.width + marginX * 2} ${bbox.height + marginY * 2}`,
   );
   try {
     return new XMLSerializer().serializeToString(trimmedSvg);
@@ -313,7 +332,11 @@ function applyTrimmedSvgToImage(img, originalSrc) {
     if (img.dataset.trimmedSvgSource === originalSrc) {
       return;
     }
-    if (typeof Blob === 'undefined' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    if (
+      typeof Blob === 'undefined' ||
+      typeof URL === 'undefined' ||
+      typeof URL.createObjectURL !== 'function'
+    ) {
       return;
     }
     try {
@@ -337,13 +360,15 @@ function applyValidationFeedback(disabled) {
   const hardwareType = state.hardwareType;
   const hardwareLabel = typeof hardwareType === 'string' ? hardwareType.toLowerCase() : '';
 
-  const needsThreadSize = !['Fuse', 'Connector', 'Custom', 'Bearing', 'Component'].includes(hardwareType);
+  const needsThreadSize = !['Fuse', 'Connector', 'Custom', 'Bearing', 'Component'].includes(
+    hardwareType,
+  );
   const threadValid = !needsThreadSize || Boolean(state.threadSize);
   updateInputFieldState({
     input: threadSizeSelect,
     container: threadSizeContainer,
     messageElement: threadSizeMessage,
-    valid: threadValid
+    valid: threadValid,
   });
   if (!threadValid) {
     requirements.push('select a thread size');
@@ -356,26 +381,75 @@ function applyValidationFeedback(disabled) {
     input: lengthInput,
     container: lengthContainer,
     messageElement: lengthMessage,
-    valid: lengthValid
+    valid: lengthValid,
   });
   if (!lengthValid) {
     const lengthDescription = hardwareLabel ? `${hardwareLabel} length` : 'length';
     requirements.push(`enter the ${lengthDescription}`);
   }
 
-  const standardRequired =
-    (hardwareType === 'Bolt' || hardwareType === 'Screw') && Boolean(standardSelect) && Boolean(standardField);
-  const needsStandard =
-    standardRequired && Boolean(hardwareImageFolders[hardwareType]) && !standardSelect.disabled;
-  const standardValid = !needsStandard || Boolean(state.standardCode);
-  updateInputFieldState({
-    input: standardSelect,
-    container: standardField,
-    messageElement: null,
-    valid: standardValid
-  });
-  if (!standardValid) {
-    requirements.push('choose a hardware standard');
+  if (hardwareType === 'Bolt') {
+    const headValid = Boolean(state.boltHead);
+    const driveValid = Boolean(state.boltDrive);
+    updateInputFieldState({
+      input: boltHeadSelect,
+      container: boltHeadField,
+      messageElement: boltHeadMessage,
+      valid: headValid,
+      message: 'Select a head style',
+    });
+    updateInputFieldState({
+      input: boltDriveSelect,
+      container: boltDriveField,
+      messageElement: boltDriveMessage,
+      valid: driveValid,
+      message: 'Select a drive style',
+    });
+    updateInputFieldState({
+      input: null,
+      container: standardField,
+      messageElement: null,
+      valid: headValid && driveValid,
+    });
+    updateInputFieldState({
+      input: standardSelect,
+      container: null,
+      messageElement: null,
+      valid: true,
+    });
+    if (!headValid) {
+      requirements.push('choose a head style');
+    }
+    if (!driveValid) {
+      requirements.push('choose a drive style');
+    }
+  } else {
+    const standardRequired =
+      hardwareType === 'Screw' && Boolean(standardSelect) && Boolean(standardField);
+    const needsStandard =
+      standardRequired && Boolean(hardwareImageFolders[hardwareType]) && !standardSelect.disabled;
+    const standardValid = !needsStandard || Boolean(state.standardCode);
+    updateInputFieldState({
+      input: standardSelect,
+      container: standardField,
+      messageElement: null,
+      valid: standardValid,
+    });
+    updateInputFieldState({
+      input: boltHeadSelect,
+      container: boltHeadField,
+      messageElement: boltHeadMessage,
+      valid: true,
+    });
+    updateInputFieldState({
+      input: boltDriveSelect,
+      container: boltDriveField,
+      messageElement: boltDriveMessage,
+      valid: true,
+    });
+    if (!standardValid) {
+      requirements.push('choose a hardware standard');
+    }
   }
 
   const needsFuseValue = hardwareType === 'Fuse';
@@ -384,7 +458,7 @@ function applyValidationFeedback(disabled) {
     input: fuseValueSelect,
     container: fuseValueContainer,
     messageElement: fuseValueMessage,
-    valid: fuseValid
+    valid: fuseValid,
   });
   if (!fuseValid) {
     requirements.push('choose a fuse value');
@@ -396,7 +470,7 @@ function applyValidationFeedback(disabled) {
     input: connectorCategorySelect,
     container: connectorCategoryContainer,
     messageElement: connectorCategoryMessage,
-    valid: connectorCategoryValid
+    valid: connectorCategoryValid,
   });
   if (!connectorCategoryValid) {
     requirements.push('choose a connector category');
@@ -407,7 +481,7 @@ function applyValidationFeedback(disabled) {
     input: notesInput,
     container: notesField,
     messageElement: connectorNotesMessage,
-    valid: connectorNotesValid
+    valid: connectorNotesValid,
   });
 
   const needsBearingSelection = hardwareType === 'Bearing';
@@ -416,7 +490,7 @@ function applyValidationFeedback(disabled) {
     input: bearingTypeSelect,
     container: bearingOptionsContainer,
     messageElement: bearingTypeMessage,
-    valid: bearingValid
+    valid: bearingValid,
   });
   if (!bearingValid) {
     requirements.push('select a bearing');
@@ -428,7 +502,7 @@ function applyValidationFeedback(disabled) {
     radios: componentCategoryRadios,
     container: componentCategoryContainer,
     messageElement: componentCategoryMessage,
-    valid: componentCategoryValid
+    valid: componentCategoryValid,
   });
   if (!componentCategoryValid) {
     requirements.push('choose a component type');
@@ -439,7 +513,7 @@ function applyValidationFeedback(disabled) {
     radios: componentMountRadios,
     container: componentMountContainer,
     messageElement: componentMountMessage,
-    valid: componentMountValid
+    valid: componentMountValid,
   });
   if (!componentMountValid) {
     requirements.push('choose a mounting style');
@@ -452,7 +526,7 @@ function applyValidationFeedback(disabled) {
     input: customLine1Input,
     container: customLine1Field,
     messageElement: customLine1Message,
-    valid: customTitleValid
+    valid: customTitleValid,
   });
   if (!customTitleValid) {
     requirements.push('add a custom label title');
@@ -460,7 +534,10 @@ function applyValidationFeedback(disabled) {
 
   if (formStatusMessage) {
     if (disabled) {
-      const summary = requirements.length > 0 ? formatRequirementSummary(requirements) : 'complete the required fields';
+      const summary =
+        requirements.length > 0
+          ? formatRequirementSummary(requirements)
+          : 'complete the required fields';
       formStatusMessage.textContent = `To enable Download and Print, ${summary}.`;
       formStatusMessage.classList.remove('d-none');
     } else {
@@ -483,33 +560,40 @@ function getHardwareImageInfo() {
   if (!catalogKey) {
     return null;
   }
-  const code = (state.standardCode || '').trim();
-  const standardName = (state.standard || '').trim();
   if (catalogKey === 'Bolt') {
-    if (!code) {
+    const headId = (state.boltHead || '').trim();
+    const driveId = (state.boltDrive || '').trim();
+    if (!headId || !driveId) {
       return null;
     }
-    const boltEntries = hardwareCatalog.Bolt;
-    const matchedEntry = Array.isArray(boltEntries)
-      ? boltEntries.find(entry => entry && entry.code === code)
-      : null;
-    if (!matchedEntry) {
+    const headEntry = boltHeadMap.get(headId);
+    const driveEntry = boltDriveMap.get(driveId);
+    if (!headEntry || !driveEntry) {
       return null;
     }
-    const headImage = (matchedEntry.headImage || '').trim();
-    const driveImage = (matchedEntry.driveImage || '').trim();
+    const headImage = (headEntry.image || '').trim();
+    const driveImage = (driveEntry.image || '').trim();
     if (!headImage || !driveImage) {
       return null;
     }
-    const altBase = (standardName || matchedEntry.name || matchedEntry.code || 'Bolt').trim() || 'Bolt';
+    const altPieces = [];
+    if (headEntry.label) {
+      altPieces.push(headEntry.label);
+    }
+    if (driveEntry.label) {
+      altPieces.push(driveEntry.label);
+    }
+    const altBase = altPieces.length > 0 ? altPieces.join(' — ') : 'Bolt';
     return {
       type: 'boltSvg',
       headSrc: `images/bolts/head/${headImage}.svg`,
       driveSrc: `images/bolts/drive/${driveImage}.svg`,
       headAlt: `${altBase} — head view`,
-      driveAlt: `${altBase} — drive view`
+      driveAlt: `${altBase} — drive view`,
     };
   }
+  const code = (state.standardCode || '').trim();
+  const standardName = (state.standard || '').trim();
   const folder = hardwareImageFolders[catalogKey];
   if (!folder) {
     return null;
@@ -533,7 +617,7 @@ function getHardwareImageInfo() {
   return {
     type: 'photo',
     src,
-    alt: altBase ? `${altBase} reference illustration` : 'Hardware reference illustration'
+    alt: altBase ? `${altBase} reference illustration` : 'Hardware reference illustration',
   };
 }
 
@@ -546,6 +630,9 @@ function applyTextFitting(primaryFontSize, secondaryFontSize) {
   if (line2Div) {
     line2Div.style.fontSize = secondaryFontSize + 'px';
   }
+  if (line3Div) {
+    line3Div.style.fontSize = secondaryFontSize + 'px';
+  }
 
   const availableWidth = textBlockDiv.clientWidth;
   const availableHeight = labelInner ? labelInner.clientHeight : textBlockDiv.clientHeight;
@@ -553,25 +640,31 @@ function applyTextFitting(primaryFontSize, secondaryFontSize) {
     return;
   }
 
-  const hasLine2 = Boolean(
-    line2Div &&
-      line2Div.style.display !== 'none' &&
-      line2Div.textContent &&
-      line2Div.textContent.trim()
-  );
-
-  let line1Size = primaryFontSize;
-  let line2Size = secondaryFontSize;
-
   const absolutePrimaryMin = 4;
   const absoluteSecondaryMin = 3.5;
-  let minLine1 = Math.min(primaryFontSize, 6);
-  minLine1 = Math.max(absolutePrimaryMin, minLine1);
-  let minLine2 = 0;
-  if (hasLine2) {
-    minLine2 = Math.min(secondaryFontSize, 5);
-    minLine2 = Math.max(absoluteSecondaryMin, minLine2);
-  }
+  const lineStates = [];
+
+  lineStates.push({
+    element: line1Div,
+    size: primaryFontSize,
+    minSize: Math.max(absolutePrimaryMin, Math.min(primaryFontSize, 6)),
+  });
+
+  const secondaryLines = [line2Div, line3Div].filter(
+    element =>
+      element &&
+      element.style.display !== 'none' &&
+      element.textContent &&
+      element.textContent.trim(),
+  );
+
+  secondaryLines.forEach(element => {
+    lineStates.push({
+      element,
+      size: secondaryFontSize,
+      minSize: Math.max(absoluteSecondaryMin, Math.min(secondaryFontSize, 5)),
+    });
+  });
 
   const tolerance = 0.5;
   let iterations = 0;
@@ -579,26 +672,22 @@ function applyTextFitting(primaryFontSize, secondaryFontSize) {
   while (iterations < maxIterations) {
     let adjusted = false;
 
-    if (line1Div.scrollWidth - tolerance > availableWidth && line1Size > minLine1) {
-      line1Size = Math.max(minLine1, line1Size - 0.5);
-      line1Div.style.fontSize = line1Size + 'px';
-      adjusted = true;
-    }
-
-    if (hasLine2 && line2Div.scrollWidth - tolerance > availableWidth && line2Size > minLine2) {
-      line2Size = Math.max(minLine2, line2Size - 0.5);
-      line2Div.style.fontSize = line2Size + 'px';
-      adjusted = true;
-    }
+    lineStates.forEach(state => {
+      if (state.element.scrollWidth - tolerance > availableWidth && state.size > state.minSize) {
+        state.size = Math.max(state.minSize, state.size - 0.5);
+        state.element.style.fontSize = state.size + 'px';
+        adjusted = true;
+      }
+    });
 
     if (textBlockDiv.scrollHeight - tolerance > availableHeight) {
-      if (line1Size > minLine1 && (!hasLine2 || line1Size >= line2Size || line2Size <= minLine2)) {
-        line1Size = Math.max(minLine1, line1Size - 0.5);
-        line1Div.style.fontSize = line1Size + 'px';
-        adjusted = true;
-      } else if (hasLine2 && line2Size > minLine2) {
-        line2Size = Math.max(minLine2, line2Size - 0.5);
-        line2Div.style.fontSize = line2Size + 'px';
+      const reducible = lineStates.filter(state => state.size > state.minSize);
+      if (reducible.length > 0) {
+        const largest = reducible.reduce((prev, current) =>
+          current.size > prev.size ? current : prev,
+        );
+        largest.size = Math.max(largest.minSize, largest.size - 0.5);
+        largest.element.style.fontSize = largest.size + 'px';
         adjusted = true;
       }
     }
@@ -627,7 +716,10 @@ export function isLabelReady() {
   if (state.hardwareType === 'Component') {
     return Boolean(state.componentCategory && state.componentMount);
   }
-  if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
+  if (state.hardwareType === 'Bolt') {
+    return Boolean(state.threadSize && state.length && state.boltHead && state.boltDrive);
+  }
+  if (state.hardwareType === 'Screw') {
     return Boolean(state.threadSize && state.length && state.standardCode);
   }
   return Boolean(state.threadSize);
@@ -723,6 +815,10 @@ export function updatePreview() {
     line1Div.textContent = '';
     line2Div.textContent = '';
     line2Div.style.display = 'none';
+    if (line3Div) {
+      line3Div.textContent = '';
+      line3Div.style.display = 'none';
+    }
     if (qrCanvas) {
       const ctx = qrCanvas.getContext('2d');
       if (ctx) {
@@ -771,7 +867,7 @@ export function updatePreview() {
   }
   const basePaddingX = Math.max(
     mmToPx(horizontalPaddingBaselineMm * paddingScale),
-    mmToPx(minHorizontalPaddingMm)
+    mmToPx(minHorizontalPaddingMm),
   );
   const basePaddingY = Math.max(mmToPx(1.0 * verticalScale), mmToPx(0.8));
   const baseGap = Math.max(mmToPx(0.8 * gapScale), mmToPx(0.6));
@@ -828,7 +924,10 @@ export function updatePreview() {
           const boltPreferredWidth = Math.max(0, Math.min(innerHeightPx * 1.4, innerWidthPx * 0.6));
           maxWidthForPhoto = Math.max(maxWidthForPhoto, boltPreferredWidth);
         } else {
-          const photoPreferredWidth = Math.max(0, Math.min(innerHeightPx * 1.2, innerWidthPx * 0.5));
+          const photoPreferredWidth = Math.max(
+            0,
+            Math.min(innerHeightPx * 1.2, innerWidthPx * 0.5),
+          );
           maxWidthForPhoto = Math.max(maxWidthForPhoto, photoPreferredWidth);
         }
         if (maxWidthForPhoto > 0) {
@@ -859,13 +958,13 @@ export function updatePreview() {
               {
                 src: photoInfo.driveSrc,
                 alt: photoInfo.driveAlt,
-                className: 'hardware-photo bolt-drive-view'
+                className: 'hardware-photo bolt-drive-view',
               },
               {
                 src: photoInfo.headSrc,
                 alt: photoInfo.headAlt,
-                className: 'hardware-photo bolt-head-view'
-              }
+                className: 'hardware-photo bolt-head-view',
+              },
             ];
             let maxWidthPerImage = Math.floor(maxWidthForPhoto / boltImages.length);
             if (!Number.isFinite(maxWidthPerImage) || maxWidthPerImage <= 0) {
@@ -938,9 +1037,15 @@ export function updatePreview() {
     line1Div.textContent = topLine || 'Custom Label';
     line2Div.textContent = bottomLine;
     line2Div.style.display = bottomLine ? 'block' : 'none';
+    if (line3Div) {
+      line3Div.textContent = '';
+      line3Div.style.display = 'none';
+    }
   } else {
     let line1 = '';
     let connectorLine2Parts = null;
+    let line2 = '';
+    let line3 = '';
     if (state.hardwareType === 'Fuse') {
       const fuseParts = [];
       const fuseLabel = state.fuseType ? `${state.fuseType} Fuse` : 'Fuse';
@@ -994,17 +1099,44 @@ export function updatePreview() {
         componentParts.push(state.componentMount);
       }
       line1 = componentParts.join(' — ');
+    } else if (state.hardwareType === 'Bolt') {
+      if (state.threadSize) {
+        line1 = state.threadSize;
+      }
+      if (state.length) {
+        line1 += line1 ? ` × ${state.length}` : state.length;
+      }
+      const headEntry = boltHeadMap.get((state.boltHead || '').trim());
+      const driveEntry = boltDriveMap.get((state.boltDrive || '').trim());
+      const headLabel = headEntry ? headEntry.label : '';
+      const driveLabel = driveEntry ? driveEntry.label : '';
+      const showHead = state.showStandard && headLabel;
+      const showDrive = state.showStandard && driveLabel;
+      if (showHead) {
+        line2 = headLabel;
+      }
+      if (showDrive) {
+        line3 = driveLabel;
+      }
+      if (state.notes) {
+        if (line3) {
+          line3 += ` • ${state.notes}`;
+        } else if (line2) {
+          line3 = state.notes;
+        } else {
+          line2 = state.notes;
+        }
+      }
     } else {
       if (state.threadSize) {
         line1 = state.threadSize;
       }
-      if ((state.hardwareType === 'Screw' || state.hardwareType === 'Bolt') && state.length) {
+      if (state.hardwareType === 'Screw' && state.length) {
         line1 += line1 ? ` × ${state.length}` : state.length;
       }
     }
     const fallbackLabel = state.hardwareType === 'Fuse' ? 'Fuse' : state.hardwareType;
     line1Div.textContent = line1 || fallbackLabel;
-    let line2 = '';
     if (state.hardwareType === 'Fuse') {
       const fuseDetails = [];
       if (state.showStandard && state.standard) {
@@ -1039,7 +1171,7 @@ export function updatePreview() {
       if (state.notes) {
         line2 = state.notes;
       }
-    } else {
+    } else if (state.hardwareType !== 'Bolt') {
       if (state.showStandard && state.standard) {
         line2 = state.standard;
       }
@@ -1049,6 +1181,10 @@ export function updatePreview() {
     }
     line2Div.textContent = line2;
     line2Div.style.display = line2 ? 'block' : 'none';
+    if (line3Div) {
+      line3Div.textContent = line3;
+      line3Div.style.display = line3 ? 'block' : 'none';
+    }
   }
 
   const primaryFontSize = Math.max(8, Math.floor(innerHeightPx * 0.45));
@@ -1088,14 +1224,16 @@ export function updatePreview() {
         if (!state.showQr || !latestContent || !qrCanvas) {
           return;
         }
-        const renderFn = qrCodeLib && typeof qrCodeLib.toCanvas === 'function' ? qrCodeLib.toCanvas : null;
+        const renderFn =
+          qrCodeLib && typeof qrCodeLib.toCanvas === 'function' ? qrCodeLib.toCanvas : null;
         if (!renderFn) {
           throw new Error('QR code library is missing the toCanvas function.');
         }
         try {
           const qrMarginModules = 1;
           let moduleCount = null;
-          const createFn = qrCodeLib && typeof qrCodeLib.create === 'function' ? qrCodeLib.create : null;
+          const createFn =
+            qrCodeLib && typeof qrCodeLib.create === 'function' ? qrCodeLib.create : null;
           if (createFn) {
             try {
               const qrMatrix = createFn.call(qrCodeLib, latestContent);
@@ -1107,7 +1245,8 @@ export function updatePreview() {
             }
           }
 
-          const totalModules = moduleCount && moduleCount > 0 ? moduleCount + qrMarginModules * 2 : null;
+          const totalModules =
+            moduleCount && moduleCount > 0 ? moduleCount + qrMarginModules * 2 : null;
           let modulePixelSize = 0;
           let qrPixelSize = qrEstimatedSizePx;
           if (totalModules && totalModules > 0) {
@@ -1126,8 +1265,8 @@ export function updatePreview() {
             margin: qrMarginModules,
             color: {
               dark: '#000',
-              light: '#00000000'
-            }
+              light: '#00000000',
+            },
           };
 
           if (modulePixelSize > 0 && totalModules && totalModules > 0) {
@@ -1182,12 +1321,13 @@ export function updatePreview() {
       ? Math.max(paddingRightPx, desiredQrEdgeClearancePx)
       : paddingRightPx;
     const qrWidthContribution = qrVisible ? qrEstimatedSizePx : 0;
-    return innerWidthPx - (
-      paddingLeftPx +
-      effectiveRightPadding +
-      gapPx * gapCount +
-      hardwareWidthPx +
-      qrWidthContribution
+    return (
+      innerWidthPx -
+      (paddingLeftPx +
+        effectiveRightPadding +
+        gapPx * gapCount +
+        hardwareWidthPx +
+        qrWidthContribution)
     );
   };
 
@@ -1261,7 +1401,7 @@ export async function renderLabelCanvas() {
     width: containerWidth,
     height: containerHeight,
     scrollX: 0,
-    scrollY: 0
+    scrollY: 0,
   });
 
   const containerRect = previewContainer.getBoundingClientRect();
@@ -1295,7 +1435,7 @@ export async function renderLabelCanvas() {
       0,
       0,
       outputCanvas.width,
-      outputCanvas.height
+      outputCanvas.height,
     );
   }
   return outputCanvas;
@@ -1314,7 +1454,7 @@ export async function renderLabelBlob(type = 'image/png', quality) {
           reject(new Error('Unable to convert canvas to blob.'));
         },
         type,
-        quality
+        quality,
       );
     });
   }

--- a/js/state.js
+++ b/js/state.js
@@ -10,6 +10,8 @@ export const state = {
   notes: '',
   standard: '',
   standardCode: '',
+  boltHead: '',
+  boltDrive: '',
   showStandard: true,
   showImage: true,
   showQr: false,
@@ -24,9 +26,9 @@ export const state = {
   customLine1: '',
   customLine2: '',
   customImageData: '',
-  customImageName: ''
+  customImageName: '',
 };
 
 export const standardFilterState = {
-  query: ''
+  query: '',
 };

--- a/js/theme.js
+++ b/js/theme.js
@@ -5,9 +5,10 @@ const themeColorMeta = document.getElementById('theme-color-meta');
 const statusBarStyleMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
 const themeColorByMode = { light: '#f8fafc', dark: '#0f172a' };
 const statusBarStyleByMode = { light: 'default', dark: 'black-translucent' };
-const prefersDarkScheme = typeof window.matchMedia === 'function'
-  ? window.matchMedia('(prefers-color-scheme: dark)')
-  : { matches: false };
+const prefersDarkScheme =
+  typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : { matches: false };
 
 function isValidTheme(value) {
   return value === 'light' || value === 'dark';
@@ -91,7 +92,8 @@ export function initTheme() {
   applyTheme(getPreferredTheme());
   if (themeToggleButton) {
     themeToggleButton.addEventListener('click', () => {
-      const currentTheme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      const currentTheme =
+        document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
       const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
       applyTheme(nextTheme);
       setStoredTheme(nextTheme);

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -5,7 +5,9 @@ import {
   imperialThreadSizes,
   fuseValues,
   bearingOptions,
-  connectorCatalog
+  connectorCatalog,
+  boltHeadOptions,
+  boltDriveOptions,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -22,6 +24,8 @@ const FIELD_MAP = {
   notes: 'no',
   standard: 'sd',
   standardCode: 'sc',
+  boltHead: 'bh',
+  boltDrive: 'bv',
   showStandard: 'ss',
   showImage: 'si',
   showQr: 'sq',
@@ -36,7 +40,7 @@ const FIELD_MAP = {
   customLine1: 'c1',
   customLine2: 'c2',
   customImageData: 'cid',
-  customImageName: 'cin'
+  customImageName: 'cin',
 };
 
 const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) => {
@@ -46,31 +50,31 @@ const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) =>
 
 const hardwareTypeOptions = elements.hardwareTypeOptions || new Set();
 const fuseTypeOptions = new Set(
-  Array.isArray(elements.fuseTypeRadios) ? elements.fuseTypeRadios.map(radio => radio.value) : []
+  Array.isArray(elements.fuseTypeRadios) ? elements.fuseTypeRadios.map(radio => radio.value) : [],
 );
 const componentCategoryOptions = new Set(
   Array.isArray(elements.componentCategoryRadios)
     ? elements.componentCategoryRadios.map(radio => radio.value)
-    : []
+    : [],
 );
 const componentMountOptions = new Set(
   Array.isArray(elements.componentMountRadios)
     ? elements.componentMountRadios.map(radio => radio.value)
-    : []
+    : [],
 );
 const heightOptions = new Set(
   Array.isArray(elements.heightRadios)
     ? elements.heightRadios
         .map(radio => Number.parseInt(radio.value, 10))
         .filter(value => Number.isFinite(value))
-    : []
+    : [],
 );
 const glassSizeOptions = new Set(
   elements.glassSizeSelect
     ? Array.from(elements.glassSizeSelect.options)
         .map(option => option.value)
         .filter(value => value && value.trim().length > 0)
-    : []
+    : [],
 );
 const glassSpeedOptions = new Set(['Slow Blow (Time Delay)', 'Fast Blow']);
 const metricThreadSet = new Set(metricThreadSizes);
@@ -80,6 +84,8 @@ const fuseValueOptions = new Set(fuseValues.map(value => String(value)));
 const connectorCategoryOptions = new Set(connectorCatalog.map(category => category.id));
 const bearingCodeOptions = new Set(bearingOptions.map(option => option.code));
 const systemTypeOptions = new Set(['Metric', 'Imperial']);
+const boltHeadIds = new Set(boltHeadOptions.map(option => option.id));
+const boltDriveIds = new Set(boltDriveOptions.map(option => option.id));
 
 function encodeToBase64Url(input) {
   const encoder = new TextEncoder();
@@ -96,9 +102,7 @@ function decodeFromBase64Url(input) {
   const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
   const paddingNeeded = normalized.length % 4;
   const padded =
-    paddingNeeded === 0
-      ? normalized
-      : normalized + '='.repeat((4 - paddingNeeded) % 4);
+    paddingNeeded === 0 ? normalized : normalized + '='.repeat((4 - paddingNeeded) % 4);
   const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i += 1) {
@@ -334,6 +338,14 @@ function applyExpandedPayload(expanded) {
   }
   if (typeof expanded.standard === 'string') {
     state.standard = sanitizeShortText(expanded.standard);
+  }
+  if (typeof expanded.boltHead === 'string') {
+    const trimmedHead = expanded.boltHead.trim();
+    state.boltHead = boltHeadIds.has(trimmedHead) ? trimmedHead : '';
+  }
+  if (typeof expanded.boltDrive === 'string') {
+    const trimmedDrive = expanded.boltDrive.trim();
+    state.boltDrive = boltDriveIds.has(trimmedDrive) ? trimmedDrive : '';
   }
 
   if (typeof expanded.showStandard === 'boolean') {

--- a/style-print.css
+++ b/style-print.css
@@ -102,7 +102,8 @@
   }
 
   .print-ruler.print-ruler--with-majors.print-ruler--horizontal {
-    background-image: repeating-linear-gradient(
+    background-image:
+      repeating-linear-gradient(
         to right,
         transparent,
         transparent calc(5mm - 0.15mm),
@@ -119,7 +120,8 @@
   }
 
   .print-ruler.print-ruler--with-majors.print-ruler--vertical {
-    background-image: repeating-linear-gradient(
+    background-image:
+      repeating-linear-gradient(
         to bottom,
         transparent,
         transparent calc(5mm - 0.15mm),

--- a/style.css
+++ b/style.css
@@ -70,8 +70,8 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   min-height: 100svh;
-  padding: env(safe-area-inset-top) env(safe-area-inset-right)
-    env(safe-area-inset-bottom) env(safe-area-inset-left);
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+    env(safe-area-inset-left);
   transition: background 0.3s ease;
   -webkit-font-smoothing: antialiased;
   text-size-adjust: 100%;
@@ -90,7 +90,7 @@ main {
 }
 
 .title-section h1 {
-  font-family: "Tagesschrift", sans-serif;
+  font-family: 'Tagesschrift', sans-serif;
   font-size: clamp(1.35rem, 6vw, 4.5rem);
   line-height: 1.05;
 }
@@ -105,7 +105,9 @@ main {
   border: 1px solid var(--field-help-border);
   background-color: var(--field-help-bg);
   padding: 0.75rem 1rem;
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
 }
 
 .field-help[open] {
@@ -170,7 +172,6 @@ main {
   flex-wrap: wrap;
   gap: 0.75rem;
 }
-
 
 .label-preview {
   position: relative;
@@ -380,10 +381,7 @@ main {
   --label-padding-y: 10px;
   --label-padding-inline-start: var(--label-padding-x);
   --label-padding-inline-end: var(--label-padding-x);
-  padding:
-    var(--label-padding-y)
-    var(--label-padding-inline-end)
-    var(--label-padding-y)
+  padding: var(--label-padding-y) var(--label-padding-inline-end) var(--label-padding-y)
     var(--label-padding-inline-start);
 }
 
@@ -411,7 +409,10 @@ main {
   cursor: default;
   flex-shrink: 0;
   user-select: none;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .qr-info-icon i {
@@ -503,7 +504,11 @@ main {
   line-height: 1.1;
   cursor: pointer;
   white-space: nowrap;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .theme-toggle-button:hover {

--- a/test/threadSizes.test.js
+++ b/test/threadSizes.test.js
@@ -15,7 +15,7 @@ const createMockSelect = () => ({
       return;
     }
     throw new Error(`Unexpected innerHTML assignment: ${value}`);
-  }
+  },
 });
 
 const mockThreadSizeSelect = createMockSelect();
@@ -26,14 +26,14 @@ const mockUpdateDownloadState = jest.fn();
 jest.mock('../js/dom-elements.js', () => ({
   __esModule: true,
   elements: {
-    threadSizeSelect: mockThreadSizeSelect
-  }
+    threadSizeSelect: mockThreadSizeSelect,
+  },
 }));
 
 jest.mock('../js/render.js', () => ({
   __esModule: true,
   updatePreview: mockUpdatePreview,
-  updateDownloadState: mockUpdateDownloadState
+  updateDownloadState: mockUpdateDownloadState,
 }));
 
 const createElementMock = jest.fn(tagName => {
@@ -42,12 +42,12 @@ const createElementMock = jest.fn(tagName => {
   }
   return {
     value: '',
-    textContent: ''
+    textContent: '',
   };
 });
 
 global.document = {
-  createElement: createElementMock
+  createElement: createElementMock,
 };
 
 let populateThreadSizes;
@@ -85,7 +85,7 @@ describe('populateThreadSizes', () => {
     expect(mockThreadSizeSelect.options).toHaveLength(metricThreadSizes.length + 1);
     const [placeholder, ...options] = mockThreadSizeSelect.options;
     expect(placeholder).toEqual(
-      expect.objectContaining({ value: '', textContent: 'Select size…' })
+      expect.objectContaining({ value: '', textContent: 'Select size…' }),
     );
     expect(options.map(option => option.textContent)).toEqual(metricThreadSizes);
     expect(options.map(option => option.value)).toEqual(metricThreadSizes);
@@ -103,7 +103,7 @@ describe('populateThreadSizes', () => {
     expect(state.threadSize).toBe('');
     expect(mockThreadSizeSelect.options).toHaveLength(1);
     expect(mockThreadSizeSelect.options[0]).toEqual(
-      expect.objectContaining({ value: '', textContent: 'Not applicable' })
+      expect.objectContaining({ value: '', textContent: 'Not applicable' }),
     );
     expect(mockUpdateDownloadState).toHaveBeenCalledTimes(1);
     expect(mockUpdatePreview).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- split bolt hardware selection into dedicated drive and head dropdowns with validation feedback
- update preview rendering, label text, image handling, and shared state to use the new bolt selections and add a third text line
- run Prettier across the project to align formatting and ensure command checks succeed

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d117d9fa4083299e6de78977e170b3