### PR TITLE
Ensure bolt drive/head dropdowns align horizontally

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,8 +472,12 @@
                     >Hardware Standard</label
                   >
                   <select id="standard-select" class="form-select"></select>
-                  <div id="bolt-standard-group" class="row g-2 d-none" aria-hidden="true">
-                    <div id="bolt-drive-field" class="col-12 col-sm-6">
+                  <div
+                    id="bolt-standard-group"
+                    class="row row-cols-2 g-2 d-none"
+                    aria-hidden="true"
+                  >
+                    <div id="bolt-drive-field" class="col">
                       <label for="bolt-drive-select" class="form-label">Drive</label>
                       <select id="bolt-drive-select" class="form-select"></select>
                       <div
@@ -481,7 +485,7 @@
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>
-                    <div id="bolt-head-field" class="col-12 col-sm-6">
+                    <div id="bolt-head-field" class="col">
                       <label for="bolt-head-select" class="form-label">Head</label>
                       <select id="bolt-head-select" class="form-select"></select>
                       <div


### PR DESCRIPTION
## Summary
- force the bolt drive and head selects into a two-column layout so the controls stay side by side
- simplify the child column classes to rely on the shared row column utility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12bf61d9083298281eef195bc005b