### PR TITLE
Align bolt controls layout with thread row

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,22 +467,22 @@
                 <div id="standard-field">
                   <label
                     for="standard-select"
-                    class="form-label fw-semibold"
+                    class="form-label fw-semibold visually-hidden"
                     id="standard-field-label"
                     >Hardware Standard</label
                   >
                   <select id="standard-select" class="form-select"></select>
-                  <div id="bolt-standard-group" class="row g-2 d-none" aria-hidden="true">
-                    <div id="bolt-drive-field" class="col-12 col-sm-6">
-                      <label for="bolt-drive-select" class="form-label">Drive</label>
+                  <div id="bolt-standard-group" class="row g-3 d-none" aria-hidden="true">
+                    <div id="bolt-drive-field" class="col-12 col-sm-6 thread-length-field">
+                      <label for="bolt-drive-select" class="form-label fw-semibold">Drive</label>
                       <select id="bolt-drive-select" class="form-select"></select>
                       <div
                         id="bolt-drive-message"
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>
-                    <div id="bolt-head-field" class="col-12 col-sm-6">
-                      <label for="bolt-head-select" class="form-label">Head</label>
+                    <div id="bolt-head-field" class="col-12 col-sm-6 thread-length-field">
+                      <label for="bolt-head-select" class="form-label fw-semibold">Head</label>
                       <select id="bolt-head-select" class="form-select"></select>
                       <div
                         id="bolt-head-message"

--- a/js/render.js
+++ b/js/render.js
@@ -396,14 +396,12 @@ function applyValidationFeedback(disabled) {
       container: boltHeadField,
       messageElement: boltHeadMessage,
       valid: headValid,
-      message: 'Select a head style',
     });
     updateInputFieldState({
       input: boltDriveSelect,
       container: boltDriveField,
       messageElement: boltDriveMessage,
       valid: driveValid,
-      message: 'Select a drive style',
     });
     updateInputFieldState({
       input: null,

--- a/style.css
+++ b/style.css
@@ -600,12 +600,14 @@ main {
 }
 
 @media (min-width: 576px) {
-  #thread-length-row {
+  #thread-length-row,
+  #bolt-standard-group {
     --thread-length-gap: 1rem;
     gap: var(--thread-length-gap);
   }
 
-  #thread-length-row > .thread-length-field {
+  #thread-length-row > .thread-length-field,
+  #bolt-standard-group > .thread-length-field {
     flex: 0 0 calc(50% - (var(--thread-length-gap) / 2));
     max-width: calc(50% - (var(--thread-length-gap) / 2));
   }
@@ -616,7 +618,8 @@ main {
     justify-content: center;
   }
 
-  #thread-length-row {
+  #thread-length-row,
+  #bolt-standard-group {
     --thread-length-gap: 0.75rem;
     margin-left: 0;
     margin-right: 0;
@@ -626,17 +629,20 @@ main {
     row-gap: var(--thread-length-gap);
   }
 
-  #thread-length-row > .thread-length-field {
+  #thread-length-row > .thread-length-field,
+  #bolt-standard-group > .thread-length-field {
     padding-left: 0;
     padding-right: 0;
   }
 
-  #thread-length-row.single-column {
+  #thread-length-row.single-column,
+  #bolt-standard-group.single-column {
     grid-template-columns: minmax(0, 1fr);
   }
 }
 
-#thread-length-row.single-column > .thread-length-field {
+#thread-length-row.single-column > .thread-length-field,
+#bolt-standard-group.single-column > .thread-length-field {
   flex: 0 0 100%;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- hide the Hardware Standard label visually while keeping it available to assistive tech
- align the bolt drive/head row spacing and typography with the thread size/length controls
- keep helper text hidden by dropping the placeholder validation strings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1330bd5f48329b44bc88ea057ee82