### PR TITLE
Fix hardware image aspect ratios

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -338,6 +338,44 @@ function clearHardwareImageContent() {
   hardwareImageDiv.innerHTML = '';
 }
 
+function setExplicitWidthFromAspectRatio(img, targetHeightPx, maxWidthPx) {
+  if (!img || !Number.isFinite(targetHeightPx) || targetHeightPx <= 0) {
+    return;
+  }
+
+  const applyWidth = () => {
+    if (!img || !img.isConnected) {
+      return;
+    }
+    const { naturalWidth, naturalHeight } = img;
+    if (!Number.isFinite(naturalWidth) || !Number.isFinite(naturalHeight)) {
+      return;
+    }
+    if (naturalWidth <= 0 || naturalHeight <= 0) {
+      return;
+    }
+    const aspectRatio = naturalWidth / naturalHeight;
+    if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+      return;
+    }
+    let desiredWidth = aspectRatio * targetHeightPx;
+    if (!Number.isFinite(desiredWidth) || desiredWidth <= 0) {
+      return;
+    }
+    if (Number.isFinite(maxWidthPx) && maxWidthPx > 0) {
+      desiredWidth = Math.min(desiredWidth, maxWidthPx);
+    }
+    if (Number.isFinite(desiredWidth) && desiredWidth > 0) {
+      img.style.width = desiredWidth + 'px';
+    }
+  };
+
+  img.addEventListener('load', applyWidth);
+  if (img.complete) {
+    applyWidth();
+  }
+}
+
 function applyTrimmedSvgToImage(img, originalSrc) {
   if (!img || typeof originalSrc !== 'string' || !originalSrc) {
     return;
@@ -1017,6 +1055,7 @@ export function updatePreview() {
               boltImg.style.maxWidth = maxWidthPerImage + 'px';
               boltImg.addEventListener('error', handleMissingAsset);
               boltGroup.appendChild(boltImg);
+              setExplicitWidthFromAspectRatio(boltImg, innerHeightPx, maxWidthPerImage);
               applyTrimmedSvgToImage(boltImg, imageInfo.src);
             });
           } else {
@@ -1027,7 +1066,9 @@ export function updatePreview() {
             img.decoding = 'async';
             img.loading = 'lazy';
             img.style.maxHeight = innerHeightPx + 'px';
+            img.style.height = innerHeightPx + 'px';
             img.style.maxWidth = maxWidthForPhoto + 'px';
+            setExplicitWidthFromAspectRatio(img, innerHeightPx, maxWidthForPhoto);
             hardwareImageDiv.appendChild(img);
           }
         } else {

--- a/style.css
+++ b/style.css
@@ -270,7 +270,6 @@ main {
   display: block;
   max-width: 100%;
   max-height: 100%;
-  object-fit: contain;
   filter: grayscale(100%);
 }
 
@@ -282,7 +281,7 @@ main {
 .bolt-image-group {
   display: flex;
   align-items: stretch;
-  justify-content: space-between;
+  justify-content: center;
   gap: 0.75rem;
   max-height: 100%;
   width: 100%;
@@ -293,7 +292,7 @@ main {
   max-height: 100%;
   height: 100%;
   width: auto;
-  flex: 1 1 0;
+  flex: 0 0 auto;
 }
 
 .bolt-drive-view {


### PR DESCRIPTION
## Summary
- compute hardware photo widths from their natural aspect ratios when preview images load
- adjust bolt preview layout styles so widths come from script rather than object-fit

## Testing
- npm run lint
- Manually downloaded a bolt label to confirm drive/head icons keep their proportions

------
https://chatgpt.com/codex/tasks/task_e_68d149c52068832997be6c32d2167d17