### PR TITLE
Replace label export with shared SVG renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ include:
 - Contextual validation and helper messaging that keep the preview in sync with
   selected options.
 - Optional QR code content with automatic library loading only when needed.
-- Download-and-print flows that use html2canvas to export the on-screen label
-  preview.
+- Download-and-print flows that use a shared SVG renderer to keep the preview
+  and exported artwork in sync.
 - Shareable label URLs with Web Share API support and clipboard fallback.
 
 The repository is structured as a traditional GitHub Pages site, making it easy
@@ -36,7 +36,7 @@ to host the tool directly from the `main` branch.
 │   ├── dom-elements.js    # Cached DOM references for easier querying
 │   ├── events.js          # Wiring for form, download, and print events
 │   ├── forms.js           # Field population, validation, and UI helpers
-│   ├── lazy-loaders.js    # On-demand loading of html2canvas and QR libraries
+│   ├── lazy-loaders.js    # On-demand loading of the QR code library
 │   ├── render.js          # Label preview updates and export orchestration
 │   ├── state.js           # Centralized application state store
 │   ├── theme.js           # Theme toggle behavior and persistence helpers

--- a/index.html
+++ b/index.html
@@ -22,9 +22,8 @@
     <!--
     Standalone tool for generating and printing Gridfinity labels.  Styling
     now layers a lightweight Bootstrap 5 theme for modern form controls and
-    layout utilities.  Two small third-party libraries are loaded on demand
-    via CDN: html2canvas to capture the label preview as an image and qrcode
-    to generate optional QR codes.
+    layout utilities.  A lightweight QR code library is loaded on demand via
+    CDN to generate optional QR codes.
   -->
     <link
       rel="stylesheet"
@@ -705,15 +704,42 @@
               <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
               <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
             </div>
-            <div id="label-inner" class="label-inner" style="display: none">
-              <div id="hardware-image" class="hardware-icon"></div>
-              <div id="preview-text" class="text-block">
-                <div id="line1" class="text-line"></div>
-                <div id="line2" class="text-line small"></div>
-                <div id="line3" class="text-line small"></div>
-              </div>
-              <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
-            </div>
+            <svg
+              id="label-svg"
+              class="label-svg"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 55 12"
+              aria-hidden="true"
+            >
+              <rect
+                id="label-frame"
+                class="label-frame"
+                x="0"
+                y="0"
+                width="55"
+                height="12"
+                rx="0"
+                ry="0"
+              ></rect>
+              <g id="printable" transform="translate(2,1)">
+                <foreignObject id="printable-foreignObject" x="0" y="0" width="51" height="10">
+                  <div
+                    xmlns="http://www.w3.org/1999/xhtml"
+                    id="label-inner"
+                    class="label-inner"
+                    style="display: none"
+                  >
+                    <div id="hardware-image" class="hardware-icon"></div>
+                    <div id="preview-text" class="text-block">
+                      <div id="line1" class="text-line"></div>
+                      <div id="line2" class="text-line small"></div>
+                      <div id="line3" class="text-line small"></div>
+                    </div>
+                    <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
+                  </div>
+                </foreignObject>
+              </g>
+            </svg>
           </div>
         </div>
       </section>

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { findConnectorCategory, boltHeadMap, boltDriveMap } from './data.js';
-import { renderLabelCanvas } from './render.js';
+import { renderLabelPng } from './render.js';
 import { buildShareUrl } from './url-state.js';
 
 async function copyLinkToClipboard(link) {
@@ -61,10 +61,11 @@ function formatTimestamp(date) {
 }
 
 export function downloadLabel() {
-  renderLabelCanvas()
-    .then(canvas => {
+  renderLabelPng()
+    .then(({ blob }) => {
       const link = document.createElement('a');
-      link.href = canvas.toDataURL('image/png');
+      const objectUrl = URL.createObjectURL(blob);
+      link.href = objectUrl;
       const fileParts = [];
       if (state.hardwareType === 'Fuse') {
         fileParts.push('Fuse');
@@ -150,6 +151,7 @@ export function downloadLabel() {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
     })
     .catch(err => {
       console.error('Label download failed', err);
@@ -201,14 +203,14 @@ export function printLabel() {
     img.style.maxHeight = 'none';
     img.style.imageRendering = 'pixelated';
   }
-  renderLabelCanvas()
-    .then(canvas => {
-      const dataUrl = canvas.toDataURL('image/png');
+  renderLabelPng()
+    .then(({ blob, widthPx, heightPx }) => {
       if (!(img instanceof HTMLImageElement)) {
         throw new Error('Print image element was not created.');
       }
-      img.setAttribute('width', String(canvas.width));
-      img.setAttribute('height', String(canvas.height));
+      const objectUrl = URL.createObjectURL(blob);
+      img.setAttribute('width', String(widthPx));
+      img.setAttribute('height', String(heightPx));
       const handleLoad = () => {
         if (printBody) {
           printBody.setAttribute('data-ready', 'true');
@@ -216,12 +218,20 @@ export function printLabel() {
         if (statusDiv) {
           statusDiv.textContent = 'Label ready – opening printer dialog…';
         }
+        URL.revokeObjectURL(objectUrl);
         printWindow.focus();
         printWindow.print();
         printWindow.close();
       };
       img.addEventListener('load', handleLoad, { once: true });
-      img.src = dataUrl;
+      img.addEventListener(
+        'error',
+        () => {
+          URL.revokeObjectURL(objectUrl);
+        },
+        { once: true },
+      );
+      img.src = objectUrl;
     })
     .catch(err => {
       console.error('Print preview generation failed', err);

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -68,6 +68,10 @@ const printAreaDisplay = document.getElementById('print-area-display');
 const previewContainer = document.getElementById('preview-container');
 const previewPlaceholder = document.getElementById('preview-placeholder');
 const previewStatusText = document.getElementById('preview-status-text');
+const labelSvg = document.getElementById('label-svg');
+const labelFrame = labelSvg ? labelSvg.querySelector('#label-frame') : null;
+const printableGroup = labelSvg ? labelSvg.querySelector('#printable') : null;
+const printableForeignObject = labelSvg ? labelSvg.querySelector('#printable-foreignObject') : null;
 const labelInner = document.getElementById('label-inner');
 const hardwareImageDiv = document.getElementById('hardware-image');
 const textBlockDiv = document.getElementById('preview-text');
@@ -168,6 +172,10 @@ export const elements = {
   previewContainer,
   previewPlaceholder,
   previewStatusText,
+  labelSvg,
+  labelFrame,
+  printableGroup,
+  printableForeignObject,
   labelInner,
   hardwareImageDiv,
   textBlockDiv,

--- a/js/lazy-loaders.js
+++ b/js/lazy-loaders.js
@@ -45,13 +45,6 @@ function loadScript(src, globalName) {
   return promise;
 }
 
-export function loadHtml2Canvas() {
-  return loadScript(
-    'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js',
-    'html2canvas',
-  );
-}
-
 export function loadQrCodeLibrary() {
   return loadScript('https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js', 'QRCode');
 }

--- a/js/render.js
+++ b/js/render.js
@@ -7,13 +7,17 @@ import {
   boltHeadMap,
   boltDriveMap,
 } from './data.js';
-import { loadHtml2Canvas, loadQrCodeLibrary } from './lazy-loaders.js';
+import { loadQrCodeLibrary } from './lazy-loaders.js';
 
 const {
   labelSizeDisplay,
   printAreaDisplay,
   previewContainer,
   labelInner,
+  labelSvg,
+  labelFrame,
+  printableGroup,
+  printableForeignObject,
   hardwareImageDiv,
   textBlockDiv,
   line1Div,
@@ -71,12 +75,86 @@ const {
 const HORIZONTAL_SAFE_MARGIN_PER_SIDE_MM = 2;
 const VERTICAL_SAFE_MARGIN_PER_SIDE_MM = 1;
 
+const SVG_XMLNS = 'http://www.w3.org/2000/svg';
+const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const EXPORT_DPI = 300;
+
 function computePrintableDimension(dimensionMm, marginPerSideMm) {
   if (!Number.isFinite(dimensionMm)) {
     return 0;
   }
   const marginTotalMm = marginPerSideMm * 2;
   return Math.max(0, dimensionMm - marginTotalMm);
+}
+
+function formatMillimeters(value) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  const rounded = Math.round(value * 10) / 10;
+  if (Math.abs(rounded - Math.round(rounded)) < 0.001) {
+    return String(Math.round(rounded));
+  }
+  return rounded.toFixed(1);
+}
+
+function getLabelGeometry() {
+  const rawWidth = Number.isFinite(state.widthMm) ? state.widthMm : 0;
+  const rawHeight = Number.isFinite(state.heightMm) ? state.heightMm : 0;
+  const labelWidthMm = Math.max(0, rawWidth);
+  const labelHeightMm = Math.max(0, rawHeight);
+  const printableWidthMm = computePrintableDimension(
+    labelWidthMm,
+    HORIZONTAL_SAFE_MARGIN_PER_SIDE_MM,
+  );
+  const printableHeightMm = computePrintableDimension(
+    labelHeightMm,
+    VERTICAL_SAFE_MARGIN_PER_SIDE_MM,
+  );
+  const marginX = Math.max(0, (labelWidthMm - printableWidthMm) / 2);
+  const marginY = Math.max(0, (labelHeightMm - printableHeightMm) / 2);
+  return {
+    labelWidthMm,
+    labelHeightMm,
+    printableWidthMm,
+    printableHeightMm,
+    marginX,
+    marginY,
+  };
+}
+
+function applySvgGeometryElements({ frame, group, foreignObject }, geometry) {
+  if (!geometry) {
+    return;
+  }
+  const { labelWidthMm, labelHeightMm, printableWidthMm, printableHeightMm, marginX, marginY } =
+    geometry;
+  if (frame) {
+    frame.setAttribute('x', '0');
+    frame.setAttribute('y', '0');
+    frame.setAttribute('width', String(labelWidthMm));
+    frame.setAttribute('height', String(labelHeightMm));
+  }
+  if (group) {
+    group.setAttribute('transform', `translate(${marginX} ${marginY})`);
+  }
+  if (foreignObject) {
+    foreignObject.setAttribute('x', '0');
+    foreignObject.setAttribute('y', '0');
+    foreignObject.setAttribute('width', String(printableWidthMm));
+    foreignObject.setAttribute('height', String(printableHeightMm));
+  }
+}
+
+function mmToPixelsAtDpi(mm, dpi = EXPORT_DPI) {
+  if (!Number.isFinite(mm) || !Number.isFinite(dpi)) {
+    return 0;
+  }
+  const raw = (mm * dpi) / 25.4;
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+  return Math.max(1, Math.round(raw));
 }
 
 let qrRenderRequestId = 0;
@@ -962,30 +1040,55 @@ export function updateQrContentVisibility(options = {}) {
 }
 
 export function updatePreview() {
-  if (!previewContainer || !labelInner || !labelSizeDisplay || !printAreaDisplay) {
+  if (
+    !previewContainer ||
+    !labelInner ||
+    !labelSizeDisplay ||
+    !printAreaDisplay ||
+    !labelSvg ||
+    !labelFrame ||
+    !printableGroup ||
+    !printableForeignObject
+  ) {
     return;
   }
-  const width = state.widthMm;
-  const height = state.heightMm;
-  const printableWidth = computePrintableDimension(width, HORIZONTAL_SAFE_MARGIN_PER_SIDE_MM);
-  const printableHeight = computePrintableDimension(height, VERTICAL_SAFE_MARGIN_PER_SIDE_MM);
-  labelSizeDisplay.innerHTML = `${width}&nbsp;mm ×&nbsp;${height}&nbsp;mm (label size)`;
-  printAreaDisplay.innerHTML = `${printableWidth}&nbsp;mm ×&nbsp;${printableHeight}&nbsp;mm (printable area)`;
-  const safeWidthMm = Number.isFinite(width) && width > 0 ? width : 1;
-  const safeHeightMm = Number.isFinite(height) && height > 0 ? height : 1;
+
+  const geometry = getLabelGeometry();
+  const { labelWidthMm, labelHeightMm, printableWidthMm, printableHeightMm } = geometry;
+
+  labelSizeDisplay.textContent = `${formatMillimeters(labelWidthMm)} × ${formatMillimeters(
+    labelHeightMm,
+  )} mm (label size)`;
+  printAreaDisplay.textContent = `${formatMillimeters(printableWidthMm)} × ${formatMillimeters(
+    printableHeightMm,
+  )} mm (printable area)`;
+
+  const safeWidthMm = labelWidthMm > 0 ? labelWidthMm : 1;
+  const safeHeightMm = labelHeightMm > 0 ? labelHeightMm : 1;
   document.documentElement.style.setProperty('--label-width-mm', `${safeWidthMm}mm`);
   document.documentElement.style.setProperty('--label-height-mm', `${safeHeightMm}mm`);
-  const pxWidth = width * pxPerMm;
-  const pxHeight = height * pxPerMm;
-  previewContainer.style.width = pxWidth + 'px';
-  previewContainer.style.height = pxHeight + 'px';
-  const innerWidthPx = pxWidth;
-  const innerHeightPx = pxHeight;
+
+  const labelWidthPx = Math.max(1, Math.round(labelWidthMm * pxPerMm));
+  const labelHeightPx = Math.max(1, Math.round(labelHeightMm * pxPerMm));
+  previewContainer.style.width = labelWidthPx + 'px';
+  previewContainer.style.height = labelHeightPx + 'px';
+
+  labelSvg.setAttribute('viewBox', `0 0 ${labelWidthMm} ${labelHeightMm}`);
+  labelSvg.style.width = labelWidthPx + 'px';
+  labelSvg.style.height = labelHeightPx + 'px';
+  applySvgGeometryElements(
+    { frame: labelFrame, group: printableGroup, foreignObject: printableForeignObject },
+    geometry,
+  );
+
+  const innerWidthPx = Math.max(1, Math.round(printableWidthMm * pxPerMm));
+  const innerHeightPx = Math.max(1, Math.round(printableHeightMm * pxPerMm));
   labelInner.style.width = innerWidthPx + 'px';
   labelInner.style.height = innerHeightPx + 'px';
-  labelInner.style.left = '0px';
-  labelInner.style.top = '0px';
-  const readyForPreview = isLabelReady();
+
+  const printableValid = printableWidthMm > 0 && printableHeightMm > 0;
+  const readyForPreview = printableValid && isLabelReady();
+  labelSvg.setAttribute('aria-hidden', readyForPreview ? 'false' : 'true');
 
   if (!readyForPreview) {
     if (previewPlaceholder) {
@@ -1036,8 +1139,8 @@ export function updatePreview() {
   }
   labelInner.style.display = 'flex';
   const mmToPx = mm => Math.max(0, Math.round(mm * pxPerMm));
-  const widthMm = Number.isFinite(width) ? width : 0;
-  const heightMm = Number.isFinite(height) ? height : 0;
+  const widthMm = labelWidthMm;
+  const heightMm = labelHeightMm;
   const longestEdgeMm = Math.max(widthMm, heightMm, 0);
   const baseScale = Math.sqrt(Math.max(longestEdgeMm, 1) / 40);
   const paddingScale = Math.max(1, Math.min(baseScale, 1.35));
@@ -1611,72 +1714,246 @@ export function updatePreview() {
   announcePreviewStatus('Preview updated.');
 }
 
-export async function renderLabelCanvas() {
-  if (!previewContainer || !labelInner) {
-    throw new Error('Label preview is not available.');
+async function ensureFontsReady() {
+  if (typeof document === 'undefined' || !document.fonts || !document.fonts.ready) {
+    return;
   }
-
-  const labelWidthMm = state.widthMm;
-  const labelHeightMm = state.heightMm;
-  const exportDpi = 300;
-  const pixelsPerMmAtExportDpi = exportDpi / 25.4;
-  const scale = pixelsPerMmAtExportDpi / pxPerMm;
-
-  const containerWidth = previewContainer.offsetWidth || previewContainer.clientWidth;
-  const containerHeight = previewContainer.offsetHeight || previewContainer.clientHeight;
-  if (!containerWidth || !containerHeight) {
-    throw new Error('Label preview has no measurable size.');
+  try {
+    await document.fonts.ready;
+  } catch (error) {
+    console.warn('Unable to verify font readiness before export.', error);
   }
-
-  const html2canvas = await loadHtml2Canvas();
-  const canvas = await html2canvas(previewContainer, {
-    backgroundColor: null,
-    scale,
-    width: containerWidth,
-    height: containerHeight,
-    scrollX: 0,
-    scrollY: 0,
-  });
-
-  const containerRect = previewContainer.getBoundingClientRect();
-  const innerRect = labelInner.getBoundingClientRect();
-  const ratioX = canvas.width / containerWidth;
-  const ratioY = canvas.height / containerHeight;
-  const cropX = Math.max(0, Math.floor((innerRect.left - containerRect.left) * ratioX));
-  const cropY = Math.max(0, Math.floor((innerRect.top - containerRect.top) * ratioY));
-  const cropWidth = Math.max(1, Math.ceil(innerRect.width * ratioX));
-  const cropHeight = Math.max(1, Math.ceil(innerRect.height * ratioY));
-  const sourceWidth = Math.min(cropWidth, canvas.width - cropX);
-  const sourceHeight = Math.min(cropHeight, canvas.height - cropY);
-
-  if (sourceWidth <= 0 || sourceHeight <= 0) {
-    throw new Error('Computed label dimensions are invalid.');
-  }
-
-  const outputCanvas = document.createElement('canvas');
-  const targetWidthPx = Math.max(1, Math.round(labelWidthMm * pixelsPerMmAtExportDpi));
-  const targetHeightPx = Math.max(1, Math.round(labelHeightMm * pixelsPerMmAtExportDpi));
-  outputCanvas.width = targetWidthPx;
-  outputCanvas.height = targetHeightPx;
-  const ctx = outputCanvas.getContext('2d');
-  if (ctx) {
-    ctx.drawImage(
-      canvas,
-      cropX,
-      cropY,
-      sourceWidth,
-      sourceHeight,
-      0,
-      0,
-      outputCanvas.width,
-      outputCanvas.height,
-    );
-  }
-  return outputCanvas;
 }
 
-export async function renderLabelBlob(type = 'image/png', quality) {
-  const canvas = await renderLabelCanvas();
+async function ensureImageLoaded(image) {
+  if (!(image instanceof HTMLImageElement)) {
+    return;
+  }
+  if (image.complete && image.naturalWidth > 0 && image.naturalHeight > 0) {
+    return;
+  }
+  await new Promise((resolve, reject) => {
+    const handleLoad = () => {
+      resolve();
+    };
+    const handleError = () => {
+      reject(new Error('Image failed to load.'));
+    };
+    image.addEventListener('load', handleLoad, { once: true });
+    image.addEventListener('error', handleError, { once: true });
+  });
+}
+
+async function imageElementToDataUrl(image) {
+  if (!(image instanceof HTMLImageElement)) {
+    return '';
+  }
+  const src = image.currentSrc || image.src;
+  if (!src) {
+    return '';
+  }
+  if (src.startsWith('data:')) {
+    return src;
+  }
+  try {
+    await ensureImageLoaded(image);
+  } catch (error) {
+    console.warn('Image asset could not be fully loaded for export.', error);
+  }
+  const width = image.naturalWidth || image.width || 0;
+  const height = image.naturalHeight || image.height || 0;
+  if (!width || !height) {
+    return '';
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return '';
+  }
+  try {
+    ctx.drawImage(image, 0, 0, width, height);
+    return canvas.toDataURL('image/png');
+  } catch (error) {
+    console.error('Failed to inline image asset for export.', error);
+    return '';
+  }
+}
+
+function getComputedStyleText(element) {
+  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+    return '';
+  }
+  const computed = window.getComputedStyle(element);
+  if (!computed) {
+    return '';
+  }
+  const declarations = [];
+  for (let i = 0; i < computed.length; i += 1) {
+    const property = computed[i];
+    const value = computed.getPropertyValue(property);
+    if (value) {
+      declarations.push(`${property}:${value};`);
+    }
+  }
+  return declarations.join('');
+}
+
+async function inlineStylesAndAssets(sourceNode, targetNode) {
+  if (!(sourceNode instanceof Element) || !(targetNode instanceof Element)) {
+    return;
+  }
+
+  const styleText = getComputedStyleText(sourceNode);
+  if (styleText) {
+    targetNode.setAttribute('style', styleText);
+  } else {
+    targetNode.removeAttribute('style');
+  }
+
+  if (sourceNode instanceof HTMLCanvasElement) {
+    const doc = targetNode.ownerDocument;
+    if (!doc) {
+      return;
+    }
+    const replacement = doc.createElementNS(XHTML_NAMESPACE, 'img');
+    replacement.setAttribute('src', sourceNode.toDataURL('image/png'));
+    replacement.setAttribute('width', String(sourceNode.width));
+    replacement.setAttribute('height', String(sourceNode.height));
+    if (styleText) {
+      replacement.setAttribute('style', styleText);
+    }
+    if (targetNode.getAttribute('class')) {
+      replacement.setAttribute('class', targetNode.getAttribute('class'));
+    }
+    const altText =
+      sourceNode.getAttribute('aria-label') ||
+      targetNode.getAttribute('alt') ||
+      targetNode.id ||
+      '';
+    if (altText) {
+      replacement.setAttribute('alt', altText);
+    }
+    targetNode.replaceWith(replacement);
+    return;
+  }
+
+  if (sourceNode instanceof HTMLImageElement) {
+    const dataUrl = await imageElementToDataUrl(sourceNode);
+    if (dataUrl) {
+      targetNode.setAttribute('src', dataUrl);
+    }
+    if (sourceNode.getAttribute('alt')) {
+      targetNode.setAttribute('alt', sourceNode.getAttribute('alt'));
+    }
+  }
+
+  const sourceChildren = Array.from(sourceNode.children || []);
+  const targetChildren = Array.from(targetNode.children || []);
+  const limit = Math.min(sourceChildren.length, targetChildren.length);
+  for (let i = 0; i < limit; i += 1) {
+    await inlineStylesAndAssets(sourceChildren[i], targetChildren[i]);
+  }
+}
+
+async function createPrintableSvgClone() {
+  if (!labelSvg) {
+    throw new Error('Label preview is not available.');
+  }
+  const geometry = getLabelGeometry();
+  const { printableWidthMm, printableHeightMm } = geometry;
+  if (!(printableWidthMm > 0 && printableHeightMm > 0)) {
+    throw new Error('Printable area is not defined.');
+  }
+
+  const clone = labelSvg.cloneNode(true);
+  clone.removeAttribute('style');
+  applySvgGeometryElements(
+    {
+      frame: clone.querySelector('#label-frame'),
+      group: clone.querySelector('#printable'),
+      foreignObject: clone.querySelector('#printable-foreignObject'),
+    },
+    geometry,
+  );
+
+  const sourceInner = printableForeignObject
+    ? printableForeignObject.querySelector('#label-inner')
+    : null;
+  const cloneInner = clone.querySelector('#printable-foreignObject #label-inner');
+  if (!sourceInner || !cloneInner) {
+    throw new Error('Printable content is missing.');
+  }
+  await inlineStylesAndAssets(sourceInner, cloneInner);
+
+  clone.setAttribute('xmlns', SVG_XMLNS);
+  clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+  return { clone, geometry };
+}
+
+function serializeSvgElement(svgElement) {
+  if (typeof XMLSerializer === 'undefined') {
+    throw new Error('SVG serialization is not supported in this environment.');
+  }
+  return new XMLSerializer().serializeToString(svgElement);
+}
+
+async function createPrintableSvgMarkup() {
+  await ensureFontsReady();
+  const { clone, geometry } = await createPrintableSvgClone();
+  const { printableWidthMm, printableHeightMm, marginX, marginY } = geometry;
+
+  const frame = clone.querySelector('#label-frame');
+  if (frame && frame.parentNode) {
+    frame.parentNode.removeChild(frame);
+  }
+
+  clone.setAttribute('viewBox', `${marginX} ${marginY} ${printableWidthMm} ${printableHeightMm}`);
+  const widthPx = mmToPixelsAtDpi(printableWidthMm, EXPORT_DPI);
+  const heightPx = mmToPixelsAtDpi(printableHeightMm, EXPORT_DPI);
+  clone.setAttribute('width', String(widthPx));
+  clone.setAttribute('height', String(heightPx));
+  clone.removeAttribute('aria-hidden');
+
+  const markup = serializeSvgElement(clone);
+  return { markup, geometry, widthPx, heightPx };
+}
+
+async function rasterizeSvgMarkup(markup, widthPx, heightPx) {
+  const blob = new Blob([markup], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const image = new Image();
+    image.decoding = 'async';
+    image.crossOrigin = 'anonymous';
+    const imagePromise = new Promise((resolve, reject) => {
+      image.addEventListener('load', resolve, { once: true });
+      image.addEventListener('error', () => reject(new Error('Failed to load SVG image.')), {
+        once: true,
+      });
+    });
+    image.width = widthPx;
+    image.height = heightPx;
+    image.src = url;
+    await imagePromise;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = widthPx;
+    canvas.height = heightPx;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Unable to obtain a 2D canvas context for export.');
+    }
+    ctx.clearRect(0, 0, widthPx, heightPx);
+    ctx.drawImage(image, 0, 0, widthPx, heightPx);
+    return canvas;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function canvasToBlob(canvas, type = 'image/png', quality) {
   if (typeof canvas.toBlob === 'function') {
     return new Promise((resolve, reject) => {
       canvas.toBlob(
@@ -1694,11 +1971,31 @@ export async function renderLabelBlob(type = 'image/png', quality) {
   }
 
   const dataUrl = canvas.toDataURL(type, quality);
-  const byteString = atob(dataUrl.split(',')[1] || '');
-  const mimeType = dataUrl.split(';')[0].split(':')[1] || type;
-  const buffer = new Uint8Array(byteString.length);
-  for (let i = 0; i < byteString.length; i += 1) {
-    buffer[i] = byteString.charCodeAt(i);
+  const base64 = dataUrl.split(',')[1] || '';
+  const binary = atob(base64);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    buffer[i] = binary.charCodeAt(i);
   }
-  return new Blob([buffer], { type: mimeType });
+  const mimeType = dataUrl.split(';')[0].split(':')[1] || type;
+  return Promise.resolve(new Blob([buffer], { type: mimeType }));
+}
+
+export async function renderLabelPng() {
+  const { markup, geometry, widthPx, heightPx } = await createPrintableSvgMarkup();
+  const canvas = await rasterizeSvgMarkup(markup, widthPx, heightPx);
+  const blob = await canvasToBlob(canvas, 'image/png');
+  return {
+    blob,
+    widthPx,
+    heightPx,
+    printableWidthMm: geometry.printableWidthMm,
+    printableHeightMm: geometry.printableHeightMm,
+    svgMarkup: markup,
+  };
+}
+
+export async function renderLabelSvgMarkup() {
+  const { markup } = await createPrintableSvgMarkup();
+  return markup;
 }

--- a/print.css
+++ b/print.css
@@ -108,6 +108,7 @@ body.print-window[data-ready='true'] .print-status {
   .preview-section,
   .label-preview,
   #preview-container,
+  #label-svg,
   #label-inner {
     width: var(--label-width-mm) !important;
     height: var(--label-height-mm) !important;

--- a/style-print.css
+++ b/style-print.css
@@ -59,10 +59,10 @@
     content: none !important;
   }
 
+  #label-svg,
   #label-inner {
     width: var(--label-width-mm) !important;
     height: var(--label-height-mm) !important;
-    inset: 0 !important;
     border: 0 !important;
     border-radius: 0 !important;
     box-shadow: none !important;

--- a/style.css
+++ b/style.css
@@ -203,6 +203,19 @@ main {
   z-index: 1;
 }
 
+.label-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.label-frame {
+  fill: #ffffff;
+  stroke: rgba(100, 116, 139, 0.6);
+  stroke-width: 0.25;
+  vector-effect: non-scaling-stroke;
+}
+
 .preview-placeholder {
   position: absolute;
   inset: 0;
@@ -361,8 +374,9 @@ main {
 }
 
 .label-inner {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   gap: var(--label-gap, 12px);


### PR DESCRIPTION
## Summary
- replace the preview markup with an SVG wrapper that exposes the printable area and outer frame in millimetres
- add an SVG-based export pipeline that inlines styles/assets, clones the preview, and rasterizes the printable region at 300 DPI
- update download/print actions, styles, and docs to use the new renderer instead of html2canvas

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d23b5d3a848329b188433e0ffdd26c