### PR TITLE
Improve bolt imagery scaling across label sizes

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -160,7 +160,10 @@ function applySvgGeometryElements({ frame, group, foreignObject }, geometry) {
   }
 
   if (group) {
-    group.setAttribute('transform', `translate(${formatNumber(marginXPx)} ${formatNumber(marginYPx)})`);
+    group.setAttribute(
+      'transform',
+      `translate(${formatNumber(marginXPx)} ${formatNumber(marginYPx)})`,
+    );
   }
 
   if (foreignObject) {
@@ -403,8 +406,8 @@ function deriveTrimmedSvgMarkup(svgText) {
   ) {
     return null;
   }
-  const marginRatio = 0.08;
-  const preserveWhitespaceFraction = 0.8;
+  const marginRatio = 0.02;
+  const preserveWhitespaceFraction = 0.6;
   let marginX = bbox.width * marginRatio;
   let marginY = bbox.height * marginRatio;
   if (originalBounds) {
@@ -1240,7 +1243,7 @@ export function updatePreview() {
       if (photoInfo && innerHeightPx > 0 && innerWidthPx > 0) {
         let maxWidthForPhoto = Math.max(0, Math.min(innerHeightPx, innerWidthPx * 0.45));
         if (photoInfo.type === 'boltSvg') {
-          const boltPreferredWidth = Math.max(0, Math.min(innerHeightPx * 1.4, innerWidthPx * 0.6));
+          const boltPreferredWidth = Math.max(0, Math.min(innerHeightPx * 2.4, innerWidthPx * 0.7));
           maxWidthForPhoto = Math.max(maxWidthForPhoto, boltPreferredWidth);
         } else {
           const photoPreferredWidth = Math.max(
@@ -1249,6 +1252,7 @@ export function updatePreview() {
           );
           maxWidthForPhoto = Math.max(maxWidthForPhoto, photoPreferredWidth);
         }
+        maxWidthForPhoto = Math.min(maxWidthForPhoto, innerWidthPx);
         if (maxWidthForPhoto > 0) {
           hardwareImageDiv.style.display = 'flex';
           hardwareImageDiv.style.flexShrink = '0';
@@ -1269,6 +1273,7 @@ export function updatePreview() {
             boltGroup.className = 'bolt-image-group';
             const innerHeightValue = innerHeightPx + 'px';
             boltGroup.style.maxHeight = innerHeightValue;
+            boltGroup.style.height = innerHeightValue;
             hardwareImageDiv.appendChild(boltGroup);
             const boltImages = [
               {
@@ -1684,7 +1689,7 @@ export function updatePreview() {
     ? Math.max(minPaddingBasePx, desiredQrEdgeClearancePx)
     : minPaddingBasePx;
   const minPaddingRightPx = Math.max(2, Math.min(paddingRightPx, minPaddingRightTargetPx));
-  const minTextWidthPx = Math.max(mmToPx(10), Math.floor(innerHeightPx * 1.45));
+  const minTextWidthPx = Math.max(mmToPx(9), Math.floor(innerHeightPx * 1.2));
 
   const computeAvailableTextWidth = () => {
     const effectiveRightPadding = qrVisible
@@ -1878,8 +1883,11 @@ function captureLayoutFromDom() {
     };
   };
 
-  const textLines = [collectTextLine(line1Div), collectTextLine(line2Div), collectTextLine(line3Div)]
-    .filter(Boolean);
+  const textLines = [
+    collectTextLine(line1Div),
+    collectTextLine(line2Div),
+    collectTextLine(line3Div),
+  ].filter(Boolean);
 
   let qr = null;
   if (qrCanvas && qrCanvas.style.display !== 'none') {
@@ -1953,7 +1961,13 @@ async function renderLayoutToCanvas(layout) {
   for (const image of layout.hardwareImages) {
     try {
       const img = await loadImage(image.src);
-      ctx.drawImage(img, image.xPx + offsetXPx, image.yPx + offsetYPx, image.widthPx, image.heightPx);
+      ctx.drawImage(
+        img,
+        image.xPx + offsetXPx,
+        image.yPx + offsetYPx,
+        image.widthPx,
+        image.heightPx,
+      );
     } catch (error) {
       console.warn('Hardware image could not be rendered for export.', error);
     }

--- a/style.css
+++ b/style.css
@@ -260,9 +260,18 @@ main {
   box-shadow: none;
 }
 
+.label-inner.has-hardware-image .hardware-icon {
+  align-self: stretch;
+  height: calc(100% + var(--label-padding-y) * 2);
+}
+
 .label-inner.has-hardware-image .hardware-icon:not(:empty) {
   margin-inline-start: calc(-1 * var(--label-padding-inline-start));
   margin-left: calc(-1 * var(--label-padding-inline-start));
+  margin-block-start: calc(-1 * var(--label-padding-y));
+  margin-block-end: calc(-1 * var(--label-padding-y));
+  margin-top: calc(-1 * var(--label-padding-y));
+  margin-bottom: calc(-1 * var(--label-padding-y));
   justify-content: flex-start;
 }
 
@@ -297,6 +306,7 @@ main {
   justify-content: center;
   gap: 0.75rem;
   max-height: 100%;
+  height: 100%;
   width: 100%;
 }
 
@@ -345,7 +355,8 @@ main {
   align-items: flex-start;
   min-width: 0;
   white-space: normal;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
   flex: 1;
   gap: 0.2em;
 }


### PR DESCRIPTION
## Summary
- tighten the SVG trimming margins so bolt icons use more of the printable area
- expand bolt image layout calculations and stretching styles so drive and head views render at full height for different label sizes
- refine text block wrapping to avoid mid-word breaks while keeping hardware art vertically centered

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d295d4062483299da0541d072a8928