### PR TITLE
Ensure iOS shows numeric keyboard for length input

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,6 +381,7 @@
                       class="form-control"
                       placeholder="e.g., 10"
                       min="1"
+                      inputmode="decimal"
                       aria-describedby="length-message"
                     />
                     <div


### PR DESCRIPTION
## Summary
- add a decimal input mode to the length field so iOS devices display the numeric keypad

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a19e0c9883298076049904ed5254