### PR TITLE
Fix mobile preview overflow by scaling within viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,47 +700,49 @@
             <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
             <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
           </div>
-          <div id="preview-container" class="label-preview">
-            <div id="preview-placeholder" class="preview-placeholder">
-              <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
-              <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
-            </div>
-            <svg
-              id="label-svg"
-              class="label-svg"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 55 12"
-              aria-hidden="true"
-            >
-              <rect
-                id="label-frame"
-                class="label-frame"
-                x="0"
-                y="0"
-                width="55"
-                height="12"
-                rx="0"
-                ry="0"
-              ></rect>
-              <g id="printable" transform="translate(2,1)">
-                <foreignObject id="printable-foreignObject" x="0" y="0" width="51" height="10">
-                  <div
-                    xmlns="http://www.w3.org/1999/xhtml"
-                    id="label-inner"
-                    class="label-inner"
-                    style="display: none"
-                  >
-                    <div id="hardware-image" class="hardware-icon"></div>
-                    <div id="preview-text" class="text-block">
-                      <div id="line1" class="text-line"></div>
-                      <div id="line2" class="text-line small"></div>
-                      <div id="line3" class="text-line small"></div>
+          <div class="label-preview-viewport">
+            <div id="preview-container" class="label-preview">
+              <div id="preview-placeholder" class="preview-placeholder">
+                <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
+                <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
+              </div>
+              <svg
+                id="label-svg"
+                class="label-svg"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 55 12"
+                aria-hidden="true"
+              >
+                <rect
+                  id="label-frame"
+                  class="label-frame"
+                  x="0"
+                  y="0"
+                  width="55"
+                  height="12"
+                  rx="0"
+                  ry="0"
+                ></rect>
+                <g id="printable" transform="translate(2,1)">
+                  <foreignObject id="printable-foreignObject" x="0" y="0" width="51" height="10">
+                    <div
+                      xmlns="http://www.w3.org/1999/xhtml"
+                      id="label-inner"
+                      class="label-inner"
+                      style="display: none"
+                    >
+                      <div id="hardware-image" class="hardware-icon"></div>
+                      <div id="preview-text" class="text-block">
+                        <div id="line1" class="text-line"></div>
+                        <div id="line2" class="text-line small"></div>
+                        <div id="line3" class="text-line small"></div>
+                      </div>
+                      <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
                     </div>
-                    <canvas id="qr-canvas" class="qr-code" width="80" height="80"></canvas>
-                  </div>
-                </foreignObject>
-              </g>
-            </svg>
+                  </foreignObject>
+                </g>
+              </svg>
+            </div>
           </div>
         </div>
       </section>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -66,6 +66,7 @@ const widthValueSpan = document.getElementById('width-value');
 const labelSizeDisplay = document.getElementById('label-size-display');
 const printAreaDisplay = document.getElementById('print-area-display');
 const previewContainer = document.getElementById('preview-container');
+const previewViewport = previewContainer ? previewContainer.parentElement : null;
 const previewPlaceholder = document.getElementById('preview-placeholder');
 const previewStatusText = document.getElementById('preview-status-text');
 const labelSvg = document.getElementById('label-svg');
@@ -169,6 +170,7 @@ export const elements = {
   widthValueSpan,
   labelSizeDisplay,
   printAreaDisplay,
+  previewViewport,
   previewContainer,
   previewPlaceholder,
   previewStatusText,

--- a/js/render.js
+++ b/js/render.js
@@ -12,6 +12,7 @@ import { loadQrCodeLibrary } from './lazy-loaders.js';
 const {
   labelSizeDisplay,
   printAreaDisplay,
+  previewViewport,
   previewContainer,
   labelInner,
   labelSvg,
@@ -68,6 +69,91 @@ const {
   customLine1Message,
   formStatusMessage,
 } = elements;
+
+const previewDimensions = {
+  width: 0,
+  height: 0,
+};
+
+let previewResizeObserver = null;
+
+function applyPreviewScale() {
+  if (!previewContainer) {
+    return;
+  }
+
+  const viewport = previewViewport || (previewContainer ? previewContainer.parentElement : null);
+  if (!viewport) {
+    return;
+  }
+
+  const { width, height } = previewDimensions;
+  if (!(width > 0) || !(height > 0)) {
+    viewport.classList.remove('label-preview-viewport--scaled');
+    viewport.style.removeProperty('height');
+    previewContainer.style.removeProperty('transform');
+    previewContainer.style.removeProperty('transform-origin');
+    previewContainer.style.removeProperty('position');
+    previewContainer.style.removeProperty('left');
+    previewContainer.style.removeProperty('top');
+    previewContainer.style.removeProperty('margin');
+    return;
+  }
+
+  const availableWidth = viewport.clientWidth || viewport.getBoundingClientRect().width;
+  if (!(availableWidth > 0)) {
+    return;
+  }
+
+  const scale = Math.min(1, availableWidth / width);
+  const isScaled = scale < 0.999;
+
+  if (isScaled) {
+    const scaledHeight = Math.max(1, Math.round(height * scale));
+    viewport.classList.add('label-preview-viewport--scaled');
+    viewport.style.height = `${scaledHeight}px`;
+    previewContainer.style.transformOrigin = 'top center';
+    previewContainer.style.transform = `translateX(-50%) scale(${scale})`;
+    previewContainer.style.position = 'absolute';
+    previewContainer.style.left = '50%';
+    previewContainer.style.top = '0';
+    previewContainer.style.margin = '0';
+  } else {
+    viewport.classList.remove('label-preview-viewport--scaled');
+    viewport.style.removeProperty('height');
+    previewContainer.style.removeProperty('transform');
+    previewContainer.style.removeProperty('transform-origin');
+    previewContainer.style.removeProperty('position');
+    previewContainer.style.removeProperty('left');
+    previewContainer.style.removeProperty('top');
+    previewContainer.style.removeProperty('margin');
+  }
+}
+
+function setupPreviewResizeHandling() {
+  if (!previewContainer) {
+    return;
+  }
+
+  const viewport = previewViewport || previewContainer.parentElement;
+  if (!viewport) {
+    return;
+  }
+
+  if (typeof ResizeObserver !== 'undefined') {
+    if (previewResizeObserver) {
+      previewResizeObserver.disconnect();
+    }
+    previewResizeObserver = new ResizeObserver(() => {
+      applyPreviewScale();
+    });
+    previewResizeObserver.observe(viewport);
+  } else if (typeof window !== 'undefined') {
+    window.addEventListener('resize', applyPreviewScale);
+  }
+}
+
+setupPreviewResizeHandling();
 
 // Derived from the hardware label spec: a 37 × 12 mm label yields a 33 × 10 mm
 // printable area, implying 2 mm horizontal and 1 mm vertical safe margins per
@@ -1103,6 +1189,9 @@ export function updatePreview() {
   const labelHeightPx = Math.max(1, Math.round(labelHeightMm * pxPerMm));
   previewContainer.style.width = labelWidthPx + 'px';
   previewContainer.style.height = labelHeightPx + 'px';
+  previewDimensions.width = labelWidthPx;
+  previewDimensions.height = labelHeightPx;
+  applyPreviewScale();
 
   labelSvg.setAttribute('viewBox', `0 0 ${labelWidthPx} ${labelHeightPx}`);
   labelSvg.style.width = labelWidthPx + 'px';

--- a/style.css
+++ b/style.css
@@ -173,6 +173,21 @@ main {
   gap: 0.75rem;
 }
 
+.label-preview-viewport {
+  position: relative;
+  width: 100%;
+}
+
+.label-preview-viewport--scaled {
+  overflow: hidden;
+}
+
+.label-preview-viewport--scaled .label-preview {
+  position: absolute;
+  left: 50%;
+  top: 0;
+}
+
 .label-preview {
   position: relative;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- wrap the label preview markup in a viewport container that can constrain the preview on small screens
- add responsive scaling logic and styles so the preview fits the available width without disturbing export geometry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a4faf04c8329a7c2a43ee77d46f9