### PR TITLE
Ensure preview secondary lines stay on one line

### DIFF
--- a/style.css
+++ b/style.css
@@ -391,6 +391,9 @@ main {
   font-weight: 600;
   letter-spacing: 0.08em;
   color: #000000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .qr-code {


### PR DESCRIPTION
## Summary
- prevent the secondary preview lines from wrapping by applying no-wrap and overflow handling to `.text-line.small`, keeping the preview aligned with the export rendering

## Testing
- npm run lint
- Manually generated a "Socket Cap" bolt label in the browser preview to confirm secondary text stays on one line and matches the exported markup

------
https://chatgpt.com/codex/tasks/task_e_68d3eeba33488329ad3efa0156c5423f