### PR TITLE
Add interactive bolt drive picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,40 @@
                   <div id="bolt-standard-group" class="row g-3 d-none" aria-hidden="true">
                     <div id="bolt-drive-field" class="col-12 col-sm-6 thread-length-field">
                       <label for="bolt-drive-select" class="form-label fw-semibold">Drive</label>
-                      <select id="bolt-drive-select" class="form-select"></select>
+                      <div class="bolt-drive-picker" id="bolt-drive-picker">
+                        <select id="bolt-drive-select" class="visually-hidden"></select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="bolt-drive-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="bolt-drive-picker-list"
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span
+                              class="bolt-drive-picker__current-icon"
+                              aria-hidden="true"
+                            >
+                              <img
+                                src=""
+                                alt=""
+                                class="bolt-drive-picker__current-icon-image"
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">Select drive…</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="bolt-drive-picker-list"
+                          role="listbox"
+                          aria-labelledby="bolt-drive-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
                       <div
                         id="bolt-drive-message"
                         class="validation-message text-danger small mt-2 d-none"

--- a/js/controls.js
+++ b/js/controls.js
@@ -7,6 +7,7 @@ import {
   populateBearingOptions,
   updateCustomImageUi,
   onHardwareTypeChange,
+  setBoltDriveSelection,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
@@ -26,7 +27,6 @@ function applyStateToControls() {
     customLine2Input,
     standardSelect,
     boltHeadSelect,
-    boltDriveSelect,
     standardToggle,
     imageToggle,
     qrcodeToggle,
@@ -91,9 +91,7 @@ function applyStateToControls() {
   if (boltHeadSelect) {
     boltHeadSelect.value = state.boltHead || '';
   }
-  if (boltDriveSelect) {
-    boltDriveSelect.value = state.boltDrive || '';
-  }
+  setBoltDriveSelection(state.boltDrive || '', { triggerUpdate: false });
   if (standardToggle) {
     standardToggle.checked = state.showStandard;
   }

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -48,6 +48,9 @@ const standardFieldLabel = document.getElementById('standard-field-label');
 const boltStandardGroup = document.getElementById('bolt-standard-group');
 const boltHeadField = document.getElementById('bolt-head-field');
 const boltDriveField = document.getElementById('bolt-drive-field');
+const boltDrivePicker = document.getElementById('bolt-drive-picker');
+const boltDrivePickerButton = document.getElementById('bolt-drive-picker-button');
+const boltDrivePickerList = document.getElementById('bolt-drive-picker-list');
 const boltHeadSelect = document.getElementById('bolt-head-select');
 const boltDriveSelect = document.getElementById('bolt-drive-select');
 const boltHeadMessage = document.getElementById('bolt-head-message');
@@ -153,6 +156,9 @@ export const elements = {
   boltStandardGroup,
   boltHeadField,
   boltDriveField,
+  boltDrivePicker,
+  boltDrivePickerButton,
+  boltDrivePickerList,
   boltHeadSelect,
   boltDriveSelect,
   boltHeadMessage,

--- a/js/events.js
+++ b/js/events.js
@@ -10,6 +10,8 @@ import {
   clearCustomImage,
   handleStandardSelectKeydown,
   clearStandardFilter,
+  setBoltDriveSelection,
+  syncBoltDrivePicker,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -36,6 +38,9 @@ const {
   customImageClearButton,
   boltHeadSelect,
   boltDriveSelect,
+  boltDrivePicker,
+  boltDrivePickerButton,
+  boltDrivePickerList,
   standardSelect,
   standardToggle,
   imageToggle,
@@ -48,6 +53,243 @@ const {
   shareButton,
   printButton,
 } = elements;
+
+let boltDrivePickerOpen = false;
+
+function getBoltDriveOptionElements() {
+  if (!boltDrivePickerList) {
+    return [];
+  }
+  return Array.from(boltDrivePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusBoltDriveOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getBoltDriveOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openBoltDrivePicker() {
+  if (!boltDrivePicker || !boltDrivePickerButton || !boltDrivePickerList) {
+    return;
+  }
+  if (boltDrivePickerButton.disabled) {
+    return;
+  }
+  if (boltDrivePickerOpen) {
+    return;
+  }
+  boltDrivePickerOpen = true;
+  boltDrivePicker.classList.add('is-open');
+  boltDrivePickerList.hidden = false;
+  boltDrivePickerButton.setAttribute('aria-expanded', 'true');
+  syncBoltDrivePicker({ isValid: true });
+
+  const options = getBoltDriveOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusBoltDriveOption(selectedOption || options[0]);
+}
+
+function closeBoltDrivePicker({ focusButton = false } = {}) {
+  if (!boltDrivePicker || !boltDrivePickerButton || !boltDrivePickerList) {
+    return;
+  }
+  if (!boltDrivePickerOpen) {
+    if (focusButton && !boltDrivePickerButton.disabled) {
+      boltDrivePickerButton.focus();
+    }
+    return;
+  }
+  boltDrivePickerOpen = false;
+  boltDrivePicker.classList.remove('is-open');
+  boltDrivePickerList.hidden = true;
+  boltDrivePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !boltDrivePickerButton.disabled) {
+    boltDrivePickerButton.focus();
+  }
+}
+
+function toggleBoltDrivePicker() {
+  if (boltDrivePickerOpen) {
+    closeBoltDrivePicker({ focusButton: false });
+  } else {
+    openBoltDrivePicker();
+  }
+}
+
+function moveBoltDriveOption(delta) {
+  if (!boltDrivePickerList) {
+    return;
+  }
+  const options = getBoltDriveOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && boltDrivePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusBoltDriveOption(nextOption);
+  }
+}
+
+function handleBoltDriveButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openBoltDrivePicker();
+    moveBoltDriveOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openBoltDrivePicker();
+    moveBoltDriveOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleBoltDrivePicker();
+    return;
+  }
+  if (key === 'Escape' && boltDrivePickerOpen) {
+    event.preventDefault();
+    closeBoltDrivePicker({ focusButton: true });
+  }
+}
+
+function handleBoltDriveListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveBoltDriveOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveBoltDriveOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getBoltDriveOptionElements();
+    if (options.length > 0) {
+      focusBoltDriveOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getBoltDriveOptionElements();
+    if (options.length > 0) {
+      focusBoltDriveOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setBoltDriveSelection(option.dataset.value || '');
+        closeBoltDrivePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeBoltDrivePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeBoltDrivePicker();
+  }
+}
+
+function handleBoltDriveListClick(event) {
+  if (!boltDrivePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !boltDrivePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setBoltDriveSelection(option.dataset.value || '');
+  closeBoltDrivePicker({ focusButton: true });
+}
+
+function handleBoltDriveListFocusOut() {
+  if (!boltDrivePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!boltDrivePickerOpen) {
+      return;
+    }
+    if (!boltDrivePicker) {
+      closeBoltDrivePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !boltDrivePicker.contains(active)) {
+      closeBoltDrivePicker();
+    }
+  }, 0);
+}
+
+function handleDocumentPointer(event) {
+  if (!boltDrivePickerOpen || !boltDrivePicker) {
+    return;
+  }
+  const target = event.target;
+  if (target instanceof Node && boltDrivePicker.contains(target)) {
+    return;
+  }
+  closeBoltDrivePicker();
+}
+
+function handleDocumentFocusIn(event) {
+  if (!boltDrivePickerOpen || !boltDrivePicker) {
+    return;
+  }
+  const target = event.target;
+  if (target instanceof Node && boltDrivePicker.contains(target)) {
+    return;
+  }
+  closeBoltDrivePicker();
+}
 
 export function initEventHandlers() {
   hardwareTypeRadios.forEach(radio => {
@@ -260,10 +502,23 @@ export function initEventHandlers() {
 
   if (boltDriveSelect) {
     boltDriveSelect.addEventListener('change', () => {
-      state.boltDrive = boltDriveSelect.value;
-      updateDownloadState();
-      updatePreview();
+      setBoltDriveSelection(boltDriveSelect.value);
     });
+  }
+
+  if (boltDrivePickerButton && boltDrivePickerList) {
+    boltDrivePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleBoltDrivePicker();
+    });
+    boltDrivePickerButton.addEventListener('keydown', handleBoltDriveButtonKeydown);
+    boltDrivePickerList.addEventListener('click', handleBoltDriveListClick);
+    boltDrivePickerList.addEventListener('keydown', handleBoltDriveListKeydown);
+    boltDrivePickerList.addEventListener('focusout', handleBoltDriveListFocusOut);
+  }
+  if (boltDrivePicker) {
+    document.addEventListener('pointerdown', handleDocumentPointer);
+    document.addEventListener('focusin', handleDocumentFocusIn);
   }
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -42,6 +42,9 @@ const {
   notesField,
   standardField,
   boltStandardGroup,
+  boltDrivePicker,
+  boltDrivePickerButton,
+  boltDrivePickerList,
   boltHeadSelect,
   boltDriveSelect,
   notesLabel,
@@ -57,6 +60,92 @@ const {
   componentCategoryRadios,
   componentMountRadios,
 } = elements;
+
+const BOLT_DRIVE_PLACEHOLDER_TEXT = 'Select drive…';
+const validBoltDriveIds = new Set(boltDriveOptions.map(option => option.id));
+
+export function syncBoltDrivePicker({ isValid = true } = {}) {
+  if (!boltDriveSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+  const sanitizedValue = validBoltDriveIds.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.boltDrive = sanitizedValue;
+  }
+
+  boltDriveSelect.value = sanitizedValue;
+  if (!sanitizedValue) {
+    if (boltDriveSelect.options.length > 0) {
+      boltDriveSelect.selectedIndex = 0;
+    }
+  }
+
+  const selectedOption = sanitizedValue
+    ? boltDriveOptions.find(option => option.id === sanitizedValue) || null
+    : null;
+
+  if (boltDrivePickerButton) {
+    const label = boltDrivePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = boltDrivePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = boltDrivePickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = selectedOption ? selectedOption.label : BOLT_DRIVE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption) {
+        iconImage.src = `images/bolts/drive/${selectedOption.image}.svg`;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      boltDrivePickerButton.classList.remove('is-invalid');
+      boltDrivePickerButton.removeAttribute('aria-invalid');
+    } else {
+      boltDrivePickerButton.classList.add('is-invalid');
+      boltDrivePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (boltDrivePicker) {
+    boltDrivePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (boltDrivePickerList) {
+    const optionElements = Array.from(
+      boltDrivePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setBoltDriveSelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validBoltDriveIds.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+
+  state.boltDrive = sanitizedValue;
+  syncBoltDrivePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updatePreview();
+    updateDownloadState();
+  }
+}
 
 export function populateConnectorCategories() {
   if (!connectorCategorySelect) {
@@ -267,6 +356,9 @@ function populateBoltOptions() {
 
   boltHeadSelect.innerHTML = '';
   boltDriveSelect.innerHTML = '';
+  if (boltDrivePickerList) {
+    boltDrivePickerList.innerHTML = '';
+  }
 
   const headPlaceholder = document.createElement('option');
   headPlaceholder.value = '';
@@ -277,7 +369,7 @@ function populateBoltOptions() {
 
   const drivePlaceholder = document.createElement('option');
   drivePlaceholder.value = '';
-  drivePlaceholder.textContent = 'Select drive…';
+  drivePlaceholder.textContent = BOLT_DRIVE_PLACEHOLDER_TEXT;
   drivePlaceholder.disabled = true;
   drivePlaceholder.selected = !previousDrive;
   boltDriveSelect.appendChild(drivePlaceholder);
@@ -294,10 +386,37 @@ function populateBoltOptions() {
     opt.value = option.id;
     opt.textContent = option.label;
     boltDriveSelect.appendChild(opt);
+
+    if (boltDrivePickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      const image = document.createElement('img');
+      image.className = 'bolt-drive-picker__option-icon-image';
+      image.src = `images/bolts/drive/${option.image}.svg`;
+      image.alt = '';
+      image.loading = 'lazy';
+      image.decoding = 'async';
+      icon.appendChild(image);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      boltDrivePickerList.appendChild(item);
+    }
   });
 
   const validHeadIds = new Set(boltHeadOptions.map(option => option.id));
-  const validDriveIds = new Set(boltDriveOptions.map(option => option.id));
 
   if (previousHead && validHeadIds.has(previousHead)) {
     boltHeadSelect.value = previousHead;
@@ -306,12 +425,7 @@ function populateBoltOptions() {
     state.boltHead = '';
   }
 
-  if (previousDrive && validDriveIds.has(previousDrive)) {
-    boltDriveSelect.value = previousDrive;
-  } else {
-    boltDriveSelect.value = '';
-    state.boltDrive = '';
-  }
+  setBoltDriveSelection(previousDrive, { triggerUpdate: false });
 
   boltHeadSelect.disabled = false;
   boltHeadSelect.title = 'Select head style';
@@ -320,6 +434,14 @@ function populateBoltOptions() {
   boltDriveSelect.disabled = false;
   boltDriveSelect.title = 'Select drive style';
   boltDriveSelect.setAttribute('aria-required', 'true');
+
+  if (boltDrivePickerButton) {
+    boltDrivePickerButton.disabled = false;
+    boltDrivePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (boltDrivePickerList) {
+    boltDrivePickerList.hidden = true;
+  }
 }
 
 export function populateStandards() {
@@ -767,6 +889,21 @@ export function onHardwareTypeChange() {
       boltDriveSelect.removeAttribute('aria-required');
       boltDriveSelect.title = '';
     }
+  }
+  if (boltDrivePickerButton) {
+    boltDrivePickerButton.disabled = !showBoltFields;
+    if (!showBoltFields) {
+      boltDrivePickerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+  if (boltDrivePickerList) {
+    boltDrivePickerList.hidden = true;
+  }
+  if (boltDrivePicker) {
+    boltDrivePicker.classList.toggle('is-disabled', !showBoltFields);
+  }
+  if (!showBoltFields) {
+    syncBoltDrivePicker({ isValid: true });
   }
   if (notesInput) {
     if (showConnectorFields) {

--- a/js/render.js
+++ b/js/render.js
@@ -1,5 +1,6 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
+import { syncBoltDrivePicker } from './forms.js';
 import {
   pxPerMm,
   hardwareImageFolders,
@@ -441,6 +442,7 @@ function applyValidationFeedback(disabled) {
       messageElement: boltDriveMessage,
       valid: driveValid,
     });
+    syncBoltDrivePicker({ isValid: driveValid });
     if (!headValid) {
       requirements.push('select a head style');
     }
@@ -460,6 +462,7 @@ function applyValidationFeedback(disabled) {
       messageElement: boltDriveMessage,
       valid: true,
     });
+    syncBoltDrivePicker({ isValid: true });
   }
 
   if (hardwareType === 'Connector') {

--- a/style.css
+++ b/style.css
@@ -167,6 +167,227 @@ main {
   content: none;
 }
 
+.bolt-drive-picker {
+  position: relative;
+  display: block;
+}
+
+.bolt-drive-picker.is-open {
+  z-index: 25;
+}
+
+.bolt-drive-picker__button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--bs-border-color, rgba(148, 163, 184, 0.38));
+  background-color: var(--bs-body-bg, #ffffff);
+  padding: 0.625rem 0.875rem;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+  font-size: 1rem;
+  line-height: 1.35;
+  min-height: 2.875rem;
+}
+
+.bolt-drive-picker__button:focus-visible {
+  outline: none;
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-ring-color);
+}
+
+.bolt-drive-picker__button:hover {
+  background-color: rgba(148, 163, 184, 0.08);
+}
+
+.bolt-drive-picker__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.bolt-drive-picker.is-disabled .bolt-drive-picker__button {
+  cursor: not-allowed;
+}
+
+.bolt-drive-picker__button.is-invalid,
+.bolt-drive-picker.is-invalid .bolt-drive-picker__button {
+  border-color: var(--bs-danger-border-subtle, #f1aeb5);
+  box-shadow: 0 0 0 0.25rem var(--field-invalid-ring);
+}
+
+.bolt-drive-picker__current {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bolt-drive-picker__current-label {
+  font-weight: 600;
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bolt-drive-picker__current-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background-color: rgba(148, 163, 184, 0.12);
+  flex-shrink: 0;
+  overflow: hidden;
+  transition: background-color 0.2s ease;
+}
+
+.bolt-drive-picker__current-icon.is-empty {
+  visibility: hidden;
+}
+
+.bolt-drive-picker__current-icon-image {
+  max-width: 100%;
+  max-height: 100%;
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.bolt-drive-picker__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
+.bolt-drive-picker__chevron::before {
+  content: '';
+  display: block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.bolt-drive-picker.is-open .bolt-drive-picker__chevron::before {
+  transform: rotate(-135deg);
+}
+
+.bolt-drive-picker__list {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  background-color: var(--bs-body-bg, #ffffff);
+  border-radius: 0.75rem;
+  border: 1px solid var(--bs-border-color, rgba(148, 163, 184, 0.32));
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.15);
+  padding: 0.5rem 0.25rem;
+  margin: 0;
+  list-style: none;
+  max-height: 18rem;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  display: block;
+  z-index: 30;
+}
+
+.bolt-drive-picker__list[hidden] {
+  display: none;
+}
+
+.bolt-drive-picker__option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  font-weight: 600;
+}
+
+.bolt-drive-picker__option:focus {
+  outline: none;
+}
+
+.bolt-drive-picker__option:hover,
+.bolt-drive-picker__option:focus {
+  background-color: rgba(37, 99, 235, 0.12);
+}
+
+.bolt-drive-picker__option.is-selected {
+  background-color: rgba(37, 99, 235, 0.18);
+  color: #1d4ed8;
+}
+
+.bolt-drive-picker__option-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background-color: rgba(148, 163, 184, 0.16);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.bolt-drive-picker__option-icon-image {
+  max-width: 100%;
+  max-height: 100%;
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.bolt-drive-picker__option-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+:root[data-theme='dark'] .bolt-drive-picker__button {
+  background-color: rgba(30, 41, 59, 0.9);
+  border-color: rgba(148, 163, 184, 0.42);
+}
+
+:root[data-theme='dark'] .bolt-drive-picker__button:hover {
+  background-color: rgba(148, 163, 184, 0.18);
+}
+
+:root[data-theme='dark'] .bolt-drive-picker__list {
+  background-color: rgba(15, 23, 42, 0.98);
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 18px 36px rgba(8, 15, 30, 0.55);
+}
+
+:root[data-theme='dark'] .bolt-drive-picker__option:hover,
+:root[data-theme='dark'] .bolt-drive-picker__option:focus {
+  background-color: rgba(148, 163, 184, 0.28);
+}
+
+:root[data-theme='dark'] .bolt-drive-picker__option.is-selected {
+  background-color: rgba(148, 163, 184, 0.4);
+  color: #e2e8f0;
+}
+
 .size-info {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- replace the bolt drive select with a hidden select paired with a new icon-based picker UI
- add DOM references, helpers, and event handling to populate, sync, and navigate the picker with mouse, touch, and keyboard
- style the picker for responsive, touch-friendly use while keeping validation and state hydration in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d6bde6348329886e0c6a49318bd1