### PR TITLE
Restructure fuse labels and disable standard picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,9 +403,26 @@
                         autocomplete="off"
                         checked
                       />
-                      <label class="btn btn-outline-secondary w-100" for="fuse-type-glass"
-                        >Glass Fuse</label
+                      <label
+                        class="btn btn-outline-secondary w-100 fuse-type-option text-start"
+                        for="fuse-type-glass"
                       >
+                        <span class="fuse-type-option__icon" aria-hidden="true">
+                          <img
+                            src="images/fuses/glass_fuse.svg"
+                            width="64"
+                            height="64"
+                            loading="lazy"
+                            alt=""
+                          />
+                        </span>
+                        <span class="fuse-type-option__content">
+                          <span class="fuse-type-option__title">Glass Fuse</span>
+                          <span class="fuse-type-option__description text-muted"
+                            >Cartridge-style tube fuse for electronics.</span
+                          >
+                        </span>
+                      </label>
                     </div>
                     <div class="col-12 col-sm-6">
                       <input
@@ -416,9 +433,26 @@
                         value="Blade"
                         autocomplete="off"
                       />
-                      <label class="btn btn-outline-secondary w-100" for="fuse-type-blade"
-                        >Blade Fuse</label
+                      <label
+                        class="btn btn-outline-secondary w-100 fuse-type-option text-start"
+                        for="fuse-type-blade"
                       >
+                        <span class="fuse-type-option__icon" aria-hidden="true">
+                          <img
+                            src="images/fuses/blade_fuse.svg"
+                            width="64"
+                            height="64"
+                            loading="lazy"
+                            alt=""
+                          />
+                        </span>
+                        <span class="fuse-type-option__content">
+                          <span class="fuse-type-option__title">Blade Fuse</span>
+                          <span class="fuse-type-option__description text-muted"
+                            >Automotive blade fuse for DC circuits.</span
+                          >
+                        </span>
+                      </label>
                     </div>
                   </div>
                 </div>

--- a/js/forms.js
+++ b/js/forms.js
@@ -618,6 +618,21 @@ export function populateStandards() {
     return;
   }
 
+  if (state.hardwareType === 'Fuse') {
+    placeholder.textContent = 'Not used for fuse labels';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.dataset.defaultText = placeholder.textContent;
+    standardSelect.appendChild(placeholder);
+    standardSelect.disabled = true;
+    standardSelect.title = '';
+    state.standard = '';
+    state.standardCode = '';
+    standardSelect.value = '';
+    updatePreview();
+    return;
+  }
+
   let standards = [];
   let placeholderText = STANDARD_PLACEHOLDER_TEXT;
   let noOptionsText = 'No standards available';
@@ -968,7 +983,7 @@ export function onHardwareTypeChange() {
   if (standardField) {
     standardField.classList.toggle(
       'd-none',
-      showCustomFields || showBearingFields || showComponentFields,
+      showCustomFields || showBearingFields || showComponentFields || showFuseFields,
     );
   }
   if (standardLabel) {
@@ -980,8 +995,9 @@ export function onHardwareTypeChange() {
     standardLabel.setAttribute('for', showBoltFields ? 'bolt-head-select' : 'standard-select');
   }
   if (standardSelect) {
-    standardSelect.classList.toggle('d-none', showBoltFields);
-    if (showBoltFields) {
+    const hideStandardSelect = showBoltFields || showFuseFields;
+    standardSelect.classList.toggle('d-none', hideStandardSelect);
+    if (hideStandardSelect) {
       standardSelect.disabled = true;
       standardSelect.setAttribute('aria-hidden', 'true');
       standardSelect.setAttribute('aria-required', 'false');

--- a/js/render.js
+++ b/js/render.js
@@ -84,6 +84,17 @@ let previewReadyState = false;
 let previewStatusFrameId = null;
 let qrRenderRequestId = 0;
 
+const fuseIllustrations = {
+  Glass: {
+    src: 'images/fuses/glass_fuse.svg',
+    alt: 'Glass fuse illustration',
+  },
+  Blade: {
+    src: 'images/fuses/blade_fuse.svg',
+    alt: 'Blade fuse illustration',
+  },
+};
+
 function mmToPx(mm) {
   return Number.isFinite(mm) ? mm * pxPerMm : 0;
 }
@@ -687,6 +698,18 @@ function resolveHardwareImageInfo() {
       ],
     };
   }
+  if (state.hardwareType === 'Fuse') {
+    const fuseType = (state.fuseType || '').trim();
+    const illustration = fuseIllustrations[fuseType] || fuseIllustrations.Glass;
+    if (!illustration) {
+      return null;
+    }
+    return {
+      type: 'fuse-illustration',
+      src: illustration.src,
+      alt: illustration.alt,
+    };
+  }
   const folder = hardwareImageFolders[state.hardwareType];
   if (!folder) {
     return null;
@@ -800,6 +823,27 @@ function renderHardwareImage(imageInfo, innerHeightPx, contentWidthPx, gapPx) {
     });
     hardwareImageDiv.appendChild(group);
     usedWidthPx = maxWidth;
+  } else if (imageInfo.type === 'fuse-illustration') {
+    const maxWidth = Math.max(Math.min(contentWidthPx, innerHeightPx * 1.15), Math.round(innerHeightPx * 0.85));
+    const wrapper = document.createElement('div');
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
+    wrapper.style.width = `${maxWidth}px`;
+    wrapper.style.height = `${innerHeightPx}px`;
+
+    const img = document.createElement('img');
+    img.src = imageInfo.src;
+    img.alt = imageInfo.alt || 'Fuse illustration';
+    img.className = 'hardware-illustration';
+    img.style.maxHeight = '100%';
+    img.style.maxWidth = '100%';
+    img.decoding = 'async';
+    img.loading = 'lazy';
+
+    wrapper.appendChild(img);
+    hardwareImageDiv.appendChild(wrapper);
+    usedWidthPx = maxWidth;
   } else {
     const maxWidth = Math.max(Math.min(contentWidthPx, innerHeightPx * 1.2), innerHeightPx * 0.8);
     const img = document.createElement('img');
@@ -868,21 +912,22 @@ function buildTextLines() {
   }
 
   if (state.hardwareType === 'Fuse') {
-    const parts = [];
-    const fuseLabel = state.fuseType ? `${state.fuseType} Fuse` : 'Fuse';
-    parts.push(fuseLabel);
-    if (state.fuseValue) {
-      parts.push(`${state.fuseValue} A`);
-    }
+    const valueLabel = state.fuseValue ? `${state.fuseValue} A` : 'Fuse';
+    const typeLabel = state.fuseType ? `${state.fuseType} Fuse` : 'Fuse';
+    const typeParts = [typeLabel];
     if (state.glassSize) {
-      parts.push(state.glassSize);
+      typeParts.push(state.glassSize);
     }
+    const line2 = typeParts.filter(Boolean).join(' — ');
+    const line3Parts = [];
     if (state.glassSpeed) {
-      parts.push(state.glassSpeed);
+      line3Parts.push(state.glassSpeed);
     }
-    const line1 = parts.filter(Boolean).join(' — ');
-    const line2 = state.notes || '';
-    return { line1, line2, line3: '' };
+    if (state.notes) {
+      line3Parts.push(state.notes);
+    }
+    const line3 = line3Parts.join(' • ');
+    return { line1: valueLabel, line2, line3 };
   }
 
   if (state.hardwareType === 'Connector') {

--- a/style.css
+++ b/style.css
@@ -150,6 +150,44 @@ main {
   font-weight: 600;
 }
 
+.fuse-type-option {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  min-height: 100%;
+  padding: 0.85rem 1rem;
+}
+
+.fuse-type-option__icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+}
+
+.fuse-type-option__icon img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.fuse-type-option__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.fuse-type-option__title {
+  font-weight: 600;
+}
+
+.fuse-type-option__description {
+  font-size: 0.95rem;
+}
+
 /*
  * Previously `.field-invalid` added an outline via a pseudo-element.  That
  * extra ring duplicated Bootstrap's native validation styling, so the
@@ -582,6 +620,12 @@ main {
   max-width: 100%;
   max-height: 100%;
   filter: grayscale(100%);
+}
+
+.hardware-icon img.hardware-illustration {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .label-inner.has-hardware-image .text-block {


### PR DESCRIPTION
## Summary
- lay out fuse label text with amperage, fuse type, and speed on separate lines similar to the bolt labels
- hide and disable the hardware standard selector when Fuse is the chosen hardware type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d88e46401483299cced6078b008040