### PR TITLE
Improve form icon contrast in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,7 @@
   --label-preview-check-1: rgba(148, 163, 184, 0.24);
   --label-preview-check-2: rgba(148, 163, 184, 0.1);
   --label-preview-check-size: 24px;
+  --form-icon-filter: none;
   --focus-outline-width: 2px;
   --focus-outline-offset: 2px;
 }
@@ -58,6 +59,7 @@
   --label-preview-bg: #0b1120;
   --label-preview-check-1: rgba(148, 163, 184, 0.22);
   --label-preview-check-2: rgba(148, 163, 184, 0.1);
+  --form-icon-filter: brightness(0) saturate(100%) invert(0.92);
 }
 
 body {
@@ -172,6 +174,8 @@ main {
   display: block;
   width: 100%;
   height: auto;
+  filter: var(--form-icon-filter);
+  transition: filter 0.2s ease;
 }
 
 .fuse-type-option__content {
@@ -336,6 +340,8 @@ main {
   width: 100%;
   height: auto;
   display: block;
+  filter: var(--form-icon-filter);
+  transition: filter 0.2s ease;
 }
 
 .bolt-drive-picker__chevron {
@@ -428,6 +434,8 @@ main {
   width: 100%;
   height: auto;
   display: block;
+  filter: var(--form-icon-filter);
+  transition: filter 0.2s ease;
 }
 
 .bolt-drive-picker__option-label {


### PR DESCRIPTION
## Summary
- add a CSS variable for form icon filters so images can adapt to light and dark themes
- apply the adaptive filter to fuse and bolt picker icons to boost legibility in dark mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8987418108329a2916d82171b7633