### PR TITLE
Fix dark theme select dropdown contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,6 +39,20 @@
   --page-bg-start: #0f172a;
   --page-bg-end: #1e293b;
   --placeholder-text: rgba(226, 232, 240, 0.7);
+  --bs-body-bg: #0f172a;
+  --bs-body-color: #e2e8f0;
+  --bs-border-color: rgba(148, 163, 184, 0.45);
+  --bs-dropdown-bg: #0f172a;
+  --bs-dropdown-link-color: #e2e8f0;
+  --bs-dropdown-link-hover-bg: #1e293b;
+  --bs-dropdown-link-hover-color: #e2e8f0;
+  --bs-dropdown-link-active-bg: #1e293b;
+  --bs-form-control-bg: #111827;
+  --bs-form-control-color: #e2e8f0;
+  --bs-form-control-disabled-bg: rgba(15, 23, 42, 0.7);
+  --bs-form-select-bg: #111827;
+  --bs-form-select-color: #e2e8f0;
+  --bs-form-select-disabled-bg: rgba(15, 23, 42, 0.7);
   --qr-info-bg: rgba(148, 163, 184, 0.22);
   --qr-info-color: #e2e8f0;
   --qr-tooltip-bg: #0f172a;
@@ -914,6 +928,38 @@ main {
   box-shadow: 0 0 0 0.25rem var(--focus-ring-color);
   outline: var(--focus-outline-width) solid var(--focus-ring-border);
   outline-offset: var(--focus-outline-offset);
+}
+
+:root[data-theme='dark'] .form-select {
+  background-color: var(--bs-form-select-bg);
+  color: var(--bs-form-select-color);
+  border-color: var(--bs-border-color);
+  background-image: var(
+    --bs-form-select-bg-img,
+    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23e2e8f0' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M2.75 5.75 8 11.25l5.25-5.5'/%3e%3c/svg%3e")
+  );
+}
+
+:root[data-theme='dark'] .form-control {
+  background-color: var(--bs-form-control-bg);
+  color: var(--bs-form-control-color);
+  border-color: var(--bs-border-color);
+}
+
+:root[data-theme='dark'] .form-select:disabled {
+  background-color: var(--bs-form-select-disabled-bg);
+}
+
+:root[data-theme='dark'] .form-select option,
+:root[data-theme='dark'] .form-select optgroup {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+:root[data-theme='dark'] .form-select option:checked,
+:root[data-theme='dark'] .form-select option:hover {
+  background-color: #1e293b;
+  color: #e2e8f0;
 }
 
 .form-check-input:focus:not(.is-invalid) {


### PR DESCRIPTION
## Summary
- update dark theme CSS variables so Bootstrap form controls and dropdowns inherit dark backgrounds and text colors
- style select controls and option lists to maintain visible contrast while interacting in dark mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d89e8ffadc8329b61affad0fd81428