### PR TITLE
Rename heat insert type and display new threaded insert image

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                     >
                       <optgroup label="Hardware">
                         <option value="Bolt" selected>Bolt</option>
-                        <option value="Heat Insert">Heat Insert</option>
+                        <option value="Threaded Heat Insert">Threaded Heat Insert</option>
                         <option value="Nut">Nut</option>
                         <option value="Screw">Screw</option>
                         <option value="Washer">Washer</option>

--- a/js/data.js
+++ b/js/data.js
@@ -197,7 +197,7 @@ export const hardwareCatalog = {
     { code: 'DIN 93', name: 'Tab Washer' },
     { code: 'DIN 988', name: 'Shim Ring' },
   ],
-  'Heat Insert': [],
+  'Threaded Heat Insert': [],
   Bearing: [],
   Component: [],
   Fuse: [
@@ -212,6 +212,7 @@ export const hardwareImageFolders = {
   Screw: 'screws',
   Nut: 'nuts',
   Washer: 'washers',
+  'Threaded Heat Insert': 'threaded_heat_insert',
 };
 
 export const connectorCatalog = [

--- a/js/render.js
+++ b/js/render.js
@@ -361,6 +361,9 @@ export function isLabelReady() {
   if (state.hardwareType === 'Screw') {
     return Boolean(state.threadSize && state.length && state.standardCode);
   }
+  if (state.hardwareType === 'Threaded Heat Insert') {
+    return Boolean(state.threadSize && state.length);
+  }
   return Boolean(state.threadSize);
 }
 
@@ -372,7 +375,7 @@ function applyValidationFeedback(disabled) {
     hardwareType === 'Screw' ||
     hardwareType === 'Nut' ||
     hardwareType === 'Washer' ||
-    hardwareType === 'Heat Insert';
+    hardwareType === 'Threaded Heat Insert';
 
   if (requiresThread) {
     const valid = Boolean(state.threadSize);
@@ -397,7 +400,7 @@ function applyValidationFeedback(disabled) {
   const requiresLength =
     hardwareType === 'Bolt' ||
     hardwareType === 'Screw' ||
-    hardwareType === 'Heat Insert';
+    hardwareType === 'Threaded Heat Insert';
   if (requiresLength) {
     const valid = Boolean(state.length);
     updateInputFieldState({
@@ -708,6 +711,13 @@ function resolveHardwareImageInfo() {
       type: 'fuse-illustration',
       src: illustration.src,
       alt: illustration.alt,
+    };
+  }
+  if (state.hardwareType === 'Threaded Heat Insert') {
+    return {
+      type: 'photo',
+      src: 'images/threaded_heat_insert/heat_insert.svg',
+      alt: 'Threaded heat insert reference illustration',
     };
   }
   const folder = hardwareImageFolders[state.hardwareType];


### PR DESCRIPTION
## Summary
- rename the Heat Insert option to Threaded Heat Insert throughout the UI and supporting data
- update validation and rendering logic to require length and load the new threaded insert illustration
- register the threaded heat insert image folder for future assets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a84bef848329874997e8c91ebcb6