### PR TITLE
Add development warning banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Placeholder for upcoming changes.
+### Added
+
+- Added a prominent development warning banner to highlight the site's unstable status.
 
 ## [1.0.0] - 2025-09-20
 

--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
         <h1 class="display-5 fw-semibold">Gridfinity Label Maker</h1>
         <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
       </header>
+      <div class="alert alert-warning d-flex align-items-center justify-content-center gap-2 mb-4" role="alert">
+        <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+        <span class="fw-semibold">Website is under heavy development and may not function correctly.</span>
+      </div>
       <div class="row g-4">
         <section class="form-section col-lg-7">
           <div class="card shadow-sm h-100">


### PR DESCRIPTION
## Summary
- insert a Bootstrap warning alert between the hero header and form sections to signal the site's unstable status
- document the new warning banner in the Unreleased section of the changelog

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8b89a67108329811af0b67fd930c4