### PR TITLE
Add image-enhanced hardware type selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,10 +129,10 @@
                   >
                     Hardware Type
                   </label>
-                  <div>
+                  <div class="bolt-drive-picker" id="hardware-type-picker">
                     <select
                       id="hardware-type-select"
-                      class="form-select"
+                      class="visually-hidden"
                       aria-labelledby="hardware-type-label"
                     >
                       <optgroup label="Hardware">
@@ -152,6 +152,34 @@
                       </optgroup>
                       <option value="Custom">Custom</option>
                     </select>
+                    <button
+                      type="button"
+                      class="bolt-drive-picker__button"
+                      id="hardware-type-picker-button"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      aria-controls="hardware-type-picker-list"
+                    >
+                      <span class="bolt-drive-picker__current">
+                        <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                          <img
+                            class="bolt-drive-picker__current-icon-image"
+                            src=""
+                            alt=""
+                            hidden
+                          />
+                        </span>
+                        <span class="bolt-drive-picker__current-label">Select hardware…</span>
+                      </span>
+                      <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                    </button>
+                    <ul
+                      class="bolt-drive-picker__list"
+                      id="hardware-type-picker-list"
+                      role="listbox"
+                      aria-labelledby="hardware-type-picker-button"
+                      hidden
+                    ></ul>
                   </div>
                 </div>
                 <div id="custom-fields" class="d-none">

--- a/js/controls.js
+++ b/js/controls.js
@@ -5,6 +5,7 @@ import {
   populateFuseValues,
   populateConnectorCategories,
   populateBearingOptions,
+  populateHardwareTypePicker,
   updateCustomImageUi,
   onHardwareTypeChange,
   setBoltDriveSelection,
@@ -127,6 +128,7 @@ function init() {
   populateFuseValues();
   populateConnectorCategories();
   populateBearingOptions();
+  populateHardwareTypePicker();
   updateCustomImageUi();
   onHardwareTypeChange();
   applyStateToControls();

--- a/js/data.js
+++ b/js/data.js
@@ -222,6 +222,13 @@ export const hardwareImageFolders = {
   'Threaded Heat Insert': 'threaded_heat_insert',
 };
 
+export const hardwareTypeImageMap = {
+  Bolt: 'images/bolts/head/countersunk_head.svg',
+  'Threaded Heat Insert': 'images/threaded_heat_insert/heat_insert.svg',
+  Nut: 'images/nuts/hex_nut.svg',
+  Fuse: 'images/fuses/glass_fuse.svg',
+};
+
 export const connectorCatalog = [
   {
     id: 'pre-insulated-crimp',

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -100,6 +100,9 @@ const printButton = document.getElementById('print-button');
 
 const hardwareTypeRadios = Array.from(document.querySelectorAll('input[name="hardware-type"]'));
 const hardwareTypeSelect = document.getElementById('hardware-type-select');
+const hardwareTypePicker = document.getElementById('hardware-type-picker');
+const hardwareTypePickerButton = document.getElementById('hardware-type-picker-button');
+const hardwareTypePickerList = document.getElementById('hardware-type-picker-list');
 const hardwareTypeOptions = new Set(
   hardwareTypeRadios
     .map(radio => radio.value)
@@ -216,6 +219,9 @@ export const elements = {
   printButton,
   hardwareTypeRadios,
   hardwareTypeSelect,
+  hardwareTypePicker,
+  hardwareTypePickerButton,
+  hardwareTypePickerList,
   hardwareTypeOptions,
   systemTypeRadios,
   fuseTypeRadios,

--- a/js/events.js
+++ b/js/events.js
@@ -16,6 +16,7 @@ import {
   syncBoltHeadPicker,
   setNutTypeSelection,
   syncNutTypePicker,
+  syncHardwareTypePicker,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -23,6 +24,9 @@ import { downloadLabel, printLabel, shareLabel } from './actions.js';
 const {
   hardwareTypeRadios,
   hardwareTypeSelect,
+  hardwareTypePicker,
+  hardwareTypePickerButton,
+  hardwareTypePickerList,
   connectorCategorySelect,
   componentCategoryRadios,
   componentMountRadios,
@@ -65,9 +69,223 @@ const {
   printButton,
 } = elements;
 
+let hardwareTypePickerOpen = false;
 let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
+
+function getHardwareTypeOptionElements() {
+  if (!hardwareTypePickerList) {
+    return [];
+  }
+  return Array.from(hardwareTypePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusHardwareTypeOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getHardwareTypeOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openHardwareTypePicker() {
+  if (!hardwareTypePicker || !hardwareTypePickerButton || !hardwareTypePickerList) {
+    return;
+  }
+  if (hardwareTypePickerButton.disabled) {
+    return;
+  }
+  if (hardwareTypePickerOpen) {
+    return;
+  }
+  hardwareTypePickerOpen = true;
+  hardwareTypePicker.classList.add('is-open');
+  hardwareTypePickerList.hidden = false;
+  hardwareTypePickerButton.setAttribute('aria-expanded', 'true');
+  syncHardwareTypePicker();
+
+  const options = getHardwareTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.hardwareType === 'string' ? state.hardwareType : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusHardwareTypeOption(selectedOption || options[0]);
+}
+
+function closeHardwareTypePicker({ focusButton = false } = {}) {
+  if (!hardwareTypePicker || !hardwareTypePickerButton || !hardwareTypePickerList) {
+    return;
+  }
+  if (!hardwareTypePickerOpen) {
+    if (focusButton && !hardwareTypePickerButton.disabled) {
+      hardwareTypePickerButton.focus();
+    }
+    return;
+  }
+  hardwareTypePickerOpen = false;
+  hardwareTypePicker.classList.remove('is-open');
+  hardwareTypePickerList.hidden = true;
+  hardwareTypePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !hardwareTypePickerButton.disabled) {
+    hardwareTypePickerButton.focus();
+  }
+}
+
+function toggleHardwareTypePicker() {
+  if (hardwareTypePickerOpen) {
+    closeHardwareTypePicker({ focusButton: false });
+  } else {
+    openHardwareTypePicker();
+  }
+}
+
+function moveHardwareTypeOption(delta) {
+  if (!hardwareTypePickerList) {
+    return;
+  }
+  const options = getHardwareTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && hardwareTypePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.hardwareType === 'string' ? state.hardwareType : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusHardwareTypeOption(nextOption);
+  }
+}
+
+function handleHardwareTypeButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openHardwareTypePicker();
+    moveHardwareTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openHardwareTypePicker();
+    moveHardwareTypeOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleHardwareTypePicker();
+    return;
+  }
+  if (key === 'Escape' && hardwareTypePickerOpen) {
+    event.preventDefault();
+    closeHardwareTypePicker({ focusButton: true });
+  }
+}
+
+function handleHardwareTypeListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveHardwareTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveHardwareTypeOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getHardwareTypeOptionElements();
+    if (options.length > 0) {
+      focusHardwareTypeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getHardwareTypeOptionElements();
+    if (options.length > 0) {
+      focusHardwareTypeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        applyHardwareTypeSelection(option.dataset.value || '');
+        closeHardwareTypePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeHardwareTypePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeHardwareTypePicker();
+  }
+}
+
+function handleHardwareTypeListClick(event) {
+  if (!hardwareTypePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !hardwareTypePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  applyHardwareTypeSelection(option.dataset.value || '');
+  closeHardwareTypePicker({ focusButton: true });
+}
+
+function handleHardwareTypeListFocusOut() {
+  if (!hardwareTypePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!hardwareTypePickerOpen) {
+      return;
+    }
+    if (!hardwareTypePicker) {
+      closeHardwareTypePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !hardwareTypePicker.contains(active)) {
+      closeHardwareTypePicker();
+    }
+  }, 0);
+}
 
 function getBoltDriveOptionElements() {
   if (!boltDrivePickerList) {
@@ -710,6 +928,11 @@ function handleNutTypeListFocusOut() {
 
 function handleDocumentPointer(event) {
   const target = event.target;
+  if (hardwareTypePickerOpen && hardwareTypePicker) {
+    if (!(target instanceof Node) || !hardwareTypePicker.contains(target)) {
+      closeHardwareTypePicker();
+    }
+  }
   if (boltDrivePickerOpen && boltDrivePicker) {
     if (!(target instanceof Node) || !boltDrivePicker.contains(target)) {
       closeBoltDrivePicker();
@@ -729,6 +952,11 @@ function handleDocumentPointer(event) {
 
 function handleDocumentFocusIn(event) {
   const target = event.target;
+  if (hardwareTypePickerOpen && hardwareTypePicker) {
+    if (!(target instanceof Node) || !hardwareTypePicker.contains(target)) {
+      closeHardwareTypePicker();
+    }
+  }
   if (boltDrivePickerOpen && boltDrivePicker) {
     if (!(target instanceof Node) || !boltDrivePicker.contains(target)) {
       closeBoltDrivePicker();
@@ -761,6 +989,17 @@ export function initEventHandlers() {
     };
     hardwareTypeSelect.addEventListener('change', handleSelectChange);
     hardwareTypeSelect.addEventListener('input', handleSelectChange);
+  }
+
+  if (hardwareTypePickerButton && hardwareTypePickerList) {
+    hardwareTypePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleHardwareTypePicker();
+    });
+    hardwareTypePickerButton.addEventListener('keydown', handleHardwareTypeButtonKeydown);
+    hardwareTypePickerList.addEventListener('click', handleHardwareTypeListClick);
+    hardwareTypePickerList.addEventListener('keydown', handleHardwareTypeListKeydown);
+    hardwareTypePickerList.addEventListener('focusout', handleHardwareTypeListFocusOut);
   }
 
   if (connectorCategorySelect) {
@@ -995,7 +1234,7 @@ export function initEventHandlers() {
     nutTypePickerList.addEventListener('keydown', handleNutTypeListKeydown);
     nutTypePickerList.addEventListener('focusout', handleNutTypeListFocusOut);
   }
-  if (boltDrivePicker || boltHeadPicker || nutTypePicker) {
+  if (hardwareTypePicker || boltDrivePicker || boltHeadPicker || nutTypePicker) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
   }

--- a/js/forms.js
+++ b/js/forms.js
@@ -7,6 +7,7 @@ import {
   boltDriveOptions,
   nutTypeOptions,
   hardwareCatalog,
+  hardwareTypeImageMap,
   connectorCatalog,
   STANDARD_PLACEHOLDER_TEXT,
   CONNECTOR_PLACEHOLDER_TEXT,
@@ -64,18 +65,174 @@ const {
   defaultStandardLabel,
   hardwareTypeRadios,
   hardwareTypeSelect,
+  hardwareTypePickerButton,
+  hardwareTypePickerList,
   hardwareTypeOptions,
   systemTypeRadios,
   componentCategoryRadios,
   componentMountRadios,
 } = elements;
 
+const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select hardware…';
 const BOLT_DRIVE_PLACEHOLDER_TEXT = 'Select drive…';
 const BOLT_HEAD_PLACEHOLDER_TEXT = 'Select head…';
 const validBoltDriveIds = new Set(boltDriveOptions.map(option => option.id));
 const validBoltHeadIds = new Set(boltHeadOptions.map(option => option.id));
 const NUT_TYPE_PLACEHOLDER_TEXT = 'Select type…';
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
+
+function createHardwareTypeOption(optionElement) {
+  if (!hardwareTypePickerList) {
+    return;
+  }
+  const value = optionElement.value;
+  if (!value) {
+    return;
+  }
+
+  const item = document.createElement('li');
+  item.className = 'bolt-drive-picker__option';
+  item.dataset.value = value;
+  item.setAttribute('role', 'option');
+  item.setAttribute('aria-selected', 'false');
+  item.tabIndex = -1;
+
+  const icon = document.createElement('span');
+  icon.className = 'bolt-drive-picker__option-icon';
+
+  const imageSrc = hardwareTypeImageMap[value];
+  if (imageSrc) {
+    const image = document.createElement('img');
+    image.className = 'bolt-drive-picker__option-icon-image';
+    if (value === 'Bolt') {
+      image.classList.add('is-rotated-90');
+    }
+    image.src = imageSrc;
+    image.alt = '';
+    image.loading = 'lazy';
+    image.decoding = 'async';
+    icon.appendChild(image);
+  } else {
+    icon.classList.add('is-empty');
+  }
+
+  const label = document.createElement('span');
+  label.className = 'bolt-drive-picker__option-label';
+  label.textContent = optionElement.textContent.trim();
+
+  item.appendChild(icon);
+  item.appendChild(label);
+
+  hardwareTypePickerList.appendChild(item);
+}
+
+export function populateHardwareTypePicker() {
+  if (!hardwareTypePickerList) {
+    return;
+  }
+
+  hardwareTypePickerList.innerHTML = '';
+
+  if (!hardwareTypeSelect) {
+    return;
+  }
+
+  const children = Array.from(hardwareTypeSelect.children);
+  children.forEach(child => {
+    if (!child || !(child instanceof Element)) {
+      return;
+    }
+    const tagName = child.tagName.toLowerCase();
+    if (tagName === 'optgroup') {
+      const optionElements = Array.from(child.children).filter(
+        option => option instanceof HTMLOptionElement,
+      );
+      if (optionElements.length === 0) {
+        return;
+      }
+      const header = document.createElement('li');
+      header.className = 'bolt-drive-picker__group';
+      header.textContent = child.label;
+      header.setAttribute('role', 'presentation');
+      hardwareTypePickerList.appendChild(header);
+      optionElements.forEach(option => {
+        createHardwareTypeOption(option);
+      });
+      return;
+    }
+    if (tagName === 'option') {
+      createHardwareTypeOption(child);
+    }
+  });
+
+  if (hardwareTypePickerButton) {
+    hardwareTypePickerButton.disabled = false;
+    hardwareTypePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  hardwareTypePickerList.hidden = true;
+
+  syncHardwareTypePicker();
+}
+
+export function syncHardwareTypePicker() {
+  const currentValue = typeof state.hardwareType === 'string' ? state.hardwareType : '';
+  const sanitizedValue = hardwareTypeOptions.has(currentValue) ? currentValue : '';
+
+  if (hardwareTypeSelect) {
+    hardwareTypeSelect.value = sanitizedValue || hardwareTypeSelect.value;
+  }
+
+  if (hardwareTypePickerButton) {
+    const label = hardwareTypePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = hardwareTypePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = hardwareTypePickerButton.querySelector(
+      '.bolt-drive-picker__current-icon-image',
+    );
+
+    let optionLabel = HARDWARE_TYPE_PLACEHOLDER_TEXT;
+    if (sanitizedValue && hardwareTypeSelect) {
+      const match = Array.from(hardwareTypeSelect.options).find(
+        option => option.value === sanitizedValue,
+      );
+      if (match) {
+        optionLabel = match.textContent.trim() || HARDWARE_TYPE_PLACEHOLDER_TEXT;
+      }
+    }
+
+    if (label) {
+      label.textContent = optionLabel;
+    }
+
+    if (iconWrapper && iconImage) {
+      const imageSrc = sanitizedValue ? hardwareTypeImageMap[sanitizedValue] : '';
+      iconImage.classList.remove('is-rotated-90');
+      if (imageSrc) {
+        iconImage.src = imageSrc;
+        iconImage.hidden = false;
+        if (sanitizedValue === 'Bolt') {
+          iconImage.classList.add('is-rotated-90');
+        }
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+  }
+
+  if (hardwareTypePickerList) {
+    const optionItems = Array.from(
+      hardwareTypePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionItems.forEach(item => {
+      const isSelected = item.dataset.value === sanitizedValue;
+      item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      item.classList.toggle('is-selected', isSelected);
+      item.tabIndex = -1;
+    });
+  }
+}
 
 export function syncBoltDrivePicker({ isValid = true } = {}) {
   if (!boltDriveSelect) {
@@ -999,12 +1156,17 @@ export function handleStandardSelectKeydown(event) {
 
 function syncHardwareTypeControls(nextType) {
   const desiredType = nextType || state.hardwareType;
-  if (hardwareTypeSelect) {
-    hardwareTypeSelect.value = desiredType;
+  const sanitizedType = hardwareTypeOptions.has(desiredType) ? desiredType : '';
+
+  if (hardwareTypeSelect && sanitizedType) {
+    hardwareTypeSelect.value = sanitizedType;
   }
+
   hardwareTypeRadios.forEach(radio => {
-    radio.checked = radio.value === desiredType;
+    radio.checked = radio.value === sanitizedType;
   });
+
+  syncHardwareTypePicker();
 }
 
 export function onHardwareTypeChange() {

--- a/style.css
+++ b/style.css
@@ -348,6 +348,12 @@ main {
   visibility: hidden;
 }
 
+.bolt-drive-picker__current-icon-image.is-rotated-90,
+.bolt-drive-picker__option-icon-image.is-rotated-90 {
+  transform: rotate(90deg);
+  transform-origin: 50% 50%;
+}
+
 .bolt-drive-picker__current-icon-image {
   max-width: 100%;
   max-height: 100%;
@@ -442,6 +448,10 @@ main {
   flex-shrink: 0;
 }
 
+.bolt-drive-picker__option-icon.is-empty {
+  visibility: hidden;
+}
+
 .bolt-drive-picker__option-icon-image {
   max-width: 100%;
   max-height: 100%;
@@ -458,6 +468,23 @@ main {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.bolt-drive-picker__group {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--bs-secondary-color, #64748b);
+}
+
+.bolt-drive-picker__group + .bolt-drive-picker__option {
+  margin-top: 0.25rem;
+}
+
+.bolt-drive-picker__option + .bolt-drive-picker__group {
+  margin-top: 0.5rem;
 }
 
 .bolt-head-picker .bolt-drive-picker__current-icon-image,


### PR DESCRIPTION
## Summary
- replace the hardware type dropdown with a custom picker that mirrors the bolt drive/head controls and supports thumbnails
- add image mappings, picker population logic, and event handlers so hardware type options show the correct illustration
- extend shared picker styles and initialization to support grouped hardware options and rotated icons where needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8bcd1a57c8329b8b3676203ad9dd1