### PR TITLE
Add illustrated fuse type picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,85 +466,72 @@
                     ></div>
                   </div>
                 </div>
-                <div id="fuse-type-container" class="d-none">
-                  <label class="form-label fw-semibold">Fuse Type</label>
-                  <div class="row g-2" id="fuse-type-group">
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="fuse-type"
-                        id="fuse-type-glass"
-                        value="Glass"
-                        autocomplete="off"
-                        checked
-                      />
-                      <label
-                        class="btn btn-outline-secondary w-100 fuse-type-option text-start"
-                        for="fuse-type-glass"
+                <div id="fuse-selection-row" class="row g-3 d-none">
+                  <div class="col-12 col-sm-6" id="fuse-type-container">
+                    <label
+                      for="fuse-type-select"
+                      id="fuse-type-label"
+                      class="form-label fw-semibold"
+                      >Fuse Type</label
+                    >
+                    <div class="bolt-drive-picker" id="fuse-type-picker">
+                      <select
+                        id="fuse-type-select"
+                        class="visually-hidden"
+                        aria-labelledby="fuse-type-label"
                       >
-                        <span class="fuse-type-option__icon" aria-hidden="true">
-                          <img
-                            src="images/fuses/glass_fuse.svg"
-                            width="64"
-                            height="64"
-                            loading="lazy"
-                            alt=""
-                          />
-                        </span>
-                        <span class="fuse-type-option__content">
-                          <span class="fuse-type-option__title">Glass Fuse</span>
-                          <span class="fuse-type-option__description text-muted"
-                            >Cartridge-style tube fuse for electronics.</span
+                        <option value="Glass">Glass Fuse</option>
+                        <option value="Blade">Blade Fuse</option>
+                      </select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="fuse-type-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="fuse-type-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span
+                            class="bolt-drive-picker__current-icon is-empty"
+                            aria-hidden="true"
+                          >
+                            <img
+                              src=""
+                              alt=""
+                              class="bolt-drive-picker__current-icon-image"
+                              hidden
+                            />
+                          </span>
+                          <span class="bolt-drive-picker__current-label"
+                            >Select fuse type…</span
                           >
                         </span>
-                      </label>
-                    </div>
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="fuse-type"
-                        id="fuse-type-blade"
-                        value="Blade"
-                        autocomplete="off"
-                      />
-                      <label
-                        class="btn btn-outline-secondary w-100 fuse-type-option text-start"
-                        for="fuse-type-blade"
-                      >
-                        <span class="fuse-type-option__icon" aria-hidden="true">
-                          <img
-                            src="images/fuses/blade_fuse.svg"
-                            width="64"
-                            height="64"
-                            loading="lazy"
-                            alt=""
-                          />
-                        </span>
-                        <span class="fuse-type-option__content">
-                          <span class="fuse-type-option__title">Blade Fuse</span>
-                          <span class="fuse-type-option__description text-muted"
-                            >Automotive blade fuse for DC circuits.</span
-                          >
-                        </span>
-                      </label>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="fuse-type-picker-list"
+                        role="listbox"
+                        aria-labelledby="fuse-type-picker-button"
+                        hidden
+                      ></ul>
                     </div>
                   </div>
-                </div>
-                <div id="fuse-value-container" class="d-none">
-                  <label for="fuse-value-select" class="form-label fw-semibold"
-                    >Fuse Value (amps)</label
-                  >
-                  <select
-                    id="fuse-value-select"
-                    class="form-select"
-                    aria-describedby="fuse-value-message"
-                  ></select>
-                  <div
-                    id="fuse-value-message"
-                    class="validation-message text-danger small mt-2 d-none"
-                  ></div>
+                  <div class="col-12 col-sm-6" id="fuse-value-container">
+                    <label for="fuse-value-select" class="form-label fw-semibold"
+                      >Fuse Value (amps)</label
+                    >
+                    <select
+                      id="fuse-value-select"
+                      class="form-select"
+                      aria-describedby="fuse-value-message"
+                    ></select>
+                    <div
+                      id="fuse-value-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
                 </div>
                 <div id="glass-options-container" class="d-none">
                   <span class="form-label d-block fw-semibold">Glass Fuse Options</span>

--- a/js/controls.js
+++ b/js/controls.js
@@ -3,6 +3,7 @@ import { elements } from './dom-elements.js';
 import { initTheme } from './theme.js';
 import {
   populateFuseValues,
+  populateFuseTypePicker,
   populateConnectorCategories,
   populateBearingOptions,
   populateHardwareTypePicker,
@@ -11,6 +12,7 @@ import {
   setBoltDriveSelection,
   setBoltHeadSelection,
   setNutTypeSelection,
+  setFuseTypeSelection,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
@@ -19,7 +21,6 @@ import { hydrateStateFromUrl } from './url-state.js';
 function applyStateToControls() {
   const {
     systemTypeRadios,
-    fuseTypeRadios,
     fuseValueSelect,
     glassSizeSelect,
     glassSlowBlowCheckbox,
@@ -47,12 +48,7 @@ function applyStateToControls() {
       radio.checked = radio.value === state.systemType;
     });
   }
-  if (Array.isArray(fuseTypeRadios)) {
-    fuseTypeRadios.forEach(radio => {
-      radio.checked = radio.value === state.fuseType;
-    });
-  }
-
+  setFuseTypeSelection(state.fuseType || 'Glass', { triggerUpdate: false });
   if (fuseValueSelect) {
     fuseValueSelect.value = state.fuseValue || '';
   }
@@ -126,6 +122,7 @@ function init() {
   initTheme();
   hydrateStateFromUrl();
   populateFuseValues();
+  populateFuseTypePicker();
   populateConnectorCategories();
   populateBearingOptions();
   populateHardwareTypePicker();

--- a/js/data.js
+++ b/js/data.js
@@ -58,6 +58,11 @@ export const fuseValues = [
   '40',
 ];
 
+export const fuseTypeOptions = [
+  { id: 'Glass', label: 'Glass Fuse', image: 'images/fuses/glass_fuse.svg' },
+  { id: 'Blade', label: 'Blade Fuse', image: 'images/fuses/blade_fuse.svg' },
+];
+
 export const boltHeadOptions = [
   { id: 'button_head', label: 'Button Head', image: 'button_head' },
   { id: 'cap_head', label: 'Socket Cap', image: 'cap_head' },

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -19,7 +19,12 @@ const nutTypePickerButton = document.getElementById('nut-type-picker-button');
 const nutTypePickerList = document.getElementById('nut-type-picker-list');
 const nutTypeSelect = document.getElementById('nut-type-select');
 const nutTypeMessage = document.getElementById('nut-type-message');
+const fuseSelectionRow = document.getElementById('fuse-selection-row');
 const fuseTypeContainer = document.getElementById('fuse-type-container');
+const fuseTypeSelect = document.getElementById('fuse-type-select');
+const fuseTypePicker = document.getElementById('fuse-type-picker');
+const fuseTypePickerButton = document.getElementById('fuse-type-picker-button');
+const fuseTypePickerList = document.getElementById('fuse-type-picker-list');
 const fuseValueContainer = document.getElementById('fuse-value-container');
 const glassOptionsContainer = document.getElementById('glass-options-container');
 const fuseValueSelect = document.getElementById('fuse-value-select');
@@ -112,7 +117,6 @@ const hardwareTypeOptions = new Set(
     .filter(Boolean),
 );
 const systemTypeRadios = Array.from(document.querySelectorAll('input[name="system-type"]'));
-const fuseTypeRadios = Array.from(document.querySelectorAll('input[name="fuse-type"]'));
 const heightRadios = Array.from(document.querySelectorAll('input[name="label-height"]'));
 const componentCategoryRadios = Array.from(
   document.querySelectorAll('input[name="component-category"]'),
@@ -139,7 +143,12 @@ export const elements = {
   nutTypePickerList,
   nutTypeSelect,
   nutTypeMessage,
+  fuseSelectionRow,
   fuseTypeContainer,
+  fuseTypeSelect,
+  fuseTypePicker,
+  fuseTypePickerButton,
+  fuseTypePickerList,
   fuseValueContainer,
   glassOptionsContainer,
   fuseValueSelect,
@@ -224,7 +233,6 @@ export const elements = {
   hardwareTypePickerList,
   hardwareTypeOptions,
   systemTypeRadios,
-  fuseTypeRadios,
   heightRadios,
   componentCategoryRadios,
   componentMountRadios,

--- a/js/events.js
+++ b/js/events.js
@@ -4,7 +4,6 @@ import {
   applyHardwareTypeSelection,
   populateThreadSizes,
   populateStandards,
-  updateGlassOptionVisibility,
   updateConnectorCategoryUi,
   handleCustomImageFile,
   clearCustomImage,
@@ -17,6 +16,8 @@ import {
   setNutTypeSelection,
   syncNutTypePicker,
   syncHardwareTypePicker,
+  setFuseTypeSelection,
+  syncFuseTypePicker,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -32,7 +33,10 @@ const {
   componentMountRadios,
   bearingTypeSelect,
   systemTypeRadios,
-  fuseTypeRadios,
+  fuseTypeSelect,
+  fuseTypePicker,
+  fuseTypePickerButton,
+  fuseTypePickerList,
   threadSizeSelect,
   fuseValueSelect,
   glassSlowBlowCheckbox,
@@ -70,6 +74,7 @@ const {
 } = elements;
 
 let hardwareTypePickerOpen = false;
+let fuseTypePickerOpen = false;
 let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
@@ -283,6 +288,219 @@ function handleHardwareTypeListFocusOut() {
     const active = document.activeElement;
     if (!active || !hardwareTypePicker.contains(active)) {
       closeHardwareTypePicker();
+    }
+  }, 0);
+}
+
+function getFuseTypeOptionElements() {
+  if (!fuseTypePickerList) {
+    return [];
+  }
+  return Array.from(fuseTypePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusFuseTypeOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getFuseTypeOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openFuseTypePicker() {
+  if (!fuseTypePicker || !fuseTypePickerButton || !fuseTypePickerList) {
+    return;
+  }
+  if (fuseTypePickerButton.disabled) {
+    return;
+  }
+  if (fuseTypePickerOpen) {
+    return;
+  }
+  fuseTypePickerOpen = true;
+  fuseTypePicker.classList.add('is-open');
+  fuseTypePickerList.hidden = false;
+  fuseTypePickerButton.setAttribute('aria-expanded', 'true');
+  syncFuseTypePicker();
+
+  const options = getFuseTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.fuseType === 'string' ? state.fuseType : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusFuseTypeOption(selectedOption || options[0]);
+}
+
+function closeFuseTypePicker({ focusButton = false } = {}) {
+  if (!fuseTypePicker || !fuseTypePickerButton || !fuseTypePickerList) {
+    return;
+  }
+  if (!fuseTypePickerOpen) {
+    if (focusButton && !fuseTypePickerButton.disabled) {
+      fuseTypePickerButton.focus();
+    }
+    return;
+  }
+  fuseTypePickerOpen = false;
+  fuseTypePicker.classList.remove('is-open');
+  fuseTypePickerList.hidden = true;
+  fuseTypePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !fuseTypePickerButton.disabled) {
+    fuseTypePickerButton.focus();
+  }
+}
+
+function toggleFuseTypePicker() {
+  if (fuseTypePickerOpen) {
+    closeFuseTypePicker({ focusButton: false });
+  } else {
+    openFuseTypePicker();
+  }
+}
+
+function moveFuseTypeOption(delta) {
+  if (!fuseTypePickerList) {
+    return;
+  }
+  const options = getFuseTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && fuseTypePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.fuseType === 'string' ? state.fuseType : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusFuseTypeOption(nextOption);
+  }
+}
+
+function handleFuseTypeButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openFuseTypePicker();
+    moveFuseTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openFuseTypePicker();
+    moveFuseTypeOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleFuseTypePicker();
+    return;
+  }
+  if (key === 'Escape' && fuseTypePickerOpen) {
+    event.preventDefault();
+    closeFuseTypePicker({ focusButton: true });
+  }
+}
+
+function handleFuseTypeListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveFuseTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveFuseTypeOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getFuseTypeOptionElements();
+    if (options.length > 0) {
+      focusFuseTypeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getFuseTypeOptionElements();
+    if (options.length > 0) {
+      focusFuseTypeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setFuseTypeSelection(option.dataset.value || '');
+        closeFuseTypePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeFuseTypePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeFuseTypePicker();
+  }
+}
+
+function handleFuseTypeListClick(event) {
+  if (!fuseTypePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !fuseTypePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setFuseTypeSelection(option.dataset.value || '');
+  closeFuseTypePicker({ focusButton: true });
+}
+
+function handleFuseTypeListFocusOut() {
+  if (!fuseTypePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!fuseTypePickerOpen) {
+      return;
+    }
+    if (!fuseTypePicker) {
+      closeFuseTypePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !fuseTypePicker.contains(active)) {
+      closeFuseTypePicker();
     }
   }, 0);
 }
@@ -933,6 +1151,11 @@ function handleDocumentPointer(event) {
       closeHardwareTypePicker();
     }
   }
+  if (fuseTypePickerOpen && fuseTypePicker) {
+    if (!(target instanceof Node) || !fuseTypePicker.contains(target)) {
+      closeFuseTypePicker();
+    }
+  }
   if (boltDrivePickerOpen && boltDrivePicker) {
     if (!(target instanceof Node) || !boltDrivePicker.contains(target)) {
       closeBoltDrivePicker();
@@ -955,6 +1178,11 @@ function handleDocumentFocusIn(event) {
   if (hardwareTypePickerOpen && hardwareTypePicker) {
     if (!(target instanceof Node) || !hardwareTypePicker.contains(target)) {
       closeHardwareTypePicker();
+    }
+  }
+  if (fuseTypePickerOpen && fuseTypePicker) {
+    if (!(target instanceof Node) || !fuseTypePicker.contains(target)) {
+      closeFuseTypePicker();
     }
   }
   if (boltDrivePickerOpen && boltDrivePicker) {
@@ -1000,6 +1228,17 @@ export function initEventHandlers() {
     hardwareTypePickerList.addEventListener('click', handleHardwareTypeListClick);
     hardwareTypePickerList.addEventListener('keydown', handleHardwareTypeListKeydown);
     hardwareTypePickerList.addEventListener('focusout', handleHardwareTypeListFocusOut);
+  }
+
+  if (fuseTypePickerButton && fuseTypePickerList) {
+    fuseTypePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleFuseTypePicker();
+    });
+    fuseTypePickerButton.addEventListener('keydown', handleFuseTypeButtonKeydown);
+    fuseTypePickerList.addEventListener('click', handleFuseTypeListClick);
+    fuseTypePickerList.addEventListener('keydown', handleFuseTypeListKeydown);
+    fuseTypePickerList.addEventListener('focusout', handleFuseTypeListFocusOut);
   }
 
   if (connectorCategorySelect) {
@@ -1055,17 +1294,11 @@ export function initEventHandlers() {
     });
   });
 
-  fuseTypeRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      if (radio.checked) {
-        const previousType = state.fuseType;
-        state.fuseType = radio.value;
-        const shouldReset = previousType === 'Glass' && state.fuseType !== 'Glass';
-        updateGlassOptionVisibility({ resetIfHidden: shouldReset });
-        updatePreview();
-      }
+  if (fuseTypeSelect) {
+    fuseTypeSelect.addEventListener('change', () => {
+      setFuseTypeSelection(fuseTypeSelect.value);
     });
-  });
+  }
 
   if (threadSizeSelect) {
     threadSizeSelect.addEventListener('change', () => {
@@ -1234,10 +1467,14 @@ export function initEventHandlers() {
     nutTypePickerList.addEventListener('keydown', handleNutTypeListKeydown);
     nutTypePickerList.addEventListener('focusout', handleNutTypeListFocusOut);
   }
-  if (hardwareTypePicker || boltDrivePicker || boltHeadPicker || nutTypePicker) {
+  if (hardwareTypePicker || fuseTypePicker || boltDrivePicker || boltHeadPicker || nutTypePicker) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
   }
+
+  document.addEventListener('gridfinity:fuse-picker-close', () => {
+    closeFuseTypePicker();
+  });
 
   if (standardToggle) {
     standardToggle.addEventListener('change', () => {

--- a/js/forms.js
+++ b/js/forms.js
@@ -2,6 +2,7 @@ import { state, standardFilterState } from './state.js';
 import { elements } from './dom-elements.js';
 import {
   fuseValues,
+  fuseTypeOptions,
   bearingOptions,
   boltHeadOptions,
   boltDriveOptions,
@@ -20,7 +21,12 @@ const {
   threadSizeContainer,
   threadLengthRow,
   lengthContainer,
+  fuseSelectionRow,
   fuseTypeContainer,
+  fuseTypeSelect,
+  fuseTypePicker,
+  fuseTypePickerButton,
+  fuseTypePickerList,
   fuseValueContainer,
   glassOptionsContainer,
   fuseValueSelect,
@@ -80,6 +86,9 @@ const validBoltDriveIds = new Set(boltDriveOptions.map(option => option.id));
 const validBoltHeadIds = new Set(boltHeadOptions.map(option => option.id));
 const NUT_TYPE_PLACEHOLDER_TEXT = 'Select type…';
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
+const FUSE_TYPE_PLACEHOLDER_TEXT = 'Select fuse type…';
+const DEFAULT_FUSE_TYPE = 'Glass';
+const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 
 function createHardwareTypeOption(optionElement) {
   if (!hardwareTypePickerList) {
@@ -232,6 +241,154 @@ export function syncHardwareTypePicker() {
       item.tabIndex = -1;
     });
   }
+}
+
+export function syncFuseTypePicker({ isValid = true } = {}) {
+  const currentValue = typeof state.fuseType === 'string' ? state.fuseType : '';
+  const sanitizedValue = validFuseTypeIds.has(currentValue) ? currentValue : DEFAULT_FUSE_TYPE;
+
+  if (sanitizedValue !== currentValue) {
+    state.fuseType = sanitizedValue;
+  }
+
+  if (fuseTypeSelect) {
+    fuseTypeSelect.value = sanitizedValue;
+  }
+
+  const selectedOption = fuseTypeOptions.find(option => option.id === sanitizedValue) || null;
+
+  if (fuseTypePickerButton) {
+    const label = fuseTypePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = fuseTypePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = fuseTypePickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = selectedOption ? selectedOption.label : FUSE_TYPE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption && selectedOption.image) {
+        iconImage.src = selectedOption.image;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      fuseTypePickerButton.classList.remove('is-invalid');
+      fuseTypePickerButton.removeAttribute('aria-invalid');
+    } else {
+      fuseTypePickerButton.classList.add('is-invalid');
+      fuseTypePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (fuseTypePicker) {
+    fuseTypePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (fuseTypePickerList) {
+    const optionElements = Array.from(
+      fuseTypePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setFuseTypeSelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validFuseTypeIds.has(desiredValue) ? desiredValue : DEFAULT_FUSE_TYPE;
+  const previousValue = validFuseTypeIds.has(state.fuseType)
+    ? state.fuseType
+    : DEFAULT_FUSE_TYPE;
+
+  state.fuseType = sanitizedValue;
+  syncFuseTypePicker({ isValid: true });
+
+  const shouldResetGlassOptions = previousValue === 'Glass' && sanitizedValue !== 'Glass';
+  updateGlassOptionVisibility({ resetIfHidden: shouldResetGlassOptions });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function populateFuseTypePicker() {
+  if (!fuseTypeSelect) {
+    state.fuseType = DEFAULT_FUSE_TYPE;
+    return;
+  }
+
+  const previousType = typeof state.fuseType === 'string' ? state.fuseType : DEFAULT_FUSE_TYPE;
+
+  fuseTypeSelect.innerHTML = '';
+  if (fuseTypePickerList) {
+    fuseTypePickerList.innerHTML = '';
+  }
+
+  fuseTypeOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    fuseTypeSelect.appendChild(opt);
+
+    if (fuseTypePickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      if (option.image) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = option.image;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      fuseTypePickerList.appendChild(item);
+    }
+  });
+
+  const sanitizedValue = validFuseTypeIds.has(previousType) ? previousType : DEFAULT_FUSE_TYPE;
+  state.fuseType = sanitizedValue;
+  fuseTypeSelect.value = sanitizedValue;
+  fuseTypeSelect.disabled = false;
+
+  if (fuseTypePickerButton) {
+    fuseTypePickerButton.disabled = false;
+    fuseTypePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (fuseTypePickerList) {
+    fuseTypePickerList.hidden = true;
+  }
+
+  syncFuseTypePicker({ isValid: true });
 }
 
 export function syncBoltDrivePicker({ isValid = true } = {}) {
@@ -1297,6 +1454,33 @@ export function onHardwareTypeChange() {
         ? 'none'
         : '';
   }
+  if (fuseSelectionRow) {
+    fuseSelectionRow.classList.toggle('d-none', !showFuseFields);
+  }
+  if (fuseTypeSelect) {
+    fuseTypeSelect.disabled = !showFuseFields;
+    if (showFuseFields) {
+      const desiredType = validFuseTypeIds.has(state.fuseType)
+        ? state.fuseType
+        : DEFAULT_FUSE_TYPE;
+      fuseTypeSelect.value = desiredType;
+    }
+  }
+  if (fuseTypePickerButton) {
+    fuseTypePickerButton.disabled = !showFuseFields;
+    if (!showFuseFields) {
+      fuseTypePickerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+  if (fuseTypePickerList) {
+    fuseTypePickerList.hidden = !showFuseFields;
+  }
+  if (!showFuseFields && fuseTypePicker) {
+    fuseTypePicker.classList.remove('is-open');
+  }
+  if (!showFuseFields) {
+    document.dispatchEvent(new CustomEvent('gridfinity:fuse-picker-close'));
+  }
   if (fuseTypeContainer) {
     fuseTypeContainer.classList.toggle('d-none', !showFuseFields);
   }
@@ -1308,6 +1492,9 @@ export function onHardwareTypeChange() {
     if (showFuseFields) {
       fuseValueSelect.value = state.fuseValue || '';
     }
+  }
+  if (showFuseFields) {
+    syncFuseTypePicker();
   }
   if (connectorNotesHint) {
     connectorNotesHint.classList.toggle('d-none', !showConnectorFields);

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -50,7 +50,9 @@ const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) =>
 
 const hardwareTypeOptions = elements.hardwareTypeOptions || new Set();
 const fuseTypeOptions = new Set(
-  Array.isArray(elements.fuseTypeRadios) ? elements.fuseTypeRadios.map(radio => radio.value) : [],
+  elements.fuseTypeSelect
+    ? Array.from(elements.fuseTypeSelect.options, option => option.value).filter(Boolean)
+    : [],
 );
 const componentCategoryOptions = new Set(
   Array.isArray(elements.componentCategoryRadios)


### PR DESCRIPTION
## Summary
- replace the fuse type select with the shared picker UI so glass/blade choices display their icons beside the amperage dropdown
- add fuse type metadata, picker population, and state syncing so hardware toggles, URL hydration, and preview updates stay consistent
- extend event handling to support the new picker interactions and close/open logic when hardware type changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8c5a4918c83299e2374e6c4d47cb2