### PR TITLE
Standardize thread and fuse selectors with custom picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,11 +395,37 @@
                     <label for="thread-size-select" class="form-label fw-semibold"
                       >Thread Size</label
                     >
-                    <select
-                      id="thread-size-select"
-                      class="form-select picker-input"
-                      aria-describedby="thread-size-message"
-                    ></select>
+                    <div class="bolt-drive-picker" id="thread-size-picker">
+                      <select
+                        id="thread-size-select"
+                        class="visually-hidden"
+                        aria-describedby="thread-size-message"
+                      ></select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="thread-size-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="thread-size-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span
+                            class="bolt-drive-picker__current-icon is-empty"
+                            aria-hidden="true"
+                          ></span>
+                          <span class="bolt-drive-picker__current-label">Select size…</span>
+                        </span>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="thread-size-picker-list"
+                        role="listbox"
+                        aria-labelledby="thread-size-picker-button"
+                        hidden
+                      ></ul>
+                    </div>
                     <div
                       id="thread-size-message"
                       class="validation-message text-danger small mt-2 d-none"
@@ -522,11 +548,37 @@
                     <label for="fuse-value-select" class="form-label fw-semibold"
                       >Fuse Value (amps)</label
                     >
-                    <select
-                      id="fuse-value-select"
-                      class="form-select"
-                      aria-describedby="fuse-value-message"
-                    ></select>
+                    <div class="bolt-drive-picker" id="fuse-value-picker">
+                      <select
+                        id="fuse-value-select"
+                        class="visually-hidden"
+                        aria-describedby="fuse-value-message"
+                      ></select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="fuse-value-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="fuse-value-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span
+                            class="bolt-drive-picker__current-icon is-empty"
+                            aria-hidden="true"
+                          ></span>
+                          <span class="bolt-drive-picker__current-label">Select value…</span>
+                        </span>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="fuse-value-picker-list"
+                        role="listbox"
+                        aria-labelledby="fuse-value-picker-button"
+                        hidden
+                      ></ul>
+                    </div>
                     <div
                       id="fuse-value-message"
                       class="validation-message text-danger small mt-2 d-none"

--- a/js/controls.js
+++ b/js/controls.js
@@ -13,6 +13,8 @@ import {
   setBoltHeadSelection,
   setNutTypeSelection,
   setFuseTypeSelection,
+  setThreadSizeSelection,
+  setFuseValueSelection,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
@@ -49,9 +51,7 @@ function applyStateToControls() {
     });
   }
   setFuseTypeSelection(state.fuseType || 'Glass', { triggerUpdate: false });
-  if (fuseValueSelect) {
-    fuseValueSelect.value = state.fuseValue || '';
-  }
+  setFuseValueSelection(state.fuseValue || '', { triggerUpdate: false });
   if (glassSizeSelect) {
     glassSizeSelect.value = state.glassSize || '';
   }
@@ -65,9 +65,7 @@ function applyStateToControls() {
   if (connectorCategorySelect) {
     connectorCategorySelect.value = state.connectorCategory || '';
   }
-  if (threadSizeSelect) {
-    threadSizeSelect.value = state.threadSize || '';
-  }
+  setThreadSizeSelection(state.threadSize || '', { triggerUpdate: false });
   if (nutTypeSelect) {
     nutTypeSelect.value = state.nutType || '';
   }

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -8,6 +8,9 @@ const themeToggleText = themeToggleButton
 
 const threadSizeContainer = document.getElementById('thread-size-container');
 const threadSizeSelect = document.getElementById('thread-size-select');
+const threadSizePicker = document.getElementById('thread-size-picker');
+const threadSizePickerButton = document.getElementById('thread-size-picker-button');
+const threadSizePickerList = document.getElementById('thread-size-picker-list');
 const threadLengthRow = document.getElementById('thread-length-row');
 const lengthContainer = document.getElementById('length-container');
 const lengthInput = document.getElementById('length-input');
@@ -28,6 +31,9 @@ const fuseTypePickerList = document.getElementById('fuse-type-picker-list');
 const fuseValueContainer = document.getElementById('fuse-value-container');
 const glassOptionsContainer = document.getElementById('glass-options-container');
 const fuseValueSelect = document.getElementById('fuse-value-select');
+const fuseValuePicker = document.getElementById('fuse-value-picker');
+const fuseValuePickerButton = document.getElementById('fuse-value-picker-button');
+const fuseValuePickerList = document.getElementById('fuse-value-picker-list');
 const glassSizeSelect = document.getElementById('glass-size-select');
 const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
 const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
@@ -132,6 +138,9 @@ export const elements = {
   themeToggleText,
   threadSizeContainer,
   threadSizeSelect,
+  threadSizePicker,
+  threadSizePickerButton,
+  threadSizePickerList,
   threadLengthRow,
   lengthContainer,
   lengthInput,
@@ -152,6 +161,9 @@ export const elements = {
   fuseValueContainer,
   glassOptionsContainer,
   fuseValueSelect,
+  fuseValuePicker,
+  fuseValuePickerButton,
+  fuseValuePickerList,
   glassSizeSelect,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,

--- a/js/events.js
+++ b/js/events.js
@@ -9,6 +9,8 @@ import {
   clearCustomImage,
   handleStandardSelectKeydown,
   clearStandardFilter,
+  setThreadSizeSelection,
+  syncThreadSizePicker,
   setBoltDriveSelection,
   setBoltHeadSelection,
   syncBoltDrivePicker,
@@ -18,6 +20,8 @@ import {
   syncHardwareTypePicker,
   setFuseTypeSelection,
   syncFuseTypePicker,
+  setFuseValueSelection,
+  syncFuseValuePicker,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -38,7 +42,13 @@ const {
   fuseTypePickerButton,
   fuseTypePickerList,
   threadSizeSelect,
+  threadSizePicker,
+  threadSizePickerButton,
+  threadSizePickerList,
   fuseValueSelect,
+  fuseValuePicker,
+  fuseValuePickerButton,
+  fuseValuePickerList,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
   glassSizeSelect,
@@ -75,9 +85,11 @@ const {
 
 let hardwareTypePickerOpen = false;
 let fuseTypePickerOpen = false;
+let threadSizePickerOpen = false;
 let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
+let fuseValuePickerOpen = false;
 
 function getHardwareTypeOptionElements() {
   if (!hardwareTypePickerList) {
@@ -501,6 +513,426 @@ function handleFuseTypeListFocusOut() {
     const active = document.activeElement;
     if (!active || !fuseTypePicker.contains(active)) {
       closeFuseTypePicker();
+    }
+  }, 0);
+}
+
+function getThreadSizeOptionElements() {
+  if (!threadSizePickerList) {
+    return [];
+  }
+  return Array.from(threadSizePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusThreadSizeOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getThreadSizeOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openThreadSizePicker() {
+  if (!threadSizePicker || !threadSizePickerButton || !threadSizePickerList) {
+    return;
+  }
+  if (threadSizePickerButton.disabled || threadSizePickerOpen) {
+    return;
+  }
+  threadSizePickerOpen = true;
+  threadSizePicker.classList.add('is-open');
+  threadSizePickerList.hidden = false;
+  threadSizePickerButton.setAttribute('aria-expanded', 'true');
+  syncThreadSizePicker({ isValid: true });
+
+  const options = getThreadSizeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.threadSize === 'string' ? state.threadSize : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusThreadSizeOption(selectedOption || options[0]);
+}
+
+function closeThreadSizePicker({ focusButton = false } = {}) {
+  if (!threadSizePicker || !threadSizePickerButton || !threadSizePickerList) {
+    return;
+  }
+  if (!threadSizePickerOpen) {
+    if (focusButton && !threadSizePickerButton.disabled) {
+      threadSizePickerButton.focus();
+    }
+    return;
+  }
+  threadSizePickerOpen = false;
+  threadSizePicker.classList.remove('is-open');
+  threadSizePickerList.hidden = true;
+  threadSizePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !threadSizePickerButton.disabled) {
+    threadSizePickerButton.focus();
+  }
+}
+
+function toggleThreadSizePicker() {
+  if (threadSizePickerOpen) {
+    closeThreadSizePicker({ focusButton: false });
+  } else {
+    openThreadSizePicker();
+  }
+}
+
+function moveThreadSizeOption(delta) {
+  if (!threadSizePickerList) {
+    return;
+  }
+  const options = getThreadSizeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && threadSizePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.threadSize === 'string' ? state.threadSize : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusThreadSizeOption(nextOption);
+  }
+}
+
+function handleThreadSizeButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openThreadSizePicker();
+    moveThreadSizeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openThreadSizePicker();
+    moveThreadSizeOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleThreadSizePicker();
+    return;
+  }
+  if (key === 'Escape' && threadSizePickerOpen) {
+    event.preventDefault();
+    closeThreadSizePicker({ focusButton: true });
+  }
+}
+
+function handleThreadSizeListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveThreadSizeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveThreadSizeOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getThreadSizeOptionElements();
+    if (options.length > 0) {
+      focusThreadSizeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getThreadSizeOptionElements();
+    if (options.length > 0) {
+      focusThreadSizeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setThreadSizeSelection(option.dataset.value || '');
+        closeThreadSizePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeThreadSizePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeThreadSizePicker();
+  }
+}
+
+function handleThreadSizeListClick(event) {
+  if (!threadSizePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !threadSizePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setThreadSizeSelection(option.dataset.value || '');
+  closeThreadSizePicker({ focusButton: true });
+}
+
+function handleThreadSizeListFocusOut() {
+  if (!threadSizePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!threadSizePickerOpen) {
+      return;
+    }
+    if (!threadSizePicker) {
+      closeThreadSizePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !threadSizePicker.contains(active)) {
+      closeThreadSizePicker();
+    }
+  }, 0);
+}
+
+function getFuseValueOptionElements() {
+  if (!fuseValuePickerList) {
+    return [];
+  }
+  return Array.from(fuseValuePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusFuseValueOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getFuseValueOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openFuseValuePicker() {
+  if (!fuseValuePicker || !fuseValuePickerButton || !fuseValuePickerList) {
+    return;
+  }
+  if (fuseValuePickerButton.disabled || fuseValuePickerOpen) {
+    return;
+  }
+  fuseValuePickerOpen = true;
+  fuseValuePicker.classList.add('is-open');
+  fuseValuePickerList.hidden = false;
+  fuseValuePickerButton.setAttribute('aria-expanded', 'true');
+  syncFuseValuePicker({ isValid: true });
+
+  const options = getFuseValueOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.fuseValue === 'string' ? state.fuseValue : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusFuseValueOption(selectedOption || options[0]);
+}
+
+function closeFuseValuePicker({ focusButton = false } = {}) {
+  if (!fuseValuePicker || !fuseValuePickerButton || !fuseValuePickerList) {
+    return;
+  }
+  if (!fuseValuePickerOpen) {
+    if (focusButton && !fuseValuePickerButton.disabled) {
+      fuseValuePickerButton.focus();
+    }
+    return;
+  }
+  fuseValuePickerOpen = false;
+  fuseValuePicker.classList.remove('is-open');
+  fuseValuePickerList.hidden = true;
+  fuseValuePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !fuseValuePickerButton.disabled) {
+    fuseValuePickerButton.focus();
+  }
+}
+
+function toggleFuseValuePicker() {
+  if (fuseValuePickerOpen) {
+    closeFuseValuePicker({ focusButton: false });
+  } else {
+    openFuseValuePicker();
+  }
+}
+
+function moveFuseValueOption(delta) {
+  if (!fuseValuePickerList) {
+    return;
+  }
+  const options = getFuseValueOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && fuseValuePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.fuseValue === 'string' ? state.fuseValue : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusFuseValueOption(nextOption);
+  }
+}
+
+function handleFuseValueButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openFuseValuePicker();
+    moveFuseValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openFuseValuePicker();
+    moveFuseValueOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleFuseValuePicker();
+    return;
+  }
+  if (key === 'Escape' && fuseValuePickerOpen) {
+    event.preventDefault();
+    closeFuseValuePicker({ focusButton: true });
+  }
+}
+
+function handleFuseValueListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveFuseValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveFuseValueOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getFuseValueOptionElements();
+    if (options.length > 0) {
+      focusFuseValueOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getFuseValueOptionElements();
+    if (options.length > 0) {
+      focusFuseValueOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setFuseValueSelection(option.dataset.value || '');
+        closeFuseValuePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeFuseValuePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeFuseValuePicker();
+  }
+}
+
+function handleFuseValueListClick(event) {
+  if (!fuseValuePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !fuseValuePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setFuseValueSelection(option.dataset.value || '');
+  closeFuseValuePicker({ focusButton: true });
+}
+
+function handleFuseValueListFocusOut() {
+  if (!fuseValuePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!fuseValuePickerOpen) {
+      return;
+    }
+    if (!fuseValuePicker) {
+      closeFuseValuePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !fuseValuePicker.contains(active)) {
+      closeFuseValuePicker();
     }
   }, 0);
 }
@@ -1156,6 +1588,11 @@ function handleDocumentPointer(event) {
       closeFuseTypePicker();
     }
   }
+  if (threadSizePickerOpen && threadSizePicker) {
+    if (!(target instanceof Node) || !threadSizePicker.contains(target)) {
+      closeThreadSizePicker();
+    }
+  }
   if (boltDrivePickerOpen && boltDrivePicker) {
     if (!(target instanceof Node) || !boltDrivePicker.contains(target)) {
       closeBoltDrivePicker();
@@ -1169,6 +1606,11 @@ function handleDocumentPointer(event) {
   if (nutTypePickerOpen && nutTypePicker) {
     if (!(target instanceof Node) || !nutTypePicker.contains(target)) {
       closeNutTypePicker();
+    }
+  }
+  if (fuseValuePickerOpen && fuseValuePicker) {
+    if (!(target instanceof Node) || !fuseValuePicker.contains(target)) {
+      closeFuseValuePicker();
     }
   }
 }
@@ -1185,6 +1627,11 @@ function handleDocumentFocusIn(event) {
       closeFuseTypePicker();
     }
   }
+  if (threadSizePickerOpen && threadSizePicker) {
+    if (!(target instanceof Node) || !threadSizePicker.contains(target)) {
+      closeThreadSizePicker();
+    }
+  }
   if (boltDrivePickerOpen && boltDrivePicker) {
     if (!(target instanceof Node) || !boltDrivePicker.contains(target)) {
       closeBoltDrivePicker();
@@ -1198,6 +1645,11 @@ function handleDocumentFocusIn(event) {
   if (nutTypePickerOpen && nutTypePicker) {
     if (!(target instanceof Node) || !nutTypePicker.contains(target)) {
       closeNutTypePicker();
+    }
+  }
+  if (fuseValuePickerOpen && fuseValuePicker) {
+    if (!(target instanceof Node) || !fuseValuePicker.contains(target)) {
+      closeFuseValuePicker();
     }
   }
 }
@@ -1239,6 +1691,28 @@ export function initEventHandlers() {
     fuseTypePickerList.addEventListener('click', handleFuseTypeListClick);
     fuseTypePickerList.addEventListener('keydown', handleFuseTypeListKeydown);
     fuseTypePickerList.addEventListener('focusout', handleFuseTypeListFocusOut);
+  }
+
+  if (threadSizePickerButton && threadSizePickerList) {
+    threadSizePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleThreadSizePicker();
+    });
+    threadSizePickerButton.addEventListener('keydown', handleThreadSizeButtonKeydown);
+    threadSizePickerList.addEventListener('click', handleThreadSizeListClick);
+    threadSizePickerList.addEventListener('keydown', handleThreadSizeListKeydown);
+    threadSizePickerList.addEventListener('focusout', handleThreadSizeListFocusOut);
+  }
+
+  if (fuseValuePickerButton && fuseValuePickerList) {
+    fuseValuePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleFuseValuePicker();
+    });
+    fuseValuePickerButton.addEventListener('keydown', handleFuseValueButtonKeydown);
+    fuseValuePickerList.addEventListener('click', handleFuseValueListClick);
+    fuseValuePickerList.addEventListener('keydown', handleFuseValueListKeydown);
+    fuseValuePickerList.addEventListener('focusout', handleFuseValueListFocusOut);
   }
 
   if (connectorCategorySelect) {
@@ -1302,17 +1776,13 @@ export function initEventHandlers() {
 
   if (threadSizeSelect) {
     threadSizeSelect.addEventListener('change', () => {
-      state.threadSize = threadSizeSelect.value;
-      updateDownloadState();
-      updatePreview();
+      setThreadSizeSelection(threadSizeSelect.value);
     });
   }
 
   if (fuseValueSelect) {
     fuseValueSelect.addEventListener('change', () => {
-      state.fuseValue = fuseValueSelect.value;
-      updateDownloadState();
-      updatePreview();
+      setFuseValueSelection(fuseValueSelect.value);
     });
   }
 
@@ -1467,13 +1937,22 @@ export function initEventHandlers() {
     nutTypePickerList.addEventListener('keydown', handleNutTypeListKeydown);
     nutTypePickerList.addEventListener('focusout', handleNutTypeListFocusOut);
   }
-  if (hardwareTypePicker || fuseTypePicker || boltDrivePicker || boltHeadPicker || nutTypePicker) {
+  if (
+    hardwareTypePicker ||
+    fuseTypePicker ||
+    threadSizePicker ||
+    boltDrivePicker ||
+    boltHeadPicker ||
+    nutTypePicker ||
+    fuseValuePicker
+  ) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
   }
 
   document.addEventListener('gridfinity:fuse-picker-close', () => {
     closeFuseTypePicker();
+    closeFuseValuePicker();
   });
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -15,7 +15,11 @@ import {
   findConnectorCategory,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
-import { populateThreadSizes } from './threadSizes.js';
+import {
+  populateThreadSizes,
+  syncThreadSizePicker,
+  setThreadSizeSelection,
+} from './threadSizes.js';
 
 const {
   threadSizeContainer,
@@ -30,6 +34,9 @@ const {
   fuseValueContainer,
   glassOptionsContainer,
   fuseValueSelect,
+  fuseValuePicker,
+  fuseValuePickerButton,
+  fuseValuePickerList,
   glassSizeSelect,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
@@ -89,6 +96,8 @@ const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
 const FUSE_TYPE_PLACEHOLDER_TEXT = 'Select fuse type…';
 const DEFAULT_FUSE_TYPE = 'Glass';
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
+const FUSE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
 
 function createHardwareTypeOption(optionElement) {
   if (!hardwareTypePickerList) {
@@ -808,7 +817,71 @@ export function updateConnectorCategoryUi() {
   notesInput.placeholder = example;
 }
 
-export { populateThreadSizes };
+export { populateThreadSizes, syncThreadSizePicker, setThreadSizeSelection };
+
+export function syncFuseValuePicker({ isValid = true } = {}) {
+  if (!fuseValueSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.fuseValue === 'string' ? state.fuseValue.trim() : '';
+  const sanitizedValue = currentValue && validFuseValuesSet.has(currentValue) ? currentValue : '';
+
+  if (sanitizedValue !== currentValue) {
+    state.fuseValue = sanitizedValue;
+  }
+
+  fuseValueSelect.value = sanitizedValue;
+
+  if (fuseValuePickerButton) {
+    const label = fuseValuePickerButton.querySelector('.bolt-drive-picker__current-label');
+    if (label) {
+      label.textContent = sanitizedValue ? `${sanitizedValue} A` : FUSE_VALUE_PLACEHOLDER_TEXT;
+    }
+    const iconWrapper = fuseValuePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    if (iconWrapper) {
+      iconWrapper.classList.add('is-empty');
+    }
+
+    if (isValid) {
+      fuseValuePickerButton.classList.remove('is-invalid');
+      fuseValuePickerButton.removeAttribute('aria-invalid');
+    } else {
+      fuseValuePickerButton.classList.add('is-invalid');
+      fuseValuePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (fuseValuePicker) {
+    fuseValuePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (fuseValuePickerList) {
+    const optionElements = Array.from(
+      fuseValuePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setFuseValueSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = desiredValue && validFuseValuesSet.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.fuseValue === 'string' ? state.fuseValue : '';
+
+  state.fuseValue = sanitizedValue;
+  syncFuseValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
 
 export function populateFuseValues() {
   if (!fuseValueSelect) {
@@ -817,7 +890,7 @@ export function populateFuseValues() {
   fuseValueSelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
-  placeholder.textContent = 'Select value…';
+  placeholder.textContent = FUSE_VALUE_PLACEHOLDER_TEXT;
   fuseValueSelect.appendChild(placeholder);
   fuseValues.forEach(value => {
     const opt = document.createElement('option');
@@ -825,7 +898,45 @@ export function populateFuseValues() {
     opt.textContent = `${value} A`;
     fuseValueSelect.appendChild(opt);
   });
-  fuseValueSelect.value = state.fuseValue || '';
+
+  const currentValue = typeof state.fuseValue === 'string' ? state.fuseValue.trim() : '';
+  const sanitizedValue = currentValue && validFuseValuesSet.has(currentValue) ? currentValue : '';
+  state.fuseValue = sanitizedValue;
+  fuseValueSelect.value = sanitizedValue;
+
+  if (fuseValuePickerList) {
+    fuseValuePickerList.innerHTML = '';
+    fuseValues.forEach(value => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = value;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon is-empty';
+      icon.setAttribute('aria-hidden', 'true');
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = `${value} A`;
+      item.appendChild(label);
+
+      fuseValuePickerList.appendChild(item);
+    });
+    fuseValuePickerList.hidden = false;
+  }
+  if (fuseValuePickerButton) {
+    fuseValuePickerButton.disabled = false;
+    fuseValuePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (fuseValuePicker) {
+    fuseValuePicker.classList.remove('is-open');
+  }
+
+  syncFuseValuePicker({ isValid: true });
 }
 
 export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
@@ -1493,8 +1604,21 @@ export function onHardwareTypeChange() {
       fuseValueSelect.value = state.fuseValue || '';
     }
   }
+  if (fuseValuePickerButton) {
+    fuseValuePickerButton.disabled = !showFuseFields;
+    if (!showFuseFields) {
+      fuseValuePickerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+  if (fuseValuePickerList) {
+    fuseValuePickerList.hidden = !showFuseFields;
+  }
+  if (!showFuseFields && fuseValuePicker) {
+    fuseValuePicker.classList.remove('is-open');
+  }
   if (showFuseFields) {
     syncFuseTypePicker();
+    syncFuseValuePicker({ isValid: true });
   }
   if (connectorNotesHint) {
     connectorNotesHint.classList.toggle('d-none', !showConnectorFields);

--- a/js/render.js
+++ b/js/render.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
-import { syncBoltDrivePicker } from './forms.js';
+import { syncBoltDrivePicker, syncThreadSizePicker, syncFuseValuePicker } from './forms.js';
 import {
   pxPerMm,
   hardwareImageFolders,
@@ -396,6 +396,7 @@ function applyValidationFeedback(disabled) {
       messageElement: threadSizeMessage,
       valid,
     });
+    syncThreadSizePicker({ isValid: valid });
     if (!valid) {
       requirements.push('select a size');
     }
@@ -406,6 +407,7 @@ function applyValidationFeedback(disabled) {
       messageElement: threadSizeMessage,
       valid: true,
     });
+    syncThreadSizePicker({ isValid: true });
   }
 
   const requiresLength =
@@ -440,6 +442,7 @@ function applyValidationFeedback(disabled) {
       messageElement: fuseValueMessage,
       valid,
     });
+    syncFuseValuePicker({ isValid: valid });
     if (!valid) {
       requirements.push('choose a fuse value');
     }
@@ -450,6 +453,7 @@ function applyValidationFeedback(disabled) {
       messageElement: fuseValueMessage,
       valid: true,
     });
+    syncFuseValuePicker({ isValid: true });
   }
 
   if (hardwareType === 'Bolt' && (state.showImage || state.showStandard)) {

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -3,7 +3,118 @@ import { elements } from './dom-elements.js';
 import { metricThreadSizes, imperialThreadSizes } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 
-const { threadSizeSelect } = elements;
+const {
+  threadSizeSelect,
+  threadSizePicker,
+  threadSizePickerButton,
+  threadSizePickerList,
+} = elements;
+
+const THREAD_SIZE_PLACEHOLDER_TEXT = 'Select size…';
+const THREAD_SIZE_NOT_APPLICABLE_TEXT = 'Not applicable';
+
+let validThreadSizes = new Set();
+
+function updateThreadSizePickerLabel(text) {
+  if (!threadSizePickerButton) {
+    return;
+  }
+  const label = threadSizePickerButton.querySelector('.bolt-drive-picker__current-label');
+  if (label) {
+    label.textContent = text;
+  }
+  const iconWrapper = threadSizePickerButton.querySelector('.bolt-drive-picker__current-icon');
+  if (iconWrapper) {
+    iconWrapper.classList.add('is-empty');
+  }
+}
+
+function buildThreadSizeOptionItem(value) {
+  if (!threadSizePickerList) {
+    return;
+  }
+  const item = document.createElement('li');
+  item.className = 'bolt-drive-picker__option';
+  item.dataset.value = value;
+  item.setAttribute('role', 'option');
+  item.tabIndex = -1;
+  item.setAttribute('aria-selected', 'false');
+
+  const icon = document.createElement('span');
+  icon.className = 'bolt-drive-picker__option-icon is-empty';
+  icon.setAttribute('aria-hidden', 'true');
+  item.appendChild(icon);
+
+  const label = document.createElement('span');
+  label.className = 'bolt-drive-picker__option-label';
+  label.textContent = value;
+  item.appendChild(label);
+
+  threadSizePickerList.appendChild(item);
+}
+
+export function syncThreadSizePicker({ isValid = true } = {}) {
+  if (!threadSizeSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.threadSize === 'string' ? state.threadSize.trim() : '';
+  const sanitizedValue = validThreadSizes.has(currentValue) ? currentValue : '';
+
+  if (sanitizedValue !== currentValue) {
+    state.threadSize = sanitizedValue;
+  }
+
+  threadSizeSelect.value = sanitizedValue;
+  if (!sanitizedValue && threadSizeSelect.options.length > 0) {
+    threadSizeSelect.selectedIndex = 0;
+  }
+
+  if (threadSizePickerButton) {
+    const labelText = threadSizePickerButton.disabled
+      ? THREAD_SIZE_NOT_APPLICABLE_TEXT
+      : sanitizedValue || THREAD_SIZE_PLACEHOLDER_TEXT;
+    updateThreadSizePickerLabel(labelText);
+
+    if (isValid) {
+      threadSizePickerButton.classList.remove('is-invalid');
+      threadSizePickerButton.removeAttribute('aria-invalid');
+    } else {
+      threadSizePickerButton.classList.add('is-invalid');
+      threadSizePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (threadSizePicker) {
+    threadSizePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (threadSizePickerList) {
+    const optionElements = Array.from(
+      threadSizePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setThreadSizeSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = desiredValue && validThreadSizes.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.threadSize === 'string' ? state.threadSize : '';
+
+  state.threadSize = sanitizedValue;
+  syncThreadSizePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
 
 export function populateThreadSizes() {
   if (
@@ -13,14 +124,27 @@ export function populateThreadSizes() {
     state.hardwareType === 'Bearing' ||
     state.hardwareType === 'Component'
   ) {
+    validThreadSizes = new Set();
     if (threadSizeSelect) {
       threadSizeSelect.innerHTML = '';
       const placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = 'Not applicable';
+      placeholder.textContent = THREAD_SIZE_NOT_APPLICABLE_TEXT;
       placeholder.selected = true;
       threadSizeSelect.appendChild(placeholder);
       threadSizeSelect.disabled = true;
+    }
+    if (threadSizePickerList) {
+      threadSizePickerList.innerHTML = '';
+      threadSizePickerList.hidden = true;
+    }
+    if (threadSizePickerButton) {
+      threadSizePickerButton.disabled = true;
+      threadSizePickerButton.setAttribute('aria-expanded', 'false');
+      updateThreadSizePickerLabel(THREAD_SIZE_NOT_APPLICABLE_TEXT);
+    }
+    if (threadSizePicker) {
+      threadSizePicker.classList.remove('is-open');
     }
     state.threadSize = '';
     updateDownloadState();
@@ -29,6 +153,8 @@ export function populateThreadSizes() {
   }
 
   const list = state.systemType === 'Metric' ? metricThreadSizes : imperialThreadSizes;
+  validThreadSizes = new Set(list);
+
   if (!threadSizeSelect) {
     state.threadSize = '';
     updateDownloadState();
@@ -40,10 +166,9 @@ export function populateThreadSizes() {
   threadSizeSelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
-  placeholder.textContent = 'Select size…';
+  placeholder.textContent = THREAD_SIZE_PLACEHOLDER_TEXT;
   threadSizeSelect.appendChild(placeholder);
 
-  const validSizes = new Set(list);
   list.forEach(size => {
     const opt = document.createElement('option');
     opt.value = size;
@@ -52,12 +177,29 @@ export function populateThreadSizes() {
   });
 
   const previous = typeof state.threadSize === 'string' ? state.threadSize.trim() : '';
-  const normalized = previous && validSizes.has(previous) ? previous : '';
+  const normalized = previous && validThreadSizes.has(previous) ? previous : '';
   state.threadSize = normalized;
   threadSizeSelect.value = normalized;
   if (!normalized) {
     placeholder.selected = true;
   }
+
+  if (threadSizePickerList) {
+    threadSizePickerList.innerHTML = '';
+    list.forEach(size => {
+      buildThreadSizeOptionItem(size);
+    });
+    threadSizePickerList.hidden = false;
+  }
+  if (threadSizePickerButton) {
+    threadSizePickerButton.disabled = false;
+    threadSizePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (threadSizePicker) {
+    threadSizePicker.classList.remove('is-open');
+  }
+
+  syncThreadSizePicker({ isValid: true });
   updateDownloadState();
   updatePreview();
 }


### PR DESCRIPTION
## Summary
- convert the thread size and fuse value controls to use the custom bolt-drive picker UI so their buttons match existing dropdown styling
- extend picker population, state sync, and validation logic to support the new controls and keep their buttons in sync with form state
- update initialization and event handling so picker interactions work across hardware types and maintain accessibility

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d8d33265c08329afed9b0426b42cae