### PR TITLE
Fix thread size picker opening on load

### DIFF
--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -189,7 +189,7 @@ export function populateThreadSizes() {
     list.forEach(size => {
       buildThreadSizeOptionItem(size);
     });
-    threadSizePickerList.hidden = false;
+    threadSizePickerList.hidden = true;
   }
   if (threadSizePickerButton) {
     threadSizePickerButton.disabled = false;


### PR DESCRIPTION
## Summary
- ensure the thread size picker list stays hidden after repopulating options so it isn't displayed by default

## Testing
- manual verification by loading index.html and confirming the thread size picker remains closed

------
https://chatgpt.com/codex/tasks/task_e_68d8f952666883299f362618aadabc00