### PR TITLE
Fix fuse picker lists showing open when selecting fuse hardware type

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -926,7 +926,8 @@ export function populateFuseValues() {
 
       fuseValuePickerList.appendChild(item);
     });
-    fuseValuePickerList.hidden = false;
+    const shouldHideList = !fuseValuePicker || !fuseValuePicker.classList.contains('is-open');
+    fuseValuePickerList.hidden = shouldHideList;
   }
   if (fuseValuePickerButton) {
     fuseValuePickerButton.disabled = false;
@@ -1581,10 +1582,15 @@ export function onHardwareTypeChange() {
     fuseTypePickerButton.disabled = !showFuseFields;
     if (!showFuseFields) {
       fuseTypePickerButton.setAttribute('aria-expanded', 'false');
+    } else {
+      const isOpen = Boolean(fuseTypePicker && fuseTypePicker.classList.contains('is-open'));
+      fuseTypePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     }
   }
   if (fuseTypePickerList) {
-    fuseTypePickerList.hidden = !showFuseFields;
+    const shouldHideList =
+      !showFuseFields || !fuseTypePicker || !fuseTypePicker.classList.contains('is-open');
+    fuseTypePickerList.hidden = shouldHideList;
   }
   if (!showFuseFields && fuseTypePicker) {
     fuseTypePicker.classList.remove('is-open');
@@ -1608,10 +1614,15 @@ export function onHardwareTypeChange() {
     fuseValuePickerButton.disabled = !showFuseFields;
     if (!showFuseFields) {
       fuseValuePickerButton.setAttribute('aria-expanded', 'false');
+    } else {
+      const isOpen = Boolean(fuseValuePicker && fuseValuePicker.classList.contains('is-open'));
+      fuseValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     }
   }
   if (fuseValuePickerList) {
-    fuseValuePickerList.hidden = !showFuseFields;
+    const shouldHideList =
+      !showFuseFields || !fuseValuePicker || !fuseValuePicker.classList.contains('is-open');
+    fuseValuePickerList.hidden = shouldHideList;
   }
   if (!showFuseFields && fuseValuePicker) {
     fuseValuePicker.classList.remove('is-open');


### PR DESCRIPTION
## Summary
- ensure fuse type and fuse value picker lists stay hidden until explicitly opened
- keep aria-expanded attributes aligned with each picker's open state

## Testing
- npm run lint *(fails: existing no-unused-vars errors in js/controls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d904be0dd48329a817a0ece71d7569