### PR TITLE
Add ceramic fuse type with shared size controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,6 +613,34 @@
                     </div>
                   </div>
                 </div>
+                <div id="ceramic-options-container" class="d-none">
+                  <span class="form-label d-block fw-semibold">Ceramic Fuse Options</span>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="ceramic-slow-blow" />
+                    <label class="form-check-label" for="ceramic-slow-blow"
+                      >Slow-blow (time delay)</label
+                    >
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="ceramic-fast-blow" />
+                    <label class="form-check-label" for="ceramic-fast-blow">Fast-blow</label>
+                  </div>
+                  <div class="mt-2">
+                    <label for="ceramic-size-select" class="form-label fw-semibold"
+                      >Ceramic Fuse Size</label
+                    >
+                    <select id="ceramic-size-select" class="form-select">
+                      <option value="">Select size…</option>
+                      <option value="5 × 20 mm">5 × 20 mm</option>
+                      <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
+                        6.3 × 32 mm (1/4″ × 1-1/4″)
+                      </option>
+                    </select>
+                    <div class="form-text">
+                      Standard ceramic fuse sizes: 5 × 20 mm and 6.3 × 32 mm.
+                    </div>
+                  </div>
+                </div>
                 <div id="standard-field">
                   <label
                     for="standard-select"

--- a/js/actions.js
+++ b/js/actions.js
@@ -75,12 +75,16 @@ export function downloadLabel() {
         if (state.fuseValue) {
           fileParts.push(`${state.fuseValue}A`);
         }
-        if (state.fuseType === 'Glass') {
-          if (state.glassSize) {
-            fileParts.push(state.glassSize);
+        if (state.fuseType === 'Glass' || state.fuseType === 'Ceramic') {
+          const fuseSize =
+            state.fuseType === 'Glass' ? state.glassSize : state.ceramicSize;
+          const fuseSpeed =
+            state.fuseType === 'Glass' ? state.glassSpeed : state.ceramicSpeed;
+          if (fuseSize) {
+            fileParts.push(fuseSize);
           }
-          if (state.glassSpeed) {
-            fileParts.push(state.glassSpeed);
+          if (fuseSpeed) {
+            fileParts.push(fuseSpeed);
           }
         }
       } else if (state.hardwareType === 'Connector') {

--- a/js/controls.js
+++ b/js/controls.js
@@ -23,10 +23,12 @@ import { hydrateStateFromUrl } from './url-state.js';
 function applyStateToControls() {
   const {
     systemTypeRadios,
-    fuseValueSelect,
     glassSizeSelect,
     glassSlowBlowCheckbox,
     glassFastBlowCheckbox,
+    ceramicSizeSelect,
+    ceramicSlowBlowCheckbox,
+    ceramicFastBlowCheckbox,
     lengthInput,
     notesInput,
     customLine1Input,
@@ -40,7 +42,6 @@ function applyStateToControls() {
     widthValueSpan,
     heightRadios,
     connectorCategorySelect,
-    threadSizeSelect,
     nutTypeSelect,
     bearingTypeSelect,
   } = elements;
@@ -60,6 +61,15 @@ function applyStateToControls() {
   }
   if (glassFastBlowCheckbox) {
     glassFastBlowCheckbox.checked = state.glassSpeed.startsWith('Fast');
+  }
+  if (ceramicSizeSelect) {
+    ceramicSizeSelect.value = state.ceramicSize || '';
+  }
+  if (ceramicSlowBlowCheckbox) {
+    ceramicSlowBlowCheckbox.checked = state.ceramicSpeed.startsWith('Slow');
+  }
+  if (ceramicFastBlowCheckbox) {
+    ceramicFastBlowCheckbox.checked = state.ceramicSpeed.startsWith('Fast');
   }
 
   if (connectorCategorySelect) {

--- a/js/data.js
+++ b/js/data.js
@@ -60,6 +60,7 @@ export const fuseValues = [
 
 export const fuseTypeOptions = [
   { id: 'Glass', label: 'Glass Fuse', image: 'images/fuses/glass_fuse.svg' },
+  { id: 'Ceramic', label: 'Ceramic Fuse', image: 'images/fuses/ceramic_fuse.svg' },
   { id: 'Blade', label: 'Blade Fuse', image: 'images/fuses/blade_fuse.svg' },
 ];
 

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -30,6 +30,7 @@ const fuseTypePickerButton = document.getElementById('fuse-type-picker-button');
 const fuseTypePickerList = document.getElementById('fuse-type-picker-list');
 const fuseValueContainer = document.getElementById('fuse-value-container');
 const glassOptionsContainer = document.getElementById('glass-options-container');
+const ceramicOptionsContainer = document.getElementById('ceramic-options-container');
 const fuseValueSelect = document.getElementById('fuse-value-select');
 const fuseValuePicker = document.getElementById('fuse-value-picker');
 const fuseValuePickerButton = document.getElementById('fuse-value-picker-button');
@@ -37,6 +38,9 @@ const fuseValuePickerList = document.getElementById('fuse-value-picker-list');
 const glassSizeSelect = document.getElementById('glass-size-select');
 const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
 const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
+const ceramicSizeSelect = document.getElementById('ceramic-size-select');
+const ceramicSlowBlowCheckbox = document.getElementById('ceramic-slow-blow');
+const ceramicFastBlowCheckbox = document.getElementById('ceramic-fast-blow');
 const fuseValueMessage = document.getElementById('fuse-value-message');
 const notesInput = document.getElementById('notes-input');
 const measurementSystemContainer = document.getElementById('measurement-system-container');
@@ -160,6 +164,7 @@ export const elements = {
   fuseTypePickerList,
   fuseValueContainer,
   glassOptionsContainer,
+  ceramicOptionsContainer,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,
@@ -167,6 +172,9 @@ export const elements = {
   glassSizeSelect,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
+  ceramicSizeSelect,
+  ceramicSlowBlowCheckbox,
+  ceramicFastBlowCheckbox,
   fuseValueMessage,
   notesInput,
   measurementSystemContainer,

--- a/js/events.js
+++ b/js/events.js
@@ -52,6 +52,9 @@ const {
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
   glassSizeSelect,
+  ceramicSlowBlowCheckbox,
+  ceramicFastBlowCheckbox,
+  ceramicSizeSelect,
   lengthInput,
   notesInput,
   customLine1Input,
@@ -1821,6 +1824,45 @@ export function initEventHandlers() {
   if (glassSizeSelect) {
     glassSizeSelect.addEventListener('change', () => {
       state.glassSize = glassSizeSelect.value;
+      updatePreview();
+    });
+  }
+
+  if (ceramicSlowBlowCheckbox) {
+    ceramicSlowBlowCheckbox.addEventListener('change', () => {
+      if (!ceramicSlowBlowCheckbox.checked) {
+        if (!ceramicFastBlowCheckbox || !ceramicFastBlowCheckbox.checked) {
+          state.ceramicSpeed = '';
+        }
+      } else {
+        state.ceramicSpeed = 'Slow Blow (Time Delay)';
+        if (ceramicFastBlowCheckbox) {
+          ceramicFastBlowCheckbox.checked = false;
+        }
+      }
+      updatePreview();
+    });
+  }
+
+  if (ceramicFastBlowCheckbox) {
+    ceramicFastBlowCheckbox.addEventListener('change', () => {
+      if (!ceramicFastBlowCheckbox.checked) {
+        if (!ceramicSlowBlowCheckbox || !ceramicSlowBlowCheckbox.checked) {
+          state.ceramicSpeed = '';
+        }
+      } else {
+        state.ceramicSpeed = 'Fast Blow';
+        if (ceramicSlowBlowCheckbox) {
+          ceramicSlowBlowCheckbox.checked = false;
+        }
+      }
+      updatePreview();
+    });
+  }
+
+  if (ceramicSizeSelect) {
+    ceramicSizeSelect.addEventListener('change', () => {
+      state.ceramicSize = ceramicSizeSelect.value;
       updatePreview();
     });
   }

--- a/js/forms.js
+++ b/js/forms.js
@@ -33,6 +33,7 @@ const {
   fuseTypePickerList,
   fuseValueContainer,
   glassOptionsContainer,
+  ceramicOptionsContainer,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,
@@ -40,6 +41,9 @@ const {
   glassSizeSelect,
   glassSlowBlowCheckbox,
   glassFastBlowCheckbox,
+  ceramicSizeSelect,
+  ceramicSlowBlowCheckbox,
+  ceramicFastBlowCheckbox,
   notesInput,
   nutTypeContainer,
   nutTypePicker,
@@ -324,7 +328,9 @@ export function setFuseTypeSelection(nextId, { triggerUpdate = true } = {}) {
   syncFuseTypePicker({ isValid: true });
 
   const shouldResetGlassOptions = previousValue === 'Glass' && sanitizedValue !== 'Glass';
+  const shouldResetCeramicOptions = previousValue === 'Ceramic' && sanitizedValue !== 'Ceramic';
   updateGlassOptionVisibility({ resetIfHidden: shouldResetGlassOptions });
+  updateCeramicOptionVisibility({ resetIfHidden: shouldResetCeramicOptions });
 
   if (triggerUpdate && previousValue !== sanitizedValue) {
     updateDownloadState();
@@ -964,6 +970,34 @@ export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
     }
     if (glassSizeSelect) {
       glassSizeSelect.value = '';
+    }
+  }
+}
+
+export function updateCeramicOptionVisibility({ resetIfHidden = false } = {}) {
+  const shouldShow = state.hardwareType === 'Fuse' && state.fuseType === 'Ceramic';
+  if (ceramicOptionsContainer) {
+    ceramicOptionsContainer.classList.toggle('d-none', !shouldShow);
+  }
+  if (shouldShow) {
+    if (ceramicSizeSelect) {
+      ceramicSizeSelect.value = state.ceramicSize || '';
+    }
+    if (ceramicSlowBlowCheckbox && ceramicFastBlowCheckbox) {
+      ceramicSlowBlowCheckbox.checked = state.ceramicSpeed.startsWith('Slow');
+      ceramicFastBlowCheckbox.checked = state.ceramicSpeed.startsWith('Fast');
+    }
+  } else if (resetIfHidden) {
+    state.ceramicSpeed = '';
+    state.ceramicSize = '';
+    if (ceramicSlowBlowCheckbox) {
+      ceramicSlowBlowCheckbox.checked = false;
+    }
+    if (ceramicFastBlowCheckbox) {
+      ceramicFastBlowCheckbox.checked = false;
+    }
+    if (ceramicSizeSelect) {
+      ceramicSizeSelect.value = '';
     }
   }
 }
@@ -1771,6 +1805,7 @@ export function onHardwareTypeChange() {
     updateCustomImageUi();
   }
   updateGlassOptionVisibility({ resetIfHidden: !showFuseFields });
+  updateCeramicOptionVisibility({ resetIfHidden: !showFuseFields });
   populateThreadSizes();
   populateStandards();
   updateDownloadState();

--- a/js/render.js
+++ b/js/render.js
@@ -93,6 +93,10 @@ const fuseIllustrations = {
     src: 'images/fuses/glass_fuse.svg',
     alt: 'Glass fuse illustration',
   },
+  Ceramic: {
+    src: 'images/fuses/ceramic_fuse.svg',
+    alt: 'Ceramic fuse illustration',
+  },
   Blade: {
     src: 'images/fuses/blade_fuse.svg',
     alt: 'Blade fuse illustration',
@@ -977,13 +981,25 @@ function buildTextLines() {
     const valueLabel = state.fuseValue ? `${state.fuseValue} A` : 'Fuse';
     const typeLabel = state.fuseType ? `${state.fuseType} Fuse` : 'Fuse';
     const typeParts = [typeLabel];
-    if (state.glassSize) {
-      typeParts.push(state.glassSize);
+    const fuseSize =
+      state.fuseType === 'Glass'
+        ? state.glassSize
+        : state.fuseType === 'Ceramic'
+          ? state.ceramicSize
+          : '';
+    if (fuseSize) {
+      typeParts.push(fuseSize);
     }
     const line2 = typeParts.filter(Boolean).join(' — ');
     const line3Parts = [];
-    if (state.glassSpeed) {
-      line3Parts.push(state.glassSpeed);
+    const fuseSpeed =
+      state.fuseType === 'Glass'
+        ? state.glassSpeed
+        : state.fuseType === 'Ceramic'
+          ? state.ceramicSpeed
+          : '';
+    if (fuseSpeed) {
+      line3Parts.push(fuseSpeed);
     }
     if (state.notes) {
       line3Parts.push(state.notes);

--- a/js/state.js
+++ b/js/state.js
@@ -7,6 +7,8 @@ export const state = {
   fuseValue: '',
   glassSpeed: '',
   glassSize: '',
+  ceramicSpeed: '',
+  ceramicSize: '',
   notes: '',
   standard: '',
   standardCode: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -21,6 +21,8 @@ const FIELD_MAP = {
   fuseValue: 'fv',
   glassSpeed: 'gs',
   glassSize: 'gz',
+  ceramicSpeed: 'cs',
+  ceramicSize: 'cz',
   notes: 'no',
   standard: 'sd',
   standardCode: 'sc',
@@ -78,6 +80,17 @@ const glassSizeOptions = new Set(
         .filter(value => value && value.trim().length > 0)
     : [],
 );
+const ceramicSizeOptions = new Set(
+  elements.ceramicSizeSelect
+    ? Array.from(elements.ceramicSizeSelect.options)
+        .map(option => option.value)
+        .filter(value => value && value.trim().length > 0)
+    : [],
+);
+const cylindricalFuseSizeOptions = new Set([
+  ...glassSizeOptions,
+  ...ceramicSizeOptions,
+]);
 const glassSpeedOptions = new Set(['Slow Blow (Time Delay)', 'Fast Blow']);
 const metricThreadSet = new Set(metricThreadSizes);
 const imperialThreadSet = new Set(imperialThreadSizes);
@@ -196,7 +209,22 @@ function sanitizeGlassSize(value) {
   if (!trimmed) {
     return '';
   }
-  return glassSizeOptions.has(trimmed) ? trimmed : '';
+  return cylindricalFuseSizeOptions.has(trimmed) ? trimmed : '';
+}
+
+function sanitizeCeramicSpeed(value) {
+  return sanitizeGlassSpeed(value);
+}
+
+function sanitizeCeramicSize(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return cylindricalFuseSizeOptions.has(trimmed) ? trimmed : '';
 }
 
 function sanitizeNotes(value) {
@@ -325,10 +353,25 @@ function applyExpandedPayload(expanded) {
       state.glassSpeed = '';
       state.glassSize = '';
     }
+    if (state.fuseType === 'Ceramic') {
+      const sanitizedSpeed = sanitizeCeramicSpeed(expanded.ceramicSpeed);
+      if (sanitizedSpeed !== null) {
+        state.ceramicSpeed = sanitizedSpeed;
+      }
+      const sanitizedSize = sanitizeCeramicSize(expanded.ceramicSize);
+      if (sanitizedSize !== null) {
+        state.ceramicSize = sanitizedSize;
+      }
+    } else {
+      state.ceramicSpeed = '';
+      state.ceramicSize = '';
+    }
   } else {
     state.fuseValue = '';
     state.glassSpeed = '';
     state.glassSize = '';
+    state.ceramicSpeed = '';
+    state.ceramicSize = '';
   }
 
   if (typeof expanded.notes === 'string') {


### PR DESCRIPTION
## Summary
- add a ceramic fuse type alongside glass and blade options, complete with matching size and speed controls in the UI
- update state handling, URL serialization, and preview rendering so ceramic fuses share the same sizing and blow-rate metadata as glass fuses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d915f7a3908329a4fd84789acdf4f9