### PR TITLE
Add screw type picker with imagery

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -1,5 +1,5 @@
 import { state } from './state.js';
-import { findConnectorCategory, boltHeadMap, boltDriveMap } from './data.js';
+import { findConnectorCategory, boltHeadMap, boltDriveMap, screwTypeMap } from './data.js';
 import { renderLabelPng } from './render.js';
 import { buildShareUrl } from './url-state.js';
 
@@ -124,15 +124,27 @@ export function downloadLabel() {
         if (driveEntry && driveEntry.label) {
           fileParts.push(driveEntry.label);
         }
+      } else if (state.hardwareType === 'Screw') {
+        if (state.threadSize) {
+          fileParts.push(state.threadSize);
+        }
+        if (state.length) {
+          fileParts.push(`x${state.length}`);
+        }
+        const typeEntry = screwTypeMap.get((state.boltHead || '').trim());
+        const driveEntry = boltDriveMap.get((state.boltDrive || '').trim());
+        if (typeEntry && typeEntry.label) {
+          fileParts.push(typeEntry.label);
+        }
+        if (driveEntry && driveEntry.label) {
+          fileParts.push(driveEntry.label);
+        }
       } else {
         if (state.threadSize) {
           fileParts.push(state.threadSize);
         }
-        if (state.hardwareType === 'Screw' && state.length) {
-          fileParts.push(`x${state.length}`);
-        }
       }
-      if (state.hardwareType !== 'Bolt') {
+      if (state.hardwareType !== 'Bolt' && state.hardwareType !== 'Screw') {
         if (state.standardCode) {
           fileParts.push(state.standardCode);
         }

--- a/js/data.js
+++ b/js/data.js
@@ -95,8 +95,15 @@ export const boltDriveOptions = [
   { id: 'torx', label: 'Torx', image: 'torx' },
 ];
 
+export const screwTypeOptions = [
+  { id: 'countersunk_wood_screw', label: 'Countersunk Wood Screw', image: 'countersunk_wood_screw' },
+  { id: 'pan_head_wood_screw', label: 'Pan Head Wood Screw', image: 'pan_head_wood_screw' },
+  { id: 'self_drilling_hex_screw', label: 'Self-drilling Hex Screw', image: 'self_drilling_hex_screw' },
+];
+
 export const boltHeadMap = new Map(boltHeadOptions.map(option => [option.id, option]));
 export const boltDriveMap = new Map(boltDriveOptions.map(option => [option.id, option]));
+export const screwTypeMap = new Map(screwTypeOptions.map(option => [option.id, option]));
 
 export const nutTypeOptions = [
   { id: 'hex', label: 'Hex Nut', image: 'hex_nut' },
@@ -229,6 +236,7 @@ export const hardwareImageFolders = {
 
 export const hardwareTypeImageMap = {
   Bolt: 'images/bolts/head/countersunk_head.svg',
+  Screw: 'images/screws/countersunk_wood_screw.svg',
   'Threaded Heat Insert': 'images/threaded_heat_insert/heat_insert.svg',
   Nut: 'images/nuts/hex_nut.svg',
   Fuse: 'images/fuses/glass_fuse.svg',

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -65,6 +65,7 @@ const standardFieldLabel = document.getElementById('standard-field-label');
 const boltStandardGroup = document.getElementById('bolt-standard-group');
 const boltHeadField = document.getElementById('bolt-head-field');
 const boltDriveField = document.getElementById('bolt-drive-field');
+const boltHeadLabel = document.querySelector('label[for="bolt-head-select"]');
 const boltHeadPicker = document.getElementById('bolt-head-picker');
 const boltHeadPickerButton = document.getElementById('bolt-head-picker-button');
 const boltHeadPickerList = document.getElementById('bolt-head-picker-list');
@@ -195,6 +196,7 @@ export const elements = {
   boltStandardGroup,
   boltHeadField,
   boltDriveField,
+  boltHeadLabel,
   boltHeadPicker,
   boltHeadPickerButton,
   boltHeadPickerList,

--- a/js/forms.js
+++ b/js/forms.js
@@ -6,6 +6,7 @@ import {
   bearingOptions,
   boltHeadOptions,
   boltDriveOptions,
+  screwTypeOptions,
   nutTypeOptions,
   hardwareCatalog,
   hardwareTypeImageMap,
@@ -62,6 +63,7 @@ const {
   notesField,
   standardField,
   boltStandardGroup,
+  boltHeadLabel,
   boltHeadPicker,
   boltHeadPickerButton,
   boltHeadPickerList,
@@ -89,8 +91,11 @@ const {
 const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select hardware…';
 const BOLT_DRIVE_PLACEHOLDER_TEXT = 'Select drive…';
 const BOLT_HEAD_PLACEHOLDER_TEXT = 'Select head…';
+const SCREW_TYPE_PLACEHOLDER_TEXT = 'Select type…';
 const validBoltDriveIds = new Set(boltDriveOptions.map(option => option.id));
-const validBoltHeadIds = new Set(boltHeadOptions.map(option => option.id));
+const validBoltHeadIds = new Set(
+  boltHeadOptions.concat(screwTypeOptions).map(option => option.id),
+);
 const NUT_TYPE_PLACEHOLDER_TEXT = 'Select type…';
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
 const FUSE_TYPE_PLACEHOLDER_TEXT = 'Select fuse type…';
@@ -98,6 +103,24 @@ const DEFAULT_FUSE_TYPE = 'Glass';
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
+
+function getFastenerHeadOptions() {
+  return state.hardwareType === 'Screw' ? screwTypeOptions : boltHeadOptions;
+}
+
+function getFastenerHeadPlaceholder() {
+  return state.hardwareType === 'Screw'
+    ? SCREW_TYPE_PLACEHOLDER_TEXT
+    : BOLT_HEAD_PLACEHOLDER_TEXT;
+}
+
+function getFastenerHeadImagePath(option) {
+  if (!option || !option.image) {
+    return '';
+  }
+  const basePath = state.hardwareType === 'Screw' ? 'images/screws' : 'images/bolts/head';
+  return `${basePath}/${option.image}.svg`;
+}
 
 function createHardwareTypeOption(optionElement) {
   if (!hardwareTypePickerList) {
@@ -499,9 +522,11 @@ export function syncBoltHeadPicker({ isValid = true } = {}) {
     boltHeadSelect.selectedIndex = 0;
   }
 
+  const headOptions = getFastenerHeadOptions();
   const selectedOption = sanitizedValue
-    ? boltHeadOptions.find(option => option.id === sanitizedValue) || null
+    ? headOptions.find(option => option.id === sanitizedValue) || null
     : null;
+  const placeholderText = getFastenerHeadPlaceholder();
 
   if (boltHeadPickerButton) {
     const label = boltHeadPickerButton.querySelector('.bolt-drive-picker__current-label');
@@ -511,12 +536,12 @@ export function syncBoltHeadPicker({ isValid = true } = {}) {
     );
 
     if (label) {
-      label.textContent = selectedOption ? selectedOption.label : BOLT_HEAD_PLACEHOLDER_TEXT;
+      label.textContent = selectedOption ? selectedOption.label : placeholderText;
     }
 
     if (iconWrapper && iconImage) {
       if (selectedOption) {
-        iconImage.src = `images/bolts/head/${selectedOption.image}.svg`;
+        iconImage.src = getFastenerHeadImagePath(selectedOption);
         iconImage.hidden = false;
         iconWrapper.classList.remove('is-empty');
       } else {
@@ -1033,6 +1058,11 @@ function populateBoltOptions() {
 
   const previousHead = typeof state.boltHead === 'string' ? state.boltHead : '';
   const previousDrive = typeof state.boltDrive === 'string' ? state.boltDrive : '';
+  const isScrew = state.hardwareType === 'Screw';
+  const headOptions = getFastenerHeadOptions();
+  const headPlaceholderText = isScrew
+    ? SCREW_TYPE_PLACEHOLDER_TEXT
+    : BOLT_HEAD_PLACEHOLDER_TEXT;
 
   boltHeadSelect.innerHTML = '';
   boltDriveSelect.innerHTML = '';
@@ -1045,7 +1075,7 @@ function populateBoltOptions() {
 
   const headPlaceholder = document.createElement('option');
   headPlaceholder.value = '';
-  headPlaceholder.textContent = BOLT_HEAD_PLACEHOLDER_TEXT;
+  headPlaceholder.textContent = headPlaceholderText;
   headPlaceholder.disabled = true;
   headPlaceholder.selected = !previousHead;
   boltHeadSelect.appendChild(headPlaceholder);
@@ -1057,7 +1087,7 @@ function populateBoltOptions() {
   drivePlaceholder.selected = !previousDrive;
   boltDriveSelect.appendChild(drivePlaceholder);
 
-  boltHeadOptions.forEach(option => {
+  headOptions.forEach(option => {
     const opt = document.createElement('option');
     opt.value = option.id;
     opt.textContent = option.label;
@@ -1075,7 +1105,7 @@ function populateBoltOptions() {
 
       const image = document.createElement('img');
       image.className = 'bolt-drive-picker__option-icon-image';
-      image.src = `images/bolts/head/${option.image}.svg`;
+      image.src = getFastenerHeadImagePath(option);
       image.alt = '';
       image.loading = 'lazy';
       image.decoding = 'async';
@@ -1131,7 +1161,7 @@ function populateBoltOptions() {
   setBoltDriveSelection(previousDrive, { triggerUpdate: false });
 
   boltHeadSelect.disabled = false;
-  boltHeadSelect.title = 'Select head style';
+  boltHeadSelect.title = isScrew ? 'Select screw type' : 'Select head style';
   boltHeadSelect.setAttribute('aria-required', 'true');
 
   boltDriveSelect.disabled = false;
@@ -1157,7 +1187,7 @@ function populateBoltOptions() {
 export function populateStandards() {
   const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
 
-  if (state.hardwareType === 'Bolt') {
+  if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
     standardFilterState.query = '';
     if (standardSelect) {
       standardSelect.innerHTML = '';
@@ -1448,6 +1478,8 @@ export function onHardwareTypeChange() {
   const showCustomFields = type === 'Custom';
   const showBearingFields = type === 'Bearing';
   const showBoltFields = type === 'Bolt';
+  const showScrewFields = type === 'Screw';
+  const showFastenerFields = showBoltFields || showScrewFields;
   const showNutFields = type === 'Nut';
 
   if (lengthContainer) {
@@ -1658,10 +1690,10 @@ export function onHardwareTypeChange() {
     } else {
       standardLabel.textContent = defaultStandardLabel;
     }
-    standardLabel.setAttribute('for', showBoltFields ? 'bolt-head-select' : 'standard-select');
+    standardLabel.setAttribute('for', showFastenerFields ? 'bolt-head-select' : 'standard-select');
   }
   if (standardSelect) {
-    const hideStandardSelect = showBoltFields || showFuseFields || showNutFields;
+    const hideStandardSelect = showFastenerFields || showFuseFields || showNutFields;
     standardSelect.classList.toggle('d-none', hideStandardSelect);
     if (hideStandardSelect) {
       standardSelect.disabled = true;
@@ -1673,19 +1705,22 @@ export function onHardwareTypeChange() {
     }
   }
   if (boltStandardGroup) {
-    boltStandardGroup.classList.toggle('d-none', !showBoltFields);
-    boltStandardGroup.setAttribute('aria-hidden', showBoltFields ? 'false' : 'true');
+    boltStandardGroup.classList.toggle('d-none', !showFastenerFields);
+    boltStandardGroup.setAttribute('aria-hidden', showFastenerFields ? 'false' : 'true');
+  }
+  if (boltHeadLabel) {
+    boltHeadLabel.textContent = showScrewFields ? 'Type' : 'Head';
   }
   if (boltHeadSelect) {
-    boltHeadSelect.disabled = !showBoltFields;
-    if (!showBoltFields) {
+    boltHeadSelect.disabled = !showFastenerFields;
+    if (!showFastenerFields) {
       boltHeadSelect.removeAttribute('aria-required');
       boltHeadSelect.title = '';
     }
   }
   if (boltHeadPickerButton) {
-    boltHeadPickerButton.disabled = !showBoltFields;
-    if (!showBoltFields) {
+    boltHeadPickerButton.disabled = !showFastenerFields;
+    if (!showFastenerFields) {
       boltHeadPickerButton.setAttribute('aria-expanded', 'false');
     }
   }
@@ -1693,18 +1728,18 @@ export function onHardwareTypeChange() {
     boltHeadPickerList.hidden = true;
   }
   if (boltHeadPicker) {
-    boltHeadPicker.classList.toggle('is-disabled', !showBoltFields);
+    boltHeadPicker.classList.toggle('is-disabled', !showFastenerFields);
   }
   if (boltDriveSelect) {
-    boltDriveSelect.disabled = !showBoltFields;
-    if (!showBoltFields) {
+    boltDriveSelect.disabled = !showFastenerFields;
+    if (!showFastenerFields) {
       boltDriveSelect.removeAttribute('aria-required');
       boltDriveSelect.title = '';
     }
   }
   if (boltDrivePickerButton) {
-    boltDrivePickerButton.disabled = !showBoltFields;
-    if (!showBoltFields) {
+    boltDrivePickerButton.disabled = !showFastenerFields;
+    if (!showFastenerFields) {
       boltDrivePickerButton.setAttribute('aria-expanded', 'false');
     }
   }
@@ -1712,9 +1747,9 @@ export function onHardwareTypeChange() {
     boltDrivePickerList.hidden = true;
   }
   if (boltDrivePicker) {
-    boltDrivePicker.classList.toggle('is-disabled', !showBoltFields);
+    boltDrivePicker.classList.toggle('is-disabled', !showFastenerFields);
   }
-  if (!showBoltFields) {
+  if (!showFastenerFields) {
     syncBoltHeadPicker({ isValid: true });
     syncBoltDrivePicker({ isValid: true });
   }

--- a/js/render.js
+++ b/js/render.js
@@ -8,6 +8,7 @@ import {
   boltHeadMap,
   boltDriveMap,
   nutTypeMap,
+  screwTypeMap,
 } from './data.js';
 import { loadQrCodeLibrary } from './lazy-loaders.js';
 
@@ -353,7 +354,7 @@ export function isLabelReady() {
   if (state.hardwareType === 'Component') {
     return Boolean(state.componentCategory && state.componentMount);
   }
-  if (state.hardwareType === 'Bolt') {
+  if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
     const hasThread = Boolean(state.threadSize);
     const hasLength = Boolean(state.length);
     const detailsRequired = Boolean(state.showImage || state.showStandard);
@@ -368,9 +369,6 @@ export function isLabelReady() {
     const hasType = Boolean(state.nutType);
     const detailsSatisfied = !detailsRequired || hasType;
     return Boolean(hasThread && detailsSatisfied);
-  }
-  if (state.hardwareType === 'Screw') {
-    return Boolean(state.threadSize && state.length && state.standardCode);
   }
   if (state.hardwareType === 'Threaded Heat Insert') {
     return Boolean(state.threadSize && state.length);
@@ -456,7 +454,10 @@ function applyValidationFeedback(disabled) {
     syncFuseValuePicker({ isValid: true });
   }
 
-  if (hardwareType === 'Bolt' && (state.showImage || state.showStandard)) {
+  if (
+    (hardwareType === 'Bolt' || hardwareType === 'Screw') &&
+    (state.showImage || state.showStandard)
+  ) {
     const headValid = Boolean(state.boltHead);
     const driveValid = Boolean(state.boltDrive);
     updateInputFieldState({
@@ -473,7 +474,7 @@ function applyValidationFeedback(disabled) {
     });
     syncBoltDrivePicker({ isValid: driveValid });
     if (!headValid) {
-      requirements.push('select a head style');
+      requirements.push(hardwareType === 'Screw' ? 'choose a screw type' : 'select a head style');
     }
     if (!driveValid) {
       requirements.push('select a drive style');
@@ -736,6 +737,36 @@ function resolveHardwareImageInfo() {
       ],
     };
   }
+  if (state.hardwareType === 'Screw') {
+    const typeId = (state.boltHead || '').trim();
+    const driveId = (state.boltDrive || '').trim();
+    if (!typeId || !driveId) {
+      return null;
+    }
+    const typeEntry = screwTypeMap.get(typeId);
+    const driveEntry = boltDriveMap.get(driveId);
+    if (!typeEntry || !driveEntry) {
+      return null;
+    }
+    const typeImage = (typeEntry.image || '').trim();
+    const driveImage = (driveEntry.image || '').trim();
+    if (!typeImage || !driveImage) {
+      return null;
+    }
+    return {
+      type: 'screw',
+      images: [
+        {
+          src: `images/bolts/drive/${driveImage}.svg`,
+          alt: driveEntry.label ? `${driveEntry.label} — drive view` : 'Screw drive view',
+        },
+        {
+          src: `images/screws/${typeImage}.svg`,
+          alt: typeEntry.label ? `${typeEntry.label} — type view` : 'Screw type view',
+        },
+      ],
+    };
+  }
   if (state.hardwareType === 'Fuse') {
     const fuseType = (state.fuseType || '').trim();
     const illustration = fuseIllustrations[fuseType] || fuseIllustrations.Glass;
@@ -854,8 +885,11 @@ function renderHardwareImage(imageInfo, innerHeightPx, contentWidthPx, gapPx) {
     }
     hardwareImageDiv.appendChild(wrapper);
     usedWidthPx = targetWidth;
-  } else if (imageInfo.type === 'bolt') {
-    const images = Array.isArray(imageInfo.images) ? imageInfo.images.filter(item => item && item.src) : [];
+  } else if (imageInfo.type === 'bolt' || imageInfo.type === 'screw') {
+    const isScrew = imageInfo.type === 'screw';
+    const images = Array.isArray(imageInfo.images)
+      ? imageInfo.images.filter(item => item && item.src)
+      : [];
     if (images.length === 0) {
       hardwareImageDiv.style.display = 'none';
       hardwareImageDiv.style.removeProperty('flex-basis');
@@ -865,7 +899,7 @@ function renderHardwareImage(imageInfo, innerHeightPx, contentWidthPx, gapPx) {
     }
     const maxWidth = Math.max(Math.min(contentWidthPx, innerHeightPx * 2), innerHeightPx);
     const group = document.createElement('div');
-    group.className = 'bolt-image-group';
+    group.className = isScrew ? 'bolt-image-group screw-image-group' : 'bolt-image-group';
     group.style.height = `${innerHeightPx}px`;
     group.style.maxHeight = `${innerHeightPx}px`;
     const groupGap = Math.max(4, Math.round(gapPx * 1.1));
@@ -875,8 +909,16 @@ function renderHardwareImage(imageInfo, innerHeightPx, contentWidthPx, gapPx) {
     images.forEach((info, index) => {
       const img = document.createElement('img');
       img.src = info.src;
-      img.alt = info.alt || 'Bolt reference';
-      img.className = index === 0 ? 'hardware-photo bolt-drive-view' : 'hardware-photo bolt-head-view';
+      img.alt = info.alt || (isScrew ? 'Screw reference' : 'Bolt reference');
+      const viewClass =
+        index === 0
+          ? isScrew
+            ? 'screw-drive-view'
+            : 'bolt-drive-view'
+          : isScrew
+          ? 'screw-type-view'
+          : 'bolt-head-view';
+      img.className = `hardware-photo ${viewClass}`;
       img.style.maxHeight = `${innerHeightPx}px`;
       img.style.maxWidth = `${slotWidth}px`;
       img.decoding = 'async';
@@ -1052,15 +1094,32 @@ function buildTextLines() {
     if (state.length) {
       pieces.push(`× ${state.length}`);
     }
-    const line1 = pieces.join(' ') || 'Screw';
-    const line2Parts = [];
-    if (state.standard) {
-      line2Parts.push(state.standard);
+    const typeEntry = screwTypeMap.get((state.boltHead || '').trim());
+    const driveEntry = boltDriveMap.get((state.boltDrive || '').trim());
+    const typeLabel = typeEntry ? typeEntry.label : '';
+    const driveLabel = driveEntry ? driveEntry.label : '';
+    const notes = state.notes || '';
+    const showDetails = Boolean(state.showStandard);
+    let line2 = '';
+    let line3 = '';
+    if (showDetails) {
+      if (typeLabel) {
+        line2 = typeLabel;
+      }
+      if (driveLabel) {
+        line3 = driveLabel;
+      }
+      if (notes) {
+        if (!line2) {
+          line2 = notes;
+        } else if (!line3) {
+          line3 = notes;
+        }
+      }
+    } else {
+      line2 = notes;
     }
-    if (state.notes) {
-      line2Parts.push(state.notes);
-    }
-    return { line1, line2: line2Parts.join(' • '), line3: '' };
+    return { line1: pieces.join(' ') || 'Screw', line2, line3 };
   }
 
   const line1 = state.threadSize || state.hardwareType || 'Label';

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -8,6 +8,7 @@ import {
   connectorCatalog,
   boltHeadOptions,
   boltDriveOptions,
+  screwTypeOptions,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -86,7 +87,9 @@ const fuseValueOptions = new Set(fuseValues.map(value => String(value)));
 const connectorCategoryOptions = new Set(connectorCatalog.map(category => category.id));
 const bearingCodeOptions = new Set(bearingOptions.map(option => option.code));
 const systemTypeOptions = new Set(['Metric', 'Imperial']);
-const boltHeadIds = new Set(boltHeadOptions.map(option => option.id));
+const boltHeadIds = new Set(
+  boltHeadOptions.concat(screwTypeOptions).map(option => option.id),
+);
 const boltDriveIds = new Set(boltDriveOptions.map(option => option.id));
 
 function encodeToBase64Url(input) {


### PR DESCRIPTION
## Summary
- add screw type option data and imagery so screws have dedicated icons
- reuse the fastener picker for screws with type/drive visuals and dynamic labels
- update rendering, sharing, and downloads to include the selected screw type and drive

## Testing
- npm run lint *(fails: unused variables reported in js/controls.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d924db66288329ae9b23fe56ab6a4c