### PR TITLE
Rotate screw picker icon via CSS

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -145,7 +145,7 @@ function createHardwareTypeOption(optionElement) {
   if (imageSrc) {
     const image = document.createElement('img');
     image.className = 'bolt-drive-picker__option-icon-image';
-    if (value === 'Bolt') {
+    if (value === 'Bolt' || value === 'Screw') {
       image.classList.add('is-rotated-90');
     }
     image.src = imageSrc;
@@ -250,7 +250,7 @@ export function syncHardwareTypePicker() {
       if (imageSrc) {
         iconImage.src = imageSrc;
         iconImage.hidden = false;
-        if (sanitizedValue === 'Bolt') {
+        if (sanitizedValue === 'Bolt' || sanitizedValue === 'Screw') {
           iconImage.classList.add('is-rotated-90');
         }
         iconWrapper.classList.remove('is-empty');


### PR DESCRIPTION
## Summary
- rotate screw hardware picker icons with CSS by reusing the existing `is-rotated-90` helper
- ensure both the dropdown option and the current selection honor the rotated screw artwork without modifying SVG assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d930bfbf588329a5c2b5ced84e0a62