### PR TITLE
Align picker button height with inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,6 +252,7 @@ main {
   font-size: 1rem;
   line-height: 1.35;
   min-height: var(--picker-control-height);
+  height: var(--picker-control-height);
 }
 
 .bolt-drive-picker__button:focus-visible {


### PR DESCRIPTION
## Summary
- set the bolt drive picker button height to match the shared control height token so it stays consistent with text inputs

## Testing
- Manual verification of picker buttons and associated text inputs in the browser

------
https://chatgpt.com/codex/tasks/task_e_68da46550afc832980841616232a3df9