### PR TITLE
Add ceramic fuse option

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,6 +510,7 @@
                         aria-labelledby="fuse-type-label"
                       >
                         <option value="Glass">Glass Fuse</option>
+                        <option value="Ceramic">Ceramic Fuse</option>
                         <option value="Blade">Blade Fuse</option>
                       </select>
                       <button
@@ -589,7 +590,7 @@
                   </div>
                 </div>
                 <div id="glass-options-container" class="d-none">
-                  <span class="form-label d-block fw-semibold">Glass Fuse Options</span>
+                  <span class="form-label d-block fw-semibold">Glass &amp; Ceramic Fuse Options</span>
                   <div class="form-check">
                     <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
                     <label class="form-check-label" for="glass-slow-blow"
@@ -602,7 +603,7 @@
                   </div>
                   <div class="mt-2">
                     <label for="glass-size-select" class="form-label fw-semibold"
-                      >Glass Fuse Size</label
+                      >Glass &amp; Ceramic Fuse Size</label
                     >
                     <select id="glass-size-select" class="form-select">
                       <option value="">Select size…</option>
@@ -612,7 +613,7 @@
                       </option>
                     </select>
                     <div class="form-text">
-                      Standard glass fuse sizes: 5 × 20 mm and 6.3 × 32 mm.
+                      Standard glass and ceramic fuse sizes: 5 × 20 mm and 6.3 × 32 mm.
                     </div>
                   </div>
                 </div>

--- a/js/data.js
+++ b/js/data.js
@@ -60,6 +60,7 @@ export const fuseValues = [
 
 export const fuseTypeOptions = [
   { id: 'Glass', label: 'Glass Fuse', image: 'images/fuses/glass_fuse.svg' },
+  { id: 'Ceramic', label: 'Ceramic Fuse', image: 'images/fuses/ceramic_fuse.svg' },
   { id: 'Blade', label: 'Blade Fuse', image: 'images/fuses/blade_fuse.svg' },
 ];
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -100,6 +100,7 @@ const NUT_TYPE_PLACEHOLDER_TEXT = 'Select type…';
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
 const FUSE_TYPE_PLACEHOLDER_TEXT = 'Select fuse type…';
 const DEFAULT_FUSE_TYPE = 'Glass';
+const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
@@ -346,8 +347,10 @@ export function setFuseTypeSelection(nextId, { triggerUpdate = true } = {}) {
   state.fuseType = sanitizedValue;
   syncFuseTypePicker({ isValid: true });
 
-  const shouldResetGlassOptions = previousValue === 'Glass' && sanitizedValue !== 'Glass';
-  updateGlassOptionVisibility({ resetIfHidden: shouldResetGlassOptions });
+  const previousWasCartridge = CARTRIDGE_FUSE_TYPES.has(previousValue);
+  const nextIsCartridge = CARTRIDGE_FUSE_TYPES.has(sanitizedValue);
+  const shouldResetCartridgeOptions = previousWasCartridge && !nextIsCartridge;
+  updateGlassOptionVisibility({ resetIfHidden: shouldResetCartridgeOptions });
 
   if (triggerUpdate && previousValue !== sanitizedValue) {
     updateDownloadState();
@@ -966,7 +969,8 @@ export function populateFuseValues() {
 }
 
 export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
-  const shouldShow = state.hardwareType === 'Fuse' && state.fuseType === 'Glass';
+  const shouldShow =
+    state.hardwareType === 'Fuse' && CARTRIDGE_FUSE_TYPES.has(state.fuseType);
   if (glassOptionsContainer) {
     glassOptionsContainer.classList.toggle('d-none', !shouldShow);
   }


### PR DESCRIPTION
## Summary
- add a Ceramic Fuse choice to the fuse type picker, including updated helper copy
- ensure glass and ceramic fuse types share the existing cartridge fuse option controls

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68da675e7d688329a105b7caa41cab6e