### PR TITLE
Add resistor value and mount pickers

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,37 +257,100 @@
                     class="validation-message text-danger small mt-2 d-none"
                   ></div>
                 </div>
-                <div id="component-mount-container" class="d-none">
-                  <span class="form-label d-block fw-semibold">Mounting Style</span>
-                  <div class="row g-2" id="component-mount-group">
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="component-mount"
-                        id="component-mount-through-hole"
-                        value="Through-Hole"
-                        autocomplete="off"
-                        checked
-                      />
+                <div id="component-mount-container" class="d-none" aria-hidden="true">
+                  <div class="row g-3 align-items-end">
+                    <div class="col-12 col-lg-6" id="component-mount-field">
                       <label
-                        class="btn btn-outline-secondary w-100"
-                        for="component-mount-through-hole"
-                        >Through-Hole</label
+                        class="form-label fw-semibold"
+                        for="component-mount-picker-button"
+                        >Mounting Style</label
                       >
+                      <div class="bolt-drive-picker" id="component-mount-picker">
+                        <select
+                          id="component-mount-select"
+                          class="visually-hidden"
+                          aria-labelledby="component-mount-picker-button"
+                        >
+                          <option value="">Select mounting…</option>
+                          <option value="Through-Hole">Through-Hole</option>
+                          <option value="SMD">SMD</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="component-mount-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="component-mount-picker-list"
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">Select mounting…</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="component-mount-picker-list"
+                          role="listbox"
+                          aria-labelledby="component-mount-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
                     </div>
-                    <div class="col-12 col-sm-6">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="component-mount"
-                        id="component-mount-smd"
-                        value="SMD"
-                        autocomplete="off"
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="component-mount-smd"
-                        >SMD</label
+                    <div class="col-12 col-lg-6 d-none" id="resistor-value-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="resistor-value-picker-button"
+                        >Resistor Value</label
                       >
+                      <div class="bolt-drive-picker" id="resistor-value-picker">
+                        <select
+                          id="resistor-value-select"
+                          class="visually-hidden"
+                          aria-labelledby="resistor-value-picker-button"
+                        >
+                          <option value="">Select value…</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="resistor-value-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="resistor-value-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">Select value…</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="resistor-value-picker-list"
+                          role="listbox"
+                          aria-labelledby="resistor-value-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="resistor-value-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
                     </div>
                   </div>
                   <div

--- a/js/controls.js
+++ b/js/controls.js
@@ -7,6 +7,8 @@ import {
   populateConnectorCategories,
   populateBearingOptions,
   populateHardwareTypePicker,
+  populateComponentMountPicker,
+  populateResistorValues,
   updateCustomImageUi,
   onHardwareTypeChange,
   setBoltDriveSelection,
@@ -15,6 +17,9 @@ import {
   setFuseTypeSelection,
   setThreadSizeSelection,
   setFuseValueSelection,
+  setComponentMountSelection,
+  setResistorValueSelection,
+  updateComponentValueUi,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
@@ -70,6 +75,9 @@ function applyStateToControls() {
   if (bearingTypeSelect) {
     bearingTypeSelect.value = state.bearingType || '';
   }
+  setComponentMountSelection(state.componentMount || 'Through-Hole', { triggerUpdate: false });
+  setResistorValueSelection(state.resistorValue || '', { triggerUpdate: false });
+  updateComponentValueUi({ resetIfHidden: false });
 
   if (lengthInput) {
     lengthInput.value = state.length || '';
@@ -122,6 +130,8 @@ function init() {
   populateConnectorCategories();
   populateBearingOptions();
   populateHardwareTypePicker();
+  populateComponentMountPicker();
+  populateResistorValues();
   updateCustomImageUi();
   onHardwareTypeChange();
   applyStateToControls();

--- a/js/data.js
+++ b/js/data.js
@@ -69,9 +69,62 @@ export const electricalComponentTypes = ['Resistor', 'Capacitor', 'Diode'];
 export const componentImageMap = {
   Resistor: {
     'Through-Hole': 'images/resistors/resistor_through_hole.svg',
+    SMD: 'images/resistors/resistor_smd.svg',
     default: 'images/resistors/resistor_through_hole.svg',
   },
 };
+
+export const componentMountOptions = [
+  {
+    id: 'Through-Hole',
+    label: 'Through-Hole',
+    image: 'images/resistors/resistor_through_hole.svg',
+  },
+  { id: 'SMD', label: 'SMD', image: 'images/resistors/resistor_smd.svg' },
+];
+
+const E12_BASE_VALUES = [1, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2];
+const RESISTOR_DECADES = [0.1, 1, 10, 100, 1000, 10000, 100000, 1000000];
+
+function formatResistorValue(value) {
+  if (value === 0) {
+    return '0 Ω';
+  }
+  if (value < 1) {
+    const rounded = Math.round(value * 100) / 100;
+    return `${rounded.toString().replace(/\.0+$/, '')} Ω`;
+  }
+  if (value < 1000) {
+    const rounded = Math.round(value * 10) / 10;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
+    return `${normalized.replace(/\.0+$/, '')} Ω`;
+  }
+  if (value < 1000000) {
+    const kilo = value / 1000;
+    const rounded = Math.round(kilo * 10) / 10;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
+    return `${normalized.replace(/\.0+$/, '')} kΩ`;
+  }
+  const mega = value / 1000000;
+  const rounded = Math.round(mega * 10) / 10;
+  const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
+  return `${normalized.replace(/\.0+$/, '')} MΩ`;
+}
+
+const resistorValueSet = new Set([0]);
+RESISTOR_DECADES.forEach(multiplier => {
+  E12_BASE_VALUES.forEach(base => {
+    const value = Math.round(base * multiplier * 100) / 100;
+    resistorValueSet.add(value);
+  });
+});
+
+export const resistorValueOptions = Array.from(resistorValueSet)
+  .sort((a, b) => a - b)
+  .map(value => {
+    const label = formatResistorValue(value);
+    return { id: label, label };
+  });
 
 export const boltHeadOptions = [
   { id: 'button_head', label: 'Button Head', image: 'button_head' },

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -48,6 +48,16 @@ const connectorCategoryMessage = document.getElementById('connector-category-mes
 const connectorNotesMessage = document.getElementById('connector-notes-message');
 const componentCategoryContainer = document.getElementById('component-category-container');
 const componentMountContainer = document.getElementById('component-mount-container');
+const componentMountPicker = document.getElementById('component-mount-picker');
+const componentMountPickerButton = document.getElementById('component-mount-picker-button');
+const componentMountPickerList = document.getElementById('component-mount-picker-list');
+const componentMountSelect = document.getElementById('component-mount-select');
+const resistorValueField = document.getElementById('resistor-value-field');
+const resistorValuePicker = document.getElementById('resistor-value-picker');
+const resistorValuePickerButton = document.getElementById('resistor-value-picker-button');
+const resistorValuePickerList = document.getElementById('resistor-value-picker-list');
+const resistorValueSelect = document.getElementById('resistor-value-select');
+const resistorValueMessage = document.getElementById('resistor-value-message');
 const bearingOptionsContainer = document.getElementById('bearing-options-container');
 const bearingTypeSelect = document.getElementById('bearing-type-select');
 const bearingTypeMessage = document.getElementById('bearing-type-message');
@@ -128,7 +138,6 @@ const heightRadios = Array.from(document.querySelectorAll('input[name="label-hei
 const componentCategoryRadios = Array.from(
   document.querySelectorAll('input[name="component-category"]'),
 );
-const componentMountRadios = Array.from(document.querySelectorAll('input[name="component-mount"]'));
 const componentCategoryMessage = document.getElementById('component-category-message');
 const componentMountMessage = document.getElementById('component-mount-message');
 const formStatusMessage = document.getElementById('form-status-message');
@@ -179,6 +188,16 @@ export const elements = {
   connectorNotesMessage,
   componentCategoryContainer,
   componentMountContainer,
+  componentMountPicker,
+  componentMountPickerButton,
+  componentMountPickerList,
+  componentMountSelect,
+  resistorValueField,
+  resistorValuePicker,
+  resistorValuePickerButton,
+  resistorValuePickerList,
+  resistorValueSelect,
+  resistorValueMessage,
   bearingOptionsContainer,
   bearingTypeSelect,
   bearingTypeMessage,
@@ -249,7 +268,6 @@ export const elements = {
   systemTypeRadios,
   heightRadios,
   componentCategoryRadios,
-  componentMountRadios,
   componentCategoryMessage,
   componentMountMessage,
   formStatusMessage,

--- a/js/events.js
+++ b/js/events.js
@@ -22,6 +22,9 @@ import {
   syncFuseTypePicker,
   setFuseValueSelection,
   syncFuseValuePicker,
+  setComponentMountSelection,
+  setResistorValueSelection,
+  updateComponentValueUi,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
 import { downloadLabel, printLabel, shareLabel } from './actions.js';
@@ -34,7 +37,14 @@ const {
   hardwareTypePickerList,
   connectorCategorySelect,
   componentCategoryRadios,
-  componentMountRadios,
+  componentMountSelect,
+  componentMountPicker,
+  componentMountPickerButton,
+  componentMountPickerList,
+  resistorValueSelect,
+  resistorValuePicker,
+  resistorValuePickerButton,
+  resistorValuePickerList,
   bearingTypeSelect,
   systemTypeRadios,
   fuseTypeSelect,
@@ -90,6 +100,8 @@ let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
 let fuseValuePickerOpen = false;
+let componentMountPickerOpen = false;
+let resistorValuePickerOpen = false;
 
 function getHardwareTypeOptionElements() {
   if (!hardwareTypePickerList) {
@@ -937,6 +949,424 @@ function handleFuseValueListFocusOut() {
   }, 0);
 }
 
+function getComponentMountOptionElements() {
+  if (!componentMountPickerList) {
+    return [];
+  }
+  return Array.from(componentMountPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusComponentMountOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getComponentMountOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openComponentMountPicker() {
+  if (!componentMountPicker || !componentMountPickerButton || !componentMountPickerList) {
+    return;
+  }
+  if (componentMountPickerButton.disabled) {
+    return;
+  }
+  if (componentMountPickerOpen) {
+    return;
+  }
+  componentMountPickerOpen = true;
+  componentMountPicker.classList.add('is-open');
+  componentMountPickerList.hidden = false;
+  componentMountPickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getComponentMountOptionElements();
+  const currentValue = typeof state.componentMount === 'string' ? state.componentMount : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusComponentMountOption(selectedOption || options[0]);
+}
+
+function closeComponentMountPicker({ focusButton = false } = {}) {
+  if (!componentMountPicker || !componentMountPickerButton || !componentMountPickerList) {
+    return;
+  }
+  if (!componentMountPickerOpen) {
+    if (focusButton && !componentMountPickerButton.disabled) {
+      componentMountPickerButton.focus();
+    }
+    return;
+  }
+  componentMountPickerOpen = false;
+  componentMountPicker.classList.remove('is-open');
+  componentMountPickerList.hidden = true;
+  componentMountPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !componentMountPickerButton.disabled) {
+    componentMountPickerButton.focus();
+  }
+}
+
+function toggleComponentMountPicker() {
+  if (componentMountPickerOpen) {
+    closeComponentMountPicker({ focusButton: false });
+  } else {
+    openComponentMountPicker();
+  }
+}
+
+function moveComponentMountOption(delta) {
+  if (!componentMountPickerList) {
+    return;
+  }
+  const options = getComponentMountOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && componentMountPickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.componentMount === 'string' ? state.componentMount : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusComponentMountOption(nextOption);
+  }
+}
+
+function handleComponentMountButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openComponentMountPicker();
+    moveComponentMountOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openComponentMountPicker();
+    moveComponentMountOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleComponentMountPicker();
+    return;
+  }
+  if (key === 'Escape' && componentMountPickerOpen) {
+    event.preventDefault();
+    closeComponentMountPicker({ focusButton: true });
+  }
+}
+
+function handleComponentMountListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveComponentMountOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveComponentMountOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getComponentMountOptionElements();
+    if (options.length > 0) {
+      focusComponentMountOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getComponentMountOptionElements();
+    if (options.length > 0) {
+      focusComponentMountOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setComponentMountSelection(option.dataset.value || '');
+        closeComponentMountPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeComponentMountPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeComponentMountPicker();
+  }
+}
+
+function handleComponentMountListClick(event) {
+  if (!componentMountPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !componentMountPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setComponentMountSelection(option.dataset.value || '');
+  closeComponentMountPicker({ focusButton: true });
+}
+
+function handleComponentMountListFocusOut() {
+  if (!componentMountPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!componentMountPickerOpen) {
+      return;
+    }
+    if (!componentMountPicker) {
+      closeComponentMountPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !componentMountPicker.contains(active)) {
+      closeComponentMountPicker();
+    }
+  }, 0);
+}
+
+function getResistorValueOptionElements() {
+  if (!resistorValuePickerList) {
+    return [];
+  }
+  return Array.from(resistorValuePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusResistorValueOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getResistorValueOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openResistorValuePicker() {
+  if (!resistorValuePicker || !resistorValuePickerButton || !resistorValuePickerList) {
+    return;
+  }
+  if (resistorValuePickerButton.disabled) {
+    return;
+  }
+  if (resistorValuePickerOpen) {
+    return;
+  }
+  resistorValuePickerOpen = true;
+  resistorValuePicker.classList.add('is-open');
+  resistorValuePickerList.hidden = false;
+  resistorValuePickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getResistorValueOptionElements();
+  const currentValue = typeof state.resistorValue === 'string' ? state.resistorValue : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusResistorValueOption(selectedOption || options[0]);
+}
+
+function closeResistorValuePicker({ focusButton = false } = {}) {
+  if (!resistorValuePicker || !resistorValuePickerButton || !resistorValuePickerList) {
+    return;
+  }
+  if (!resistorValuePickerOpen) {
+    if (focusButton && !resistorValuePickerButton.disabled) {
+      resistorValuePickerButton.focus();
+    }
+    return;
+  }
+  resistorValuePickerOpen = false;
+  resistorValuePicker.classList.remove('is-open');
+  resistorValuePickerList.hidden = true;
+  resistorValuePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !resistorValuePickerButton.disabled) {
+    resistorValuePickerButton.focus();
+  }
+}
+
+function toggleResistorValuePicker() {
+  if (resistorValuePickerOpen) {
+    closeResistorValuePicker({ focusButton: false });
+  } else {
+    openResistorValuePicker();
+  }
+}
+
+function moveResistorValueOption(delta) {
+  if (!resistorValuePickerList) {
+    return;
+  }
+  const options = getResistorValueOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && resistorValuePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.resistorValue === 'string' ? state.resistorValue : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusResistorValueOption(nextOption);
+  }
+}
+
+function handleResistorValueButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openResistorValuePicker();
+    moveResistorValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openResistorValuePicker();
+    moveResistorValueOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleResistorValuePicker();
+    return;
+  }
+  if (key === 'Escape' && resistorValuePickerOpen) {
+    event.preventDefault();
+    closeResistorValuePicker({ focusButton: true });
+  }
+}
+
+function handleResistorValueListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveResistorValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveResistorValueOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getResistorValueOptionElements();
+    if (options.length > 0) {
+      focusResistorValueOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getResistorValueOptionElements();
+    if (options.length > 0) {
+      focusResistorValueOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setResistorValueSelection(option.dataset.value || '');
+        closeResistorValuePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeResistorValuePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeResistorValuePicker();
+  }
+}
+
+function handleResistorValueListClick(event) {
+  if (!resistorValuePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !resistorValuePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setResistorValueSelection(option.dataset.value || '');
+  closeResistorValuePicker({ focusButton: true });
+}
+
+function handleResistorValueListFocusOut() {
+  if (!resistorValuePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!resistorValuePickerOpen) {
+      return;
+    }
+    if (!resistorValuePicker) {
+      closeResistorValuePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !resistorValuePicker.contains(active)) {
+      closeResistorValuePicker();
+    }
+  }, 0);
+}
+
 function getBoltDriveOptionElements() {
   if (!boltDrivePickerList) {
     return [];
@@ -1613,6 +2043,16 @@ function handleDocumentPointer(event) {
       closeFuseValuePicker();
     }
   }
+  if (componentMountPickerOpen && componentMountPicker) {
+    if (!(target instanceof Node) || !componentMountPicker.contains(target)) {
+      closeComponentMountPicker();
+    }
+  }
+  if (resistorValuePickerOpen && resistorValuePicker) {
+    if (!(target instanceof Node) || !resistorValuePicker.contains(target)) {
+      closeResistorValuePicker();
+    }
+  }
 }
 
 function handleDocumentFocusIn(event) {
@@ -1650,6 +2090,16 @@ function handleDocumentFocusIn(event) {
   if (fuseValuePickerOpen && fuseValuePicker) {
     if (!(target instanceof Node) || !fuseValuePicker.contains(target)) {
       closeFuseValuePicker();
+    }
+  }
+  if (componentMountPickerOpen && componentMountPicker) {
+    if (!(target instanceof Node) || !componentMountPicker.contains(target)) {
+      closeComponentMountPicker();
+    }
+  }
+  if (resistorValuePickerOpen && resistorValuePicker) {
+    if (!(target instanceof Node) || !resistorValuePicker.contains(target)) {
+      closeResistorValuePicker();
     }
   }
 }
@@ -1729,21 +2179,46 @@ export function initEventHandlers() {
     radio.addEventListener('change', () => {
       if (radio.checked) {
         state.componentCategory = radio.value;
+        updateComponentValueUi({ resetIfHidden: true });
         updateDownloadState();
         updatePreview();
       }
     });
   });
 
-  componentMountRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      if (radio.checked) {
-        state.componentMount = radio.value;
-        updateDownloadState();
-        updatePreview();
-      }
+  if (componentMountSelect) {
+    componentMountSelect.addEventListener('change', () => {
+      setComponentMountSelection(componentMountSelect.value);
     });
-  });
+  }
+
+  if (componentMountPickerButton && componentMountPickerList) {
+    componentMountPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleComponentMountPicker();
+    });
+    componentMountPickerButton.addEventListener('keydown', handleComponentMountButtonKeydown);
+    componentMountPickerList.addEventListener('click', handleComponentMountListClick);
+    componentMountPickerList.addEventListener('keydown', handleComponentMountListKeydown);
+    componentMountPickerList.addEventListener('focusout', handleComponentMountListFocusOut);
+  }
+
+  if (resistorValueSelect) {
+    resistorValueSelect.addEventListener('change', () => {
+      setResistorValueSelection(resistorValueSelect.value);
+    });
+  }
+
+  if (resistorValuePickerButton && resistorValuePickerList) {
+    resistorValuePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleResistorValuePicker();
+    });
+    resistorValuePickerButton.addEventListener('keydown', handleResistorValueButtonKeydown);
+    resistorValuePickerList.addEventListener('click', handleResistorValueListClick);
+    resistorValuePickerList.addEventListener('keydown', handleResistorValueListKeydown);
+    resistorValuePickerList.addEventListener('focusout', handleResistorValueListFocusOut);
+  }
 
   if (bearingTypeSelect) {
     bearingTypeSelect.addEventListener('change', () => {
@@ -1944,7 +2419,9 @@ export function initEventHandlers() {
     boltDrivePicker ||
     boltHeadPicker ||
     nutTypePicker ||
-    fuseValuePicker
+    fuseValuePicker ||
+    componentMountPicker ||
+    resistorValuePicker
   ) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
@@ -1953,6 +2430,11 @@ export function initEventHandlers() {
   document.addEventListener('gridfinity:fuse-picker-close', () => {
     closeFuseTypePicker();
     closeFuseValuePicker();
+  });
+
+  document.addEventListener('gridfinity:component-picker-close', () => {
+    closeComponentMountPicker();
+    closeResistorValuePicker();
   });
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -15,6 +15,8 @@ import {
   CONNECTOR_PLACEHOLDER_TEXT,
   findConnectorCategory,
   electricalComponentTypes,
+  componentMountOptions,
+  resistorValueOptions,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 import {
@@ -55,6 +57,15 @@ const {
   connectorNotesHint,
   componentCategoryContainer,
   componentMountContainer,
+  componentMountPicker,
+  componentMountPickerButton,
+  componentMountPickerList,
+  componentMountSelect,
+  resistorValueField,
+  resistorValuePicker,
+  resistorValuePickerButton,
+  resistorValuePickerList,
+  resistorValueSelect,
   bearingOptionsContainer,
   bearingTypeSelect,
   customFieldsContainer,
@@ -86,7 +97,6 @@ const {
   hardwareTypeOptions,
   systemTypeRadios,
   componentCategoryRadios,
-  componentMountRadios,
 } = elements;
 
 const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select hardware…';
@@ -106,6 +116,10 @@ const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
+const COMPONENT_MOUNT_PLACEHOLDER_TEXT = 'Select mounting…';
+const validComponentMounts = new Set(componentMountOptions.map(option => option.id));
+const RESISTOR_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const validResistorValues = new Set(resistorValueOptions.map(option => option.id));
 
 function getFastenerHeadOptions() {
   return state.hardwareType === 'Screw' ? screwTypeOptions : boltHeadOptions;
@@ -216,6 +230,330 @@ export function populateHardwareTypePicker() {
   hardwareTypePickerList.hidden = true;
 
   syncHardwareTypePicker();
+}
+
+function createComponentMountPickerOption(option) {
+  if (!componentMountPickerList) {
+    return;
+  }
+  const item = document.createElement('li');
+  item.className = 'bolt-drive-picker__option';
+  item.dataset.value = option.id;
+  item.setAttribute('role', 'option');
+  item.setAttribute('aria-selected', 'false');
+  item.tabIndex = -1;
+
+  const icon = document.createElement('span');
+  icon.className = 'bolt-drive-picker__option-icon';
+  if (option.image) {
+    const image = document.createElement('img');
+    image.className = 'bolt-drive-picker__option-icon-image';
+    image.src = option.image;
+    image.alt = '';
+    image.loading = 'lazy';
+    image.decoding = 'async';
+    icon.appendChild(image);
+  } else {
+    icon.classList.add('is-empty');
+  }
+
+  const label = document.createElement('span');
+  label.className = 'bolt-drive-picker__option-label';
+  label.textContent = option.label;
+
+  item.appendChild(icon);
+  item.appendChild(label);
+
+  componentMountPickerList.appendChild(item);
+}
+
+export function populateComponentMountPicker() {
+  if (!componentMountSelect) {
+    return;
+  }
+
+  const previousValue = typeof state.componentMount === 'string' ? state.componentMount : '';
+
+  componentMountSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = COMPONENT_MOUNT_PLACEHOLDER_TEXT;
+  componentMountSelect.appendChild(placeholder);
+
+  componentMountOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    componentMountSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validComponentMounts.has(previousValue)
+    ? previousValue
+    : 'Through-Hole';
+  state.componentMount = sanitizedValue;
+  componentMountSelect.value = sanitizedValue;
+
+  if (componentMountPickerList) {
+    componentMountPickerList.innerHTML = '';
+    componentMountOptions.forEach(option => {
+      createComponentMountPickerOption(option);
+    });
+    componentMountPickerList.hidden = true;
+  }
+
+  if (componentMountPickerButton) {
+    componentMountPickerButton.disabled = false;
+    componentMountPickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncComponentMountPicker({ isValid: true });
+}
+
+export function syncComponentMountPicker({ isValid = true } = {}) {
+  if (!componentMountSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.componentMount === 'string' ? state.componentMount : '';
+  const sanitizedValue = validComponentMounts.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.componentMount = sanitizedValue;
+  }
+
+  componentMountSelect.value = sanitizedValue;
+  if (!sanitizedValue && componentMountSelect.options.length > 0) {
+    componentMountSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = sanitizedValue
+    ? componentMountOptions.find(option => option.id === sanitizedValue) || null
+    : null;
+
+  if (componentMountPickerButton) {
+    const label = componentMountPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = componentMountPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = componentMountPickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = selectedOption ? selectedOption.label : COMPONENT_MOUNT_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption && selectedOption.image) {
+        iconImage.src = selectedOption.image;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      componentMountPickerButton.classList.remove('is-invalid');
+      componentMountPickerButton.removeAttribute('aria-invalid');
+    } else {
+      componentMountPickerButton.classList.add('is-invalid');
+      componentMountPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (componentMountPicker) {
+    componentMountPicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (componentMountPickerList) {
+    const optionElements = Array.from(
+      componentMountPickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setComponentMountSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validComponentMounts.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.componentMount === 'string' ? state.componentMount : '';
+
+  state.componentMount = sanitizedValue || '';
+  syncComponentMountPicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function populateResistorValues() {
+  if (!resistorValueSelect) {
+    return;
+  }
+
+  const previousValue = typeof state.resistorValue === 'string' ? state.resistorValue : '';
+
+  resistorValueSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = RESISTOR_VALUE_PLACEHOLDER_TEXT;
+  resistorValueSelect.appendChild(placeholder);
+
+  resistorValueOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    resistorValueSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validResistorValues.has(previousValue) ? previousValue : '';
+  state.resistorValue = sanitizedValue;
+  resistorValueSelect.value = sanitizedValue;
+
+  if (resistorValuePickerList) {
+    resistorValuePickerList.innerHTML = '';
+    resistorValueOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon is-empty';
+      icon.setAttribute('aria-hidden', 'true');
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      resistorValuePickerList.appendChild(item);
+    });
+    resistorValuePickerList.hidden = true;
+  }
+
+  if (resistorValuePickerButton) {
+    resistorValuePickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncResistorValuePicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
+export function updateComponentValueUi({ resetIfHidden = true } = {}) {
+  const showComponentFields = ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType);
+  const category = (state.componentCategory || state.hardwareType || '').trim();
+  const showResistorValues = showComponentFields && category === 'Resistor';
+
+  if (resistorValueField) {
+    resistorValueField.classList.toggle('d-none', !showResistorValues);
+    resistorValueField.setAttribute('aria-hidden', showResistorValues ? 'false' : 'true');
+  }
+
+  if (resistorValueSelect) {
+    resistorValueSelect.disabled = !showResistorValues;
+  }
+
+  if (resistorValuePickerButton) {
+    resistorValuePickerButton.disabled = !showResistorValues;
+    const isOpen = Boolean(
+      showResistorValues &&
+        resistorValuePicker &&
+        resistorValuePicker.classList.contains('is-open'),
+    );
+    resistorValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (resistorValuePickerList) {
+    const shouldHideList =
+      !showResistorValues ||
+      !resistorValuePicker ||
+      !resistorValuePicker.classList.contains('is-open');
+    resistorValuePickerList.hidden = shouldHideList;
+  }
+
+  if (resistorValuePicker) {
+    if (!showResistorValues) {
+      resistorValuePicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    resistorValuePicker.classList.toggle('is-disabled', !showResistorValues);
+  }
+
+  if (!showResistorValues && resetIfHidden) {
+    state.resistorValue = '';
+  }
+
+  syncResistorValuePicker({ isValid: true });
+}
+
+export function syncResistorValuePicker({ isValid = true } = {}) {
+  if (!resistorValueSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.resistorValue === 'string' ? state.resistorValue : '';
+  const sanitizedValue = validResistorValues.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.resistorValue = sanitizedValue;
+  }
+
+  resistorValueSelect.value = sanitizedValue;
+  if (!sanitizedValue && resistorValueSelect.options.length > 0) {
+    resistorValueSelect.selectedIndex = 0;
+  }
+
+  if (resistorValuePickerButton) {
+    const label = resistorValuePickerButton.querySelector('.bolt-drive-picker__current-label');
+    if (label) {
+      label.textContent = sanitizedValue ? sanitizedValue : RESISTOR_VALUE_PLACEHOLDER_TEXT;
+    }
+
+    if (isValid) {
+      resistorValuePickerButton.classList.remove('is-invalid');
+      resistorValuePickerButton.removeAttribute('aria-invalid');
+    } else {
+      resistorValuePickerButton.classList.add('is-invalid');
+      resistorValuePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (resistorValuePicker) {
+    resistorValuePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (resistorValuePickerList) {
+    const optionElements = Array.from(
+      resistorValuePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setResistorValueSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validResistorValues.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.resistorValue === 'string' ? state.resistorValue : '';
+
+  state.resistorValue = sanitizedValue;
+  syncResistorValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
 }
 
 export function syncHardwareTypePicker() {
@@ -1538,23 +1876,53 @@ export function onHardwareTypeChange() {
       if (activeCategory) {
         state.componentCategory = activeCategory.value;
       }
+      updateComponentValueUi({ resetIfHidden: false });
     }
   }
-  if (componentMountRadios) {
-    const desiredMount = state.componentMount || 'Through-Hole';
-    componentMountRadios.forEach(radio => {
-      radio.disabled = !showComponentFields;
-      if (showComponentFields) {
-        radio.checked = radio.value === desiredMount;
-      }
-    });
+  if (componentMountSelect) {
     if (showComponentFields) {
-      const activeMount = componentMountRadios.find(radio => radio.checked);
-      if (activeMount) {
-        state.componentMount = activeMount.value;
-      }
+      const desiredMount = validComponentMounts.has(state.componentMount)
+        ? state.componentMount
+        : 'Through-Hole';
+      state.componentMount = desiredMount;
+      componentMountSelect.value = desiredMount;
     }
+    componentMountSelect.disabled = !showComponentFields;
   }
+
+  if (componentMountPickerButton) {
+    componentMountPickerButton.disabled = !showComponentFields;
+    const isOpen = Boolean(
+      showComponentFields &&
+        componentMountPicker &&
+        componentMountPicker.classList.contains('is-open'),
+    );
+    componentMountPickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (componentMountPickerList) {
+    const shouldHideList =
+      !showComponentFields ||
+      !componentMountPicker ||
+      !componentMountPicker.classList.contains('is-open');
+    componentMountPickerList.hidden = shouldHideList;
+  }
+
+  if (componentMountPicker) {
+    if (!showComponentFields) {
+      componentMountPicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    componentMountPicker.classList.toggle('is-disabled', !showComponentFields);
+  }
+
+  if (!showComponentFields) {
+    syncComponentMountPicker({ isValid: true });
+  } else {
+    syncComponentMountPicker({ isValid: true });
+  }
+
+  updateComponentValueUi({ resetIfHidden: !showComponentFields });
 
   if (measurementSystemContainer) {
     const hideMeasurementSystem =

--- a/js/render.js
+++ b/js/render.js
@@ -5,6 +5,8 @@ import {
   syncBoltHeadPicker,
   syncThreadSizePicker,
   syncFuseValuePicker,
+  syncComponentMountPicker,
+  syncResistorValuePicker,
 } from './forms.js';
 import {
   pxPerMm,
@@ -70,8 +72,11 @@ const {
   componentCategoryRadios,
   componentCategoryMessage,
   componentMountContainer,
-  componentMountRadios,
+  componentMountSelect,
   componentMountMessage,
+  resistorValueField,
+  resistorValueSelect,
+  resistorValueMessage,
   customLine1Input,
   customLine1Field,
   customLine1Message,
@@ -365,6 +370,10 @@ export function isLabelReady() {
     return Boolean(state.bearingType);
   }
   if (ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType)) {
+    const requiresValue = (state.componentCategory || state.hardwareType) === 'Resistor';
+    if (requiresValue) {
+      return Boolean(state.componentCategory && state.componentMount && state.resistorValue);
+    }
     return Boolean(state.componentCategory && state.componentMount);
   }
   if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
@@ -590,14 +599,30 @@ function applyValidationFeedback(disabled) {
       valid: true,
     });
     const mountValid = Boolean(state.componentMount);
-    updateRadioGroupFeedback({
-      radios: componentMountRadios,
+    updateInputFieldState({
+      input: componentMountSelect,
       container: componentMountContainer,
       messageElement: componentMountMessage,
       valid: mountValid,
+      message: mountValid ? '' : 'Choose a mounting style',
     });
+    syncComponentMountPicker({ isValid: mountValid });
     if (!mountValid) {
       requirements.push('choose a mounting style');
+    }
+
+    const requiresValue = (state.componentCategory || state.hardwareType) === 'Resistor';
+    const valueValid = !requiresValue || Boolean(state.resistorValue);
+    updateInputFieldState({
+      input: resistorValueSelect,
+      container: resistorValueField,
+      messageElement: resistorValueMessage,
+      valid: valueValid,
+      message: valueValid ? '' : 'Select a resistor value',
+    });
+    syncResistorValuePicker({ isValid: valueValid });
+    if (requiresValue && !valueValid) {
+      requirements.push('select a resistor value');
     }
   } else {
     updateRadioGroupFeedback({
@@ -606,12 +631,22 @@ function applyValidationFeedback(disabled) {
       messageElement: componentCategoryMessage,
       valid: true,
     });
-    updateRadioGroupFeedback({
-      radios: componentMountRadios,
+    updateInputFieldState({
+      input: componentMountSelect,
       container: componentMountContainer,
       messageElement: componentMountMessage,
       valid: true,
+      message: '',
     });
+    syncComponentMountPicker({ isValid: true });
+    updateInputFieldState({
+      input: resistorValueSelect,
+      container: resistorValueField,
+      messageElement: resistorValueMessage,
+      valid: true,
+      message: '',
+    });
+    syncResistorValuePicker({ isValid: true });
   }
 
   if (hardwareType === 'Custom') {
@@ -1100,6 +1135,18 @@ function buildTextLines() {
   }
 
   if (ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType)) {
+    const category = state.componentCategory || state.hardwareType || 'Component';
+    if (category === 'Resistor') {
+      const line1 = state.resistorValue || 'Resistor';
+      const line2Parts = [];
+      if (state.componentMount) {
+        line2Parts.push(state.componentMount);
+      }
+      if (state.notes) {
+        line2Parts.push(state.notes);
+      }
+      return { line1, line2: line2Parts.join(' — '), line3: '' };
+    }
     const parts = [];
     if (state.componentCategory) {
       parts.push(state.componentCategory);

--- a/js/state.js
+++ b/js/state.js
@@ -22,6 +22,7 @@ export const state = {
   connectorCategory: '',
   componentCategory: 'Resistor',
   componentMount: 'Through-Hole',
+  resistorValue: '',
   bearingType: '',
   bearingDetails: '',
   customLine1: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -10,6 +10,8 @@ import {
   boltDriveOptions,
   screwTypeOptions,
   electricalComponentTypes,
+  componentMountOptions as componentMountOptionList,
+  resistorValueOptions,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -37,6 +39,7 @@ const FIELD_MAP = {
   connectorCategory: 'cc',
   componentCategory: 'cmp',
   componentMount: 'cm',
+  resistorValue: 'rv',
   bearingType: 'bt',
   bearingDetails: 'bd',
   customLine1: 'c1',
@@ -59,11 +62,8 @@ const fuseTypeOptions = new Set(
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
 const DEFAULT_COMPONENT_TYPE = electricalComponentTypes[0] || 'Resistor';
 const componentCategoryOptions = new Set(electricalComponentTypes);
-const componentMountOptions = new Set(
-  Array.isArray(elements.componentMountRadios)
-    ? elements.componentMountRadios.map(radio => radio.value)
-    : [],
-);
+const componentMountOptions = new Set(componentMountOptionList.map(option => option.id));
+const resistorValueOptionSet = new Set(resistorValueOptions.map(option => option.id));
 const heightOptions = new Set(
   Array.isArray(elements.heightRadios)
     ? elements.heightRadios
@@ -297,6 +297,12 @@ function applyExpandedPayload(expanded) {
   ) {
     state.componentMount = expanded.componentMount;
   }
+  if (
+    typeof expanded.resistorValue === 'string' &&
+    resistorValueOptionSet.has(expanded.resistorValue)
+  ) {
+    state.resistorValue = expanded.resistorValue;
+  }
   if (typeof expanded.bearingType === 'string') {
     const trimmed = expanded.bearingType.trim();
     if (!trimmed) {
@@ -309,6 +315,8 @@ function applyExpandedPayload(expanded) {
 
   if (ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType)) {
     state.componentCategory = state.hardwareType;
+  } else {
+    state.resistorValue = '';
   }
 
   const sanitizedThread = sanitizeThreadSize(expanded.threadSize, state.hardwareType);


### PR DESCRIPTION
## Summary
- replace the resistor mounting radio buttons with an icon picker and add a paired resistor value picker
- populate component mount and resistor value options, wiring them into state hydration, validation, and sharing
- update event handling and preview logic so resistor labels show the selected value and validate required fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da78b523508329bed36acfea74613a