### PR TITLE
Remove resistor value validation helper text

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -618,7 +618,7 @@ function applyValidationFeedback(disabled) {
       container: resistorValueField,
       messageElement: resistorValueMessage,
       valid: valueValid,
-      message: valueValid ? '' : 'Select a resistor value',
+      message: '',
     });
     syncResistorValuePicker({ isValid: valueValid });
     if (requiresValue && !valueValid) {


### PR DESCRIPTION
## Summary
- remove the redundant resistor value validation helper text so the mounting style and resistor value fields stay aligned

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68da7f6ffbd48329b4ed086a8c8412db