### PR TITLE
Add capacitor component support with value picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,6 +352,53 @@
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>
+                    <div class="col-12 col-lg-6 d-none" id="capacitor-value-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="capacitor-value-picker-button"
+                        >Capacitor Value</label
+                      >
+                      <div class="bolt-drive-picker" id="capacitor-value-picker">
+                        <select
+                          id="capacitor-value-select"
+                          class="visually-hidden"
+                          aria-labelledby="capacitor-value-picker-button"
+                        >
+                          <option value="">Select value…</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="capacitor-value-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="capacitor-value-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">Select value…</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="capacitor-value-picker-list"
+                          role="listbox"
+                          aria-labelledby="capacitor-value-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="capacitor-value-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
                   </div>
                   <div
                     id="component-mount-message"

--- a/js/controls.js
+++ b/js/controls.js
@@ -9,6 +9,7 @@ import {
   populateHardwareTypePicker,
   populateComponentMountPicker,
   populateResistorValues,
+  populateCapacitorValues,
   updateCustomImageUi,
   onHardwareTypeChange,
   setBoltDriveSelection,
@@ -19,6 +20,7 @@ import {
   setFuseValueSelection,
   setComponentMountSelection,
   setResistorValueSelection,
+  setCapacitorValueSelection,
   updateComponentValueUi,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
@@ -77,6 +79,7 @@ function applyStateToControls() {
   }
   setComponentMountSelection(state.componentMount || 'Through-Hole', { triggerUpdate: false });
   setResistorValueSelection(state.resistorValue || '', { triggerUpdate: false });
+  setCapacitorValueSelection(state.capacitorValue || '', { triggerUpdate: false });
   updateComponentValueUi({ resetIfHidden: false });
 
   if (lengthInput) {
@@ -132,6 +135,7 @@ function init() {
   populateHardwareTypePicker();
   populateComponentMountPicker();
   populateResistorValues();
+  populateCapacitorValues();
   updateCustomImageUi();
   onHardwareTypeChange();
   applyStateToControls();

--- a/js/data.js
+++ b/js/data.js
@@ -72,15 +72,16 @@ export const componentImageMap = {
     SMD: 'images/resistors/resistor_smd.svg',
     default: 'images/resistors/resistor_through_hole.svg',
   },
+  Capacitor: {
+    'Through-Hole': 'images/capacitors/capacitor_through_hole.svg',
+    SMD: 'images/capacitors/capacitor_smd.svg',
+    default: 'images/capacitors/capacitor_through_hole.svg',
+  },
 };
 
 export const componentMountOptions = [
-  {
-    id: 'Through-Hole',
-    label: 'Through-Hole',
-    image: 'images/resistors/resistor_through_hole.svg',
-  },
-  { id: 'SMD', label: 'SMD', image: 'images/resistors/resistor_smd.svg' },
+  { id: 'Through-Hole', label: 'Through-Hole' },
+  { id: 'SMD', label: 'SMD' },
 ];
 
 const E12_BASE_VALUES = [1, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2];
@@ -123,6 +124,69 @@ export const resistorValueOptions = Array.from(resistorValueSet)
   .sort((a, b) => a - b)
   .map(value => {
     const label = formatResistorValue(value);
+    return { id: label, label };
+  });
+
+function formatCapacitorValue(value) {
+  const absolute = Math.abs(value);
+  if (!Number.isFinite(absolute) || absolute <= 0) {
+    return '0 F';
+  }
+  if (absolute >= 1) {
+    const rounded = Math.round(value * 100) / 100;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2);
+    return `${normalized.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1')} F`;
+  }
+  if (absolute >= 0.001) {
+    const milli = value * 1000;
+    const rounded = Math.round(milli * 100) / 100;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2);
+    return `${normalized.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1')} mF`;
+  }
+  if (absolute >= 0.000001) {
+    const micro = value * 1000000;
+    const rounded = Math.round(micro * 100) / 100;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2);
+    return `${normalized.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1')} µF`;
+  }
+  if (absolute >= 0.000000001) {
+    const nano = value * 1000000000;
+    const rounded = Math.round(nano * 100) / 100;
+    const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2);
+    return `${normalized.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1')} nF`;
+  }
+  const pico = value * 1000000000000;
+  const rounded = Math.round(pico * 100) / 100;
+  const normalized = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2);
+  return `${normalized.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1')} pF`;
+}
+
+const capacitorValueSet = new Set();
+const CAPACITOR_BASE_VALUES = [1, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2];
+const CAPACITOR_DECADES = [
+  1e-12,
+  1e-11,
+  1e-10,
+  1e-9,
+  1e-8,
+  1e-7,
+  1e-6,
+  1e-5,
+  1e-4,
+  1e-3,
+];
+
+CAPACITOR_DECADES.forEach(multiplier => {
+  CAPACITOR_BASE_VALUES.forEach(base => {
+    const value = Math.round(base * multiplier * 1000000000000) / 1000000000000;
+    capacitorValueSet.add(value);
+  });
+});
+
+export const capacitorValueOptions = Array.from(capacitorValueSet)
+  .sort((a, b) => a - b)
+  .map(value => {
+    const label = formatCapacitorValue(value);
     return { id: label, label };
   });
 
@@ -306,6 +370,7 @@ export const hardwareTypeImageMap = {
   Nut: 'images/nuts/hex_nut.svg',
   Fuse: 'images/fuses/glass_fuse.svg',
   Resistor: 'images/resistors/resistor_through_hole.svg',
+  Capacitor: 'images/capacitors/capacitor_through_hole.svg',
 };
 
 export const connectorCatalog = [

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -58,6 +58,12 @@ const resistorValuePickerButton = document.getElementById('resistor-value-picker
 const resistorValuePickerList = document.getElementById('resistor-value-picker-list');
 const resistorValueSelect = document.getElementById('resistor-value-select');
 const resistorValueMessage = document.getElementById('resistor-value-message');
+const capacitorValueField = document.getElementById('capacitor-value-field');
+const capacitorValuePicker = document.getElementById('capacitor-value-picker');
+const capacitorValuePickerButton = document.getElementById('capacitor-value-picker-button');
+const capacitorValuePickerList = document.getElementById('capacitor-value-picker-list');
+const capacitorValueSelect = document.getElementById('capacitor-value-select');
+const capacitorValueMessage = document.getElementById('capacitor-value-message');
 const bearingOptionsContainer = document.getElementById('bearing-options-container');
 const bearingTypeSelect = document.getElementById('bearing-type-select');
 const bearingTypeMessage = document.getElementById('bearing-type-message');
@@ -198,6 +204,12 @@ export const elements = {
   resistorValuePickerList,
   resistorValueSelect,
   resistorValueMessage,
+  capacitorValueField,
+  capacitorValuePicker,
+  capacitorValuePickerButton,
+  capacitorValuePickerList,
+  capacitorValueSelect,
+  capacitorValueMessage,
   bearingOptionsContainer,
   bearingTypeSelect,
   bearingTypeMessage,

--- a/js/events.js
+++ b/js/events.js
@@ -24,6 +24,7 @@ import {
   syncFuseValuePicker,
   setComponentMountSelection,
   setResistorValueSelection,
+  setCapacitorValueSelection,
   updateComponentValueUi,
 } from './forms.js';
 import { updatePreview, updateDownloadState, updateQrContentVisibility } from './render.js';
@@ -45,6 +46,10 @@ const {
   resistorValuePicker,
   resistorValuePickerButton,
   resistorValuePickerList,
+  capacitorValueSelect,
+  capacitorValuePicker,
+  capacitorValuePickerButton,
+  capacitorValuePickerList,
   bearingTypeSelect,
   systemTypeRadios,
   fuseTypeSelect,
@@ -102,6 +107,7 @@ let nutTypePickerOpen = false;
 let fuseValuePickerOpen = false;
 let componentMountPickerOpen = false;
 let resistorValuePickerOpen = false;
+let capacitorValuePickerOpen = false;
 
 function getHardwareTypeOptionElements() {
   if (!hardwareTypePickerList) {
@@ -1367,6 +1373,215 @@ function handleResistorValueListFocusOut() {
   }, 0);
 }
 
+function getCapacitorValueOptionElements() {
+  if (!capacitorValuePickerList) {
+    return [];
+  }
+  return Array.from(capacitorValuePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusCapacitorValueOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getCapacitorValueOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openCapacitorValuePicker() {
+  if (!capacitorValuePicker || !capacitorValuePickerButton || !capacitorValuePickerList) {
+    return;
+  }
+  if (capacitorValuePickerButton.disabled) {
+    return;
+  }
+  if (capacitorValuePickerOpen) {
+    return;
+  }
+  capacitorValuePickerOpen = true;
+  capacitorValuePicker.classList.add('is-open');
+  capacitorValuePickerList.hidden = false;
+  capacitorValuePickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getCapacitorValueOptionElements();
+  const currentValue = typeof state.capacitorValue === 'string' ? state.capacitorValue : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusCapacitorValueOption(selectedOption || options[0]);
+}
+
+function closeCapacitorValuePicker({ focusButton = false } = {}) {
+  if (!capacitorValuePicker || !capacitorValuePickerButton || !capacitorValuePickerList) {
+    return;
+  }
+  if (!capacitorValuePickerOpen) {
+    if (focusButton && !capacitorValuePickerButton.disabled) {
+      capacitorValuePickerButton.focus();
+    }
+    return;
+  }
+  capacitorValuePickerOpen = false;
+  capacitorValuePicker.classList.remove('is-open');
+  capacitorValuePickerList.hidden = true;
+  capacitorValuePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !capacitorValuePickerButton.disabled) {
+    capacitorValuePickerButton.focus();
+  }
+}
+
+function toggleCapacitorValuePicker() {
+  if (capacitorValuePickerOpen) {
+    closeCapacitorValuePicker({ focusButton: false });
+  } else {
+    openCapacitorValuePicker();
+  }
+}
+
+function moveCapacitorValueOption(delta) {
+  if (!capacitorValuePickerList) {
+    return;
+  }
+  const options = getCapacitorValueOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && capacitorValuePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.capacitorValue === 'string' ? state.capacitorValue : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusCapacitorValueOption(nextOption);
+  }
+}
+
+function handleCapacitorValueButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openCapacitorValuePicker();
+    moveCapacitorValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openCapacitorValuePicker();
+    moveCapacitorValueOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleCapacitorValuePicker();
+    return;
+  }
+  if (key === 'Escape' && capacitorValuePickerOpen) {
+    event.preventDefault();
+    closeCapacitorValuePicker({ focusButton: true });
+  }
+}
+
+function handleCapacitorValueListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveCapacitorValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveCapacitorValueOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getCapacitorValueOptionElements();
+    if (options.length > 0) {
+      focusCapacitorValueOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getCapacitorValueOptionElements();
+    if (options.length > 0) {
+      focusCapacitorValueOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setCapacitorValueSelection(option.dataset.value || '');
+        closeCapacitorValuePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeCapacitorValuePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeCapacitorValuePicker();
+  }
+}
+
+function handleCapacitorValueListClick(event) {
+  if (!capacitorValuePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !capacitorValuePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setCapacitorValueSelection(option.dataset.value || '');
+  closeCapacitorValuePicker({ focusButton: true });
+}
+
+function handleCapacitorValueListFocusOut() {
+  if (!capacitorValuePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!capacitorValuePickerOpen) {
+      return;
+    }
+    if (!capacitorValuePicker) {
+      closeCapacitorValuePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !capacitorValuePicker.contains(active)) {
+      closeCapacitorValuePicker();
+    }
+  }, 0);
+}
+
 function getBoltDriveOptionElements() {
   if (!boltDrivePickerList) {
     return [];
@@ -2053,6 +2268,11 @@ function handleDocumentPointer(event) {
       closeResistorValuePicker();
     }
   }
+  if (capacitorValuePickerOpen && capacitorValuePicker) {
+    if (!(target instanceof Node) || !capacitorValuePicker.contains(target)) {
+      closeCapacitorValuePicker();
+    }
+  }
 }
 
 function handleDocumentFocusIn(event) {
@@ -2100,6 +2320,11 @@ function handleDocumentFocusIn(event) {
   if (resistorValuePickerOpen && resistorValuePicker) {
     if (!(target instanceof Node) || !resistorValuePicker.contains(target)) {
       closeResistorValuePicker();
+    }
+  }
+  if (capacitorValuePickerOpen && capacitorValuePicker) {
+    if (!(target instanceof Node) || !capacitorValuePicker.contains(target)) {
+      closeCapacitorValuePicker();
     }
   }
 }
@@ -2218,6 +2443,23 @@ export function initEventHandlers() {
     resistorValuePickerList.addEventListener('click', handleResistorValueListClick);
     resistorValuePickerList.addEventListener('keydown', handleResistorValueListKeydown);
     resistorValuePickerList.addEventListener('focusout', handleResistorValueListFocusOut);
+  }
+
+  if (capacitorValueSelect) {
+    capacitorValueSelect.addEventListener('change', () => {
+      setCapacitorValueSelection(capacitorValueSelect.value);
+    });
+  }
+
+  if (capacitorValuePickerButton && capacitorValuePickerList) {
+    capacitorValuePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleCapacitorValuePicker();
+    });
+    capacitorValuePickerButton.addEventListener('keydown', handleCapacitorValueButtonKeydown);
+    capacitorValuePickerList.addEventListener('click', handleCapacitorValueListClick);
+    capacitorValuePickerList.addEventListener('keydown', handleCapacitorValueListKeydown);
+    capacitorValuePickerList.addEventListener('focusout', handleCapacitorValueListFocusOut);
   }
 
   if (bearingTypeSelect) {
@@ -2421,7 +2663,8 @@ export function initEventHandlers() {
     nutTypePicker ||
     fuseValuePicker ||
     componentMountPicker ||
-    resistorValuePicker
+    resistorValuePicker ||
+    capacitorValuePicker
   ) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
@@ -2435,6 +2678,7 @@ export function initEventHandlers() {
   document.addEventListener('gridfinity:component-picker-close', () => {
     closeComponentMountPicker();
     closeResistorValuePicker();
+    closeCapacitorValuePicker();
   });
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -15,8 +15,10 @@ import {
   CONNECTOR_PLACEHOLDER_TEXT,
   findConnectorCategory,
   electricalComponentTypes,
+  componentImageMap,
   componentMountOptions,
   resistorValueOptions,
+  capacitorValueOptions,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 import {
@@ -66,6 +68,11 @@ const {
   resistorValuePickerButton,
   resistorValuePickerList,
   resistorValueSelect,
+  capacitorValueField,
+  capacitorValuePicker,
+  capacitorValuePickerButton,
+  capacitorValuePickerList,
+  capacitorValueSelect,
   bearingOptionsContainer,
   bearingTypeSelect,
   customFieldsContainer,
@@ -120,6 +127,8 @@ const COMPONENT_MOUNT_PLACEHOLDER_TEXT = 'Select mounting…';
 const validComponentMounts = new Set(componentMountOptions.map(option => option.id));
 const RESISTOR_VALUE_PLACEHOLDER_TEXT = 'Select value…';
 const validResistorValues = new Set(resistorValueOptions.map(option => option.id));
+const CAPACITOR_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const validCapacitorValues = new Set(capacitorValueOptions.map(option => option.id));
 
 function getFastenerHeadOptions() {
   return state.hardwareType === 'Screw' ? screwTypeOptions : boltHeadOptions;
@@ -232,6 +241,63 @@ export function populateHardwareTypePicker() {
   syncHardwareTypePicker();
 }
 
+function resolveComponentMountImage(mountId) {
+  if (typeof mountId !== 'string' || !mountId) {
+    return '';
+  }
+  const categoryKey = (state.componentCategory || state.hardwareType || '').trim();
+  const imageGroup = componentImageMap[categoryKey] || componentImageMap[state.hardwareType] || null;
+  if (!imageGroup) {
+    return '';
+  }
+  if (imageGroup[mountId]) {
+    return imageGroup[mountId];
+  }
+  const normalized = mountId.toLowerCase();
+  return (
+    imageGroup[normalized] ||
+    imageGroup[normalized.replace(/\s+/g, '')] ||
+    imageGroup[normalized.replace(/[-\s]+/g, '_')] ||
+    imageGroup.default ||
+    ''
+  );
+}
+
+function refreshComponentMountPickerIcons() {
+  if (!componentMountPickerList) {
+    return;
+  }
+  const items = Array.from(componentMountPickerList.querySelectorAll('[role="option"]'));
+  items.forEach(item => {
+    const value = item.dataset.value || '';
+    const iconWrapper = item.querySelector('.bolt-drive-picker__option-icon');
+    if (!iconWrapper) {
+      return;
+    }
+    let iconImage = iconWrapper.querySelector('img');
+    const imageSrc = resolveComponentMountImage(value);
+    if (imageSrc) {
+      if (!iconImage) {
+        iconImage = document.createElement('img');
+        iconImage.className = 'bolt-drive-picker__option-icon-image';
+        iconImage.alt = '';
+        iconImage.loading = 'lazy';
+        iconImage.decoding = 'async';
+        iconWrapper.appendChild(iconImage);
+      }
+      iconWrapper.classList.remove('is-empty');
+      iconImage.src = imageSrc;
+      iconImage.hidden = false;
+    } else {
+      if (iconImage) {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+      }
+      iconWrapper.classList.add('is-empty');
+    }
+  });
+}
+
 function createComponentMountPickerOption(option) {
   if (!componentMountPickerList) {
     return;
@@ -245,10 +311,11 @@ function createComponentMountPickerOption(option) {
 
   const icon = document.createElement('span');
   icon.className = 'bolt-drive-picker__option-icon';
-  if (option.image) {
+  const imageSrc = resolveComponentMountImage(option.id);
+  if (imageSrc) {
     const image = document.createElement('img');
     image.className = 'bolt-drive-picker__option-icon-image';
-    image.src = option.image;
+    image.src = imageSrc;
     image.alt = '';
     image.loading = 'lazy';
     image.decoding = 'async';
@@ -306,6 +373,7 @@ export function populateComponentMountPicker() {
     componentMountPickerButton.setAttribute('aria-expanded', 'false');
   }
 
+  refreshComponentMountPickerIcons();
   syncComponentMountPicker({ isValid: true });
 }
 
@@ -328,6 +396,7 @@ export function syncComponentMountPicker({ isValid = true } = {}) {
   const selectedOption = sanitizedValue
     ? componentMountOptions.find(option => option.id === sanitizedValue) || null
     : null;
+  const imageSrc = resolveComponentMountImage(sanitizedValue);
 
   if (componentMountPickerButton) {
     const label = componentMountPickerButton.querySelector('.bolt-drive-picker__current-label');
@@ -339,8 +408,8 @@ export function syncComponentMountPicker({ isValid = true } = {}) {
     }
 
     if (iconWrapper && iconImage) {
-      if (selectedOption && selectedOption.image) {
-        iconImage.src = selectedOption.image;
+      if (imageSrc) {
+        iconImage.src = imageSrc;
         iconImage.hidden = false;
         iconWrapper.classList.remove('is-empty');
       } else {
@@ -373,6 +442,7 @@ export function syncComponentMountPicker({ isValid = true } = {}) {
       optionElement.classList.toggle('is-selected', isSelected);
       optionElement.tabIndex = -1;
     });
+    refreshComponentMountPickerIcons();
   }
 }
 
@@ -451,6 +521,7 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
   const showComponentFields = ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType);
   const category = (state.componentCategory || state.hardwareType || '').trim();
   const showResistorValues = showComponentFields && category === 'Resistor';
+  const showCapacitorValues = showComponentFields && category === 'Capacitor';
 
   if (resistorValueField) {
     resistorValueField.classList.toggle('d-none', !showResistorValues);
@@ -491,7 +562,49 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
     state.resistorValue = '';
   }
 
+  if (capacitorValueField) {
+    capacitorValueField.classList.toggle('d-none', !showCapacitorValues);
+    capacitorValueField.setAttribute('aria-hidden', showCapacitorValues ? 'false' : 'true');
+  }
+
+  if (capacitorValueSelect) {
+    capacitorValueSelect.disabled = !showCapacitorValues;
+  }
+
+  if (capacitorValuePickerButton) {
+    capacitorValuePickerButton.disabled = !showCapacitorValues;
+    const isOpen = Boolean(
+      showCapacitorValues &&
+        capacitorValuePicker &&
+        capacitorValuePicker.classList.contains('is-open'),
+    );
+    capacitorValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (capacitorValuePickerList) {
+    const shouldHideList =
+      !showCapacitorValues ||
+      !capacitorValuePicker ||
+      !capacitorValuePicker.classList.contains('is-open');
+    capacitorValuePickerList.hidden = shouldHideList;
+  }
+
+  if (capacitorValuePicker) {
+    if (!showCapacitorValues) {
+      capacitorValuePicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    capacitorValuePicker.classList.toggle('is-disabled', !showCapacitorValues);
+  }
+
+  if (!showCapacitorValues && resetIfHidden) {
+    state.capacitorValue = '';
+  }
+
+  refreshComponentMountPickerIcons();
+  syncComponentMountPicker({ isValid: true });
   syncResistorValuePicker({ isValid: true });
+  syncCapacitorValuePicker({ isValid: true });
 }
 
 export function syncResistorValuePicker({ isValid = true } = {}) {
@@ -549,6 +662,125 @@ export function setResistorValueSelection(nextValue, { triggerUpdate = true } = 
 
   state.resistorValue = sanitizedValue;
   syncResistorValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function populateCapacitorValues() {
+  if (!capacitorValueSelect) {
+    return;
+  }
+
+  const previousValue = typeof state.capacitorValue === 'string' ? state.capacitorValue : '';
+
+  capacitorValueSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = CAPACITOR_VALUE_PLACEHOLDER_TEXT;
+  capacitorValueSelect.appendChild(placeholder);
+
+  capacitorValueOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    capacitorValueSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validCapacitorValues.has(previousValue) ? previousValue : '';
+  state.capacitorValue = sanitizedValue;
+  capacitorValueSelect.value = sanitizedValue;
+
+  if (capacitorValuePickerList) {
+    capacitorValuePickerList.innerHTML = '';
+    capacitorValueOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon is-empty';
+      icon.setAttribute('aria-hidden', 'true');
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      capacitorValuePickerList.appendChild(item);
+    });
+    capacitorValuePickerList.hidden = true;
+  }
+
+  if (capacitorValuePickerButton) {
+    capacitorValuePickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncCapacitorValuePicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
+export function syncCapacitorValuePicker({ isValid = true } = {}) {
+  if (!capacitorValueSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.capacitorValue === 'string' ? state.capacitorValue : '';
+  const sanitizedValue = validCapacitorValues.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.capacitorValue = sanitizedValue;
+  }
+
+  capacitorValueSelect.value = sanitizedValue;
+  if (!sanitizedValue && capacitorValueSelect.options.length > 0) {
+    capacitorValueSelect.selectedIndex = 0;
+  }
+
+  if (capacitorValuePickerButton) {
+    const label = capacitorValuePickerButton.querySelector('.bolt-drive-picker__current-label');
+    if (label) {
+      label.textContent = sanitizedValue ? sanitizedValue : CAPACITOR_VALUE_PLACEHOLDER_TEXT;
+    }
+
+    if (isValid) {
+      capacitorValuePickerButton.classList.remove('is-invalid');
+      capacitorValuePickerButton.removeAttribute('aria-invalid');
+    } else {
+      capacitorValuePickerButton.classList.add('is-invalid');
+      capacitorValuePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (capacitorValuePicker) {
+    capacitorValuePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (capacitorValuePickerList) {
+    const optionElements = Array.from(
+      capacitorValuePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setCapacitorValueSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validCapacitorValues.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.capacitorValue === 'string' ? state.capacitorValue : '';
+
+  state.capacitorValue = sanitizedValue;
+  syncCapacitorValuePicker({ isValid: true });
 
   if (triggerUpdate && previousValue !== sanitizedValue) {
     updateDownloadState();

--- a/js/render.js
+++ b/js/render.js
@@ -7,6 +7,7 @@ import {
   syncFuseValuePicker,
   syncComponentMountPicker,
   syncResistorValuePicker,
+  syncCapacitorValuePicker,
 } from './forms.js';
 import {
   pxPerMm,
@@ -77,6 +78,9 @@ const {
   resistorValueField,
   resistorValueSelect,
   resistorValueMessage,
+  capacitorValueField,
+  capacitorValueSelect,
+  capacitorValueMessage,
   customLine1Input,
   customLine1Field,
   customLine1Message,
@@ -370,9 +374,14 @@ export function isLabelReady() {
     return Boolean(state.bearingType);
   }
   if (ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType)) {
-    const requiresValue = (state.componentCategory || state.hardwareType) === 'Resistor';
-    if (requiresValue) {
+    const category = state.componentCategory || state.hardwareType;
+    const requiresResistorValue = category === 'Resistor';
+    const requiresCapacitorValue = category === 'Capacitor';
+    if (requiresResistorValue) {
       return Boolean(state.componentCategory && state.componentMount && state.resistorValue);
+    }
+    if (requiresCapacitorValue) {
+      return Boolean(state.componentCategory && state.componentMount && state.capacitorValue);
     }
     return Boolean(state.componentCategory && state.componentMount);
   }
@@ -611,18 +620,32 @@ function applyValidationFeedback(disabled) {
       requirements.push('choose a mounting style');
     }
 
-    const requiresValue = (state.componentCategory || state.hardwareType) === 'Resistor';
-    const valueValid = !requiresValue || Boolean(state.resistorValue);
+    const category = (state.componentCategory || state.hardwareType || '').trim();
+    const requiresResistorValue = category === 'Resistor';
+    const requiresCapacitorValue = category === 'Capacitor';
+    const resistorValid = !requiresResistorValue || Boolean(state.resistorValue);
+    const capacitorValid = !requiresCapacitorValue || Boolean(state.capacitorValue);
     updateInputFieldState({
       input: resistorValueSelect,
       container: resistorValueField,
       messageElement: resistorValueMessage,
-      valid: valueValid,
+      valid: resistorValid,
       message: '',
     });
-    syncResistorValuePicker({ isValid: valueValid });
-    if (requiresValue && !valueValid) {
+    updateInputFieldState({
+      input: capacitorValueSelect,
+      container: capacitorValueField,
+      messageElement: capacitorValueMessage,
+      valid: capacitorValid,
+      message: '',
+    });
+    syncResistorValuePicker({ isValid: resistorValid });
+    syncCapacitorValuePicker({ isValid: capacitorValid });
+    if (requiresResistorValue && !resistorValid) {
       requirements.push('select a resistor value');
+    }
+    if (requiresCapacitorValue && !capacitorValid) {
+      requirements.push('select a capacitor value');
     }
   } else {
     updateRadioGroupFeedback({
@@ -646,7 +669,15 @@ function applyValidationFeedback(disabled) {
       valid: true,
       message: '',
     });
+    updateInputFieldState({
+      input: capacitorValueSelect,
+      container: capacitorValueField,
+      messageElement: capacitorValueMessage,
+      valid: true,
+      message: '',
+    });
     syncResistorValuePicker({ isValid: true });
+    syncCapacitorValuePicker({ isValid: true });
   }
 
   if (hardwareType === 'Custom') {
@@ -1138,6 +1169,17 @@ function buildTextLines() {
     const category = state.componentCategory || state.hardwareType || 'Component';
     if (category === 'Resistor') {
       const line1 = state.resistorValue || 'Resistor';
+      const line2Parts = [];
+      if (state.componentMount) {
+        line2Parts.push(state.componentMount);
+      }
+      if (state.notes) {
+        line2Parts.push(state.notes);
+      }
+      return { line1, line2: line2Parts.join(' — '), line3: '' };
+    }
+    if (category === 'Capacitor') {
+      const line1 = state.capacitorValue || 'Capacitor';
       const line2Parts = [];
       if (state.componentMount) {
         line2Parts.push(state.componentMount);

--- a/js/state.js
+++ b/js/state.js
@@ -23,6 +23,7 @@ export const state = {
   componentCategory: 'Resistor',
   componentMount: 'Through-Hole',
   resistorValue: '',
+  capacitorValue: '',
   bearingType: '',
   bearingDetails: '',
   customLine1: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -12,6 +12,7 @@ import {
   electricalComponentTypes,
   componentMountOptions as componentMountOptionList,
   resistorValueOptions,
+  capacitorValueOptions,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -40,6 +41,7 @@ const FIELD_MAP = {
   componentCategory: 'cmp',
   componentMount: 'cm',
   resistorValue: 'rv',
+  capacitorValue: 'cv',
   bearingType: 'bt',
   bearingDetails: 'bd',
   customLine1: 'c1',
@@ -64,6 +66,7 @@ const DEFAULT_COMPONENT_TYPE = electricalComponentTypes[0] || 'Resistor';
 const componentCategoryOptions = new Set(electricalComponentTypes);
 const componentMountOptions = new Set(componentMountOptionList.map(option => option.id));
 const resistorValueOptionSet = new Set(resistorValueOptions.map(option => option.id));
+const capacitorValueOptionSet = new Set(capacitorValueOptions.map(option => option.id));
 const heightOptions = new Set(
   Array.isArray(elements.heightRadios)
     ? elements.heightRadios
@@ -303,6 +306,12 @@ function applyExpandedPayload(expanded) {
   ) {
     state.resistorValue = expanded.resistorValue;
   }
+  if (
+    typeof expanded.capacitorValue === 'string' &&
+    capacitorValueOptionSet.has(expanded.capacitorValue)
+  ) {
+    state.capacitorValue = expanded.capacitorValue;
+  }
   if (typeof expanded.bearingType === 'string') {
     const trimmed = expanded.bearingType.trim();
     if (!trimmed) {
@@ -317,6 +326,15 @@ function applyExpandedPayload(expanded) {
     state.componentCategory = state.hardwareType;
   } else {
     state.resistorValue = '';
+    state.capacitorValue = '';
+  }
+
+  const activeCategory = state.componentCategory || state.hardwareType || '';
+  if (activeCategory !== 'Resistor') {
+    state.resistorValue = '';
+  }
+  if (activeCategory !== 'Capacitor') {
+    state.capacitorValue = '';
   }
 
   const sanitizedThread = sanitizeThreadSize(expanded.threadSize, state.hardwareType);


### PR DESCRIPTION
## Summary
- add capacitor E12 value options and formatting with new icons for mounting styles
- expose a capacitor value picker in the UI with validation, state, and sharing support alongside resistors
- update rendering, events, and controls so capacitor selections appear in the preview and persist across reloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8286016c83298d77f518efb7757b