### PR TITLE
Adjust bolt image group spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -693,11 +693,12 @@ main {
 .bolt-image-group {
   display: flex;
   align-items: stretch;
-  justify-content: center;
-  gap: 0.75rem;
+  justify-content: flex-start;
+  gap: 0.25rem;
   max-height: 100%;
   height: 100%;
-  width: 100%;
+  width: auto;
+  flex: 0 0 auto;
 }
 
 .bolt-image-group img {


### PR DESCRIPTION
## Summary
- adjust the bolt preview image group to align left and reduce spacing
- allow the preview images to take only the width they need so label text has more room

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5edf5e94832983167b9921dd6630