### PR TITLE
Update resistor label formatting in render output

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -1550,14 +1550,15 @@ function buildTextLines() {
     const category = state.componentCategory || state.hardwareType || 'Component';
     if (category === 'Resistor') {
       const line1 = state.resistorValue || 'Resistor';
-      const line2Parts = [];
+      const line2 = 'Resistor';
+      const line3Parts = [];
       if (state.componentMount) {
-        line2Parts.push(state.componentMount);
+        line3Parts.push(state.componentMount);
       }
       if (state.notes) {
-        line2Parts.push(state.notes);
+        line3Parts.push(state.notes);
       }
-      return { line1, line2: line2Parts.join(' — '), line3: '' };
+      return { line1, line2, line3: line3Parts.join(' — ') };
     }
     if (category === 'Capacitor') {
       const line1 = state.capacitorValue || 'Capacitor';


### PR DESCRIPTION
## Summary
- adjust the resistor render logic so the picker label mirrors the capacitor format
- ensure the resistor summary now uses "Resistor" as the second line and extra info on the third line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbc140ae483299b198a4fefe2f9ed