### PR TITLE
Show diode type on diode labels

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -229,6 +229,11 @@ export const diodeValueOptions = [
   { id: 'MMBZ5V6', label: 'MMBZ5V6 Zener Diode' },
 ];
 
+export const diodeValueLabelMap = diodeValueOptions.reduce((map, option) => {
+  map[option.id] = option.label;
+  return map;
+}, {});
+
 export const boltHeadOptions = [
   { id: 'button_head', label: 'Button Head', image: 'button_head' },
   { id: 'cap_head', label: 'Socket Cap', image: 'cap_head' },

--- a/js/render.js
+++ b/js/render.js
@@ -21,6 +21,7 @@ import {
   screwTypeMap,
   electricalComponentTypes,
   componentImageMap,
+  diodeValueLabelMap,
 } from './data.js';
 import { loadQrCodeLibrary } from './lazy-loaders.js';
 
@@ -1573,8 +1574,18 @@ function buildTextLines() {
       return { line1, line2, line3: line3Parts.join(' — ') };
     }
     if (category === 'Diode') {
-      const line1 = state.diodeValue || 'Diode';
-      const line2 = 'Diode';
+      const selectedDiodeId = state.diodeValue || '';
+      const line1 = selectedDiodeId || 'Diode';
+      const diodeLabel = selectedDiodeId ? diodeValueLabelMap[selectedDiodeId] : '';
+      let line2 = 'Diode';
+      if (diodeLabel) {
+        if (diodeLabel.startsWith(`${selectedDiodeId} `)) {
+          const typeLabel = diodeLabel.slice(selectedDiodeId.length).trim();
+          line2 = typeLabel || diodeLabel;
+        } else {
+          line2 = diodeLabel;
+        }
+      }
       const line3Parts = [];
       if (state.componentMount) {
         line3Parts.push(state.componentMount);


### PR DESCRIPTION
## Summary
- expose a diode value label map for easy lookup
- show the selected diode's type on the label's second line instead of the generic text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbca852de8832982e5c1c50e907947