### PR TITLE
Add connector icon to hardware picker

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -387,6 +387,7 @@ export const hardwareTypeImageMap = {
   'Threaded Heat Insert': 'images/threaded_heat_insert/heat_insert.svg',
   Nut: 'images/nuts/hex_nut.svg',
   Fuse: 'images/fuses/glass_fuse.svg',
+  Connector: 'images/connectors/connector.svg',
   Resistor: 'images/resistors/resistor_through_hole.svg',
   Capacitor: 'images/capacitors/capacitor_through_hole.svg',
   Washer: 'images/washers/plain_washer.svg',


### PR DESCRIPTION
## Summary
- update the hardware type icon map to use the uploaded generic connector artwork for the Connector option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd0d5e87c83298e59f3130479c018