### PR TITLE
Hide hardware select until picker initializes

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,59 +132,168 @@
                   >
                     Part Type
                   </label>
-                  <div class="bolt-drive-picker" id="hardware-type-picker">
+                  <div class="part-type-picker" id="hardware-type-picker">
                     <select
                       id="hardware-type-select"
-                      class="visually-hidden"
                       aria-labelledby="hardware-type-label"
                     >
                       <optgroup label="Hardware">
-                        <option value="Bolt" selected>Bolt</option>
-                        <option value="Threaded Heat Insert">Threaded Heat Insert</option>
-                        <option value="Nut">Nut</option>
-                        <option value="Screw">Screw</option>
-                        <option value="Washer">Washer</option>
+                        <option
+                          value="Bolt"
+                          data-img="images/bolts/head/countersunk_head.svg"
+                          data-cat="Hardware"
+                          selected
+                        >
+                          Bolt
+                        </option>
+                        <option
+                          value="Threaded Heat Insert"
+                          data-img="images/threaded_heat_insert/heat_insert.svg"
+                          data-cat="Hardware"
+                        >
+                          Threaded Heat Insert
+                        </option>
+                        <option value="Nut" data-img="images/nuts/hex_nut.svg" data-cat="Hardware">
+                          Nut
+                        </option>
+                        <option
+                          value="Screw"
+                          data-img="images/screws/countersunk_wood_screw.svg"
+                          data-cat="Hardware"
+                        >
+                          Screw
+                        </option>
+                        <option value="Washer" data-img="images/washers/plain_washer.svg" data-cat="Hardware">
+                          Washer
+                        </option>
                       </optgroup>
                       <optgroup label="Electrical">
-                        <option value="Fuse">Fuse</option>
-                        <option value="Connector">Connector</option>
-                        <option value="Resistor">Resistor</option>
-                        <option value="Capacitor">Capacitor</option>
-                        <option value="Diode">Diode</option>
+                        <option value="Fuse" data-img="images/fuses/glass_fuse.svg" data-cat="Electrical">
+                          Fuse
+                        </option>
+                        <option
+                          value="Connector"
+                          data-img="images/connectors/connector.svg"
+                          data-cat="Electrical"
+                        >
+                          Connector
+                        </option>
+                        <option
+                          value="Resistor"
+                          data-img="images/resistors/resistor_through_hole.svg"
+                          data-cat="Electrical"
+                        >
+                          Resistor
+                        </option>
+                        <option
+                          value="Capacitor"
+                          data-img="images/capacitors/capacitor_through_hole.svg"
+                          data-cat="Electrical"
+                        >
+                          Capacitor
+                        </option>
+                        <option value="Diode" data-img="images/diodes/diode_through_hole.svg" data-cat="Electrical">
+                          Diode
+                        </option>
                       </optgroup>
                       <optgroup label="Mechanical">
-                        <option value="Bearing">Bearing</option>
+                        <option value="Bearing" data-img="images/bearings/bearing.svg" data-cat="Mechanical">
+                          Bearing
+                        </option>
                       </optgroup>
-                      <option value="Custom">Custom</option>
+                      <option value="Custom" data-cat="Custom">Custom</option>
                     </select>
                     <button
                       type="button"
-                      class="bolt-drive-picker__button"
+                      class="part-type-picker__chip"
                       id="hardware-type-picker-button"
-                      aria-haspopup="listbox"
+                      aria-haspopup="dialog"
                       aria-expanded="false"
-                      aria-controls="hardware-type-picker-list"
+                      aria-controls="hardware-type-picker-dialog"
                     >
-                      <span class="bolt-drive-picker__current">
-                        <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
-                          <img
-                            class="bolt-drive-picker__current-icon-image"
-                            src=""
-                            alt=""
-                            hidden
-                          />
-                        </span>
-                        <span class="bolt-drive-picker__current-label">Select hardware…</span>
+                      <span class="part-type-picker__chip-thumbnail" aria-hidden="true">
+                        <img
+                          class="part-type-picker__chip-image"
+                          src=""
+                          alt=""
+                          hidden
+                          loading="lazy"
+                          decoding="async"
+                        />
+                        <span class="part-type-picker__chip-fallback" aria-hidden="true"></span>
                       </span>
-                      <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      <span class="part-type-picker__chip-label">Select part type…</span>
                     </button>
-                    <ul
-                      class="bolt-drive-picker__list"
-                      id="hardware-type-picker-list"
-                      role="listbox"
-                      aria-labelledby="hardware-type-picker-button"
+                    <dialog
+                      class="part-type-picker__dialog"
+                      id="hardware-type-picker-dialog"
+                      aria-labelledby="hardware-type-picker-title"
+                    >
+                      <div class="part-type-picker__dialog-surface" data-part-type-dialog-surface>
+                        <header class="part-type-picker__header">
+                          <div class="part-type-picker__title-group">
+                            <h2 class="part-type-picker__title" id="hardware-type-picker-title">
+                              Choose a part type
+                            </h2>
+                            <p class="part-type-picker__subtitle">Browse by category or search the catalog.</p>
+                          </div>
+                          <button
+                            type="button"
+                            class="part-type-picker__close"
+                            data-part-type-picker-close
+                            aria-label="Close part type picker"
+                          >
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                        </header>
+                        <div class="part-type-picker__search-row">
+                          <label for="hardware-type-picker-search" class="visually-hidden"
+                            >Search part types</label
+                          >
+                          <input
+                            type="search"
+                            class="part-type-picker__search"
+                            id="hardware-type-picker-search"
+                            name="hardware-type-picker-search"
+                            placeholder="Search part types"
+                            autocomplete="off"
+                          />
+                        </div>
+                        <div
+                          class="part-type-picker__filters"
+                          id="hardware-type-picker-filters"
+                          role="group"
+                          aria-label="Filter part types by category"
+                        ></div>
+                        <section
+                          class="part-type-picker__recent"
+                          id="hardware-type-picker-recent-section"
+                          hidden
+                        >
+                          <h3 class="part-type-picker__section-title">Recently used</h3>
+                          <div
+                            class="part-type-picker__recent-grid"
+                            id="hardware-type-picker-recent"
+                            role="listbox"
+                            aria-label="Recently used part types"
+                          ></div>
+                        </section>
+                        <p class="part-type-picker__empty" id="hardware-type-picker-empty" hidden>
+                          No part types match your filters.
+                        </p>
+                        <div
+                          class="part-type-picker__grid"
+                          id="hardware-type-picker-list"
+                          role="listbox"
+                          aria-label="All part types"
+                        ></div>
+                      </div>
+                    </dialog>
+                    <div
+                      class="part-type-picker__fallback-backdrop"
+                      id="hardware-type-picker-fallback"
                       hidden
-                    ></ul>
+                    ></div>
                   </div>
                 </div>
                 <div id="custom-fields" class="d-none">

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -129,7 +129,20 @@ const hardwareTypeRadios = Array.from(document.querySelectorAll('input[name="har
 const hardwareTypeSelect = document.getElementById('hardware-type-select');
 const hardwareTypePicker = document.getElementById('hardware-type-picker');
 const hardwareTypePickerButton = document.getElementById('hardware-type-picker-button');
+const hardwareTypePickerDialog = document.getElementById('hardware-type-picker-dialog');
+const hardwareTypePickerFallback = document.getElementById('hardware-type-picker-fallback');
+const hardwareTypePickerSurface = hardwareTypePickerDialog
+  ? hardwareTypePickerDialog.querySelector('[data-part-type-dialog-surface]')
+  : null;
+const hardwareTypePickerCloseButton = hardwareTypePicker
+  ? hardwareTypePicker.querySelector('[data-part-type-picker-close]')
+  : null;
+const hardwareTypePickerSearch = document.getElementById('hardware-type-picker-search');
+const hardwareTypePickerFilters = document.getElementById('hardware-type-picker-filters');
+const hardwareTypePickerRecentSection = document.getElementById('hardware-type-picker-recent-section');
+const hardwareTypePickerRecent = document.getElementById('hardware-type-picker-recent');
 const hardwareTypePickerList = document.getElementById('hardware-type-picker-list');
+const hardwareTypePickerEmpty = document.getElementById('hardware-type-picker-empty');
 const hardwareTypeOptions = new Set(
   hardwareTypeRadios
     .map(radio => radio.value)
@@ -273,7 +286,16 @@ export const elements = {
   hardwareTypeSelect,
   hardwareTypePicker,
   hardwareTypePickerButton,
+  hardwareTypePickerDialog,
+  hardwareTypePickerFallback,
+  hardwareTypePickerSurface,
+  hardwareTypePickerCloseButton,
+  hardwareTypePickerSearch,
+  hardwareTypePickerFilters,
+  hardwareTypePickerRecentSection,
+  hardwareTypePickerRecent,
   hardwareTypePickerList,
+  hardwareTypePickerEmpty,
   hardwareTypeOptions,
   systemTypeRadios,
   heightRadios,

--- a/js/events.js
+++ b/js/events.js
@@ -18,6 +18,9 @@ import {
   setNutTypeSelection,
   syncNutTypePicker,
   syncHardwareTypePicker,
+  setHardwareTypeFilterCategory,
+  setHardwareTypeSearchQuery,
+  getHardwareTypePickerMode,
   setFuseTypeSelection,
   syncFuseTypePicker,
   setFuseValueSelection,
@@ -38,7 +41,12 @@ const {
   hardwareTypeSelect,
   hardwareTypePicker,
   hardwareTypePickerButton,
-  hardwareTypePickerList,
+  hardwareTypePickerDialog,
+  hardwareTypePickerFallback,
+  hardwareTypePickerSurface,
+  hardwareTypePickerCloseButton,
+  hardwareTypePickerSearch,
+  hardwareTypePickerFilters,
   connectorCategorySelect,
   componentCategoryRadios,
   componentMountSelect,
@@ -121,11 +129,52 @@ let capacitorValuePickerOpen = false;
 let diodeValuePickerOpen = false;
 let bearingTypePickerOpen = false;
 
+const HARDWARE_TYPE_SEARCH_DELAY = 120;
+let hardwareTypePickerMode = 'dialog';
+let hardwareTypeModalElement = null;
+let hardwareTypePreviouslyFocusedElement = null;
+let hardwareTypeSearchTimeoutId = 0;
+let hardwareTypeTrapElements = [];
+let hardwareTypeActiveOptionIndex = -1;
+
+function updateHardwareTypePickerMode() {
+  hardwareTypePickerMode = getHardwareTypePickerMode();
+  hardwareTypeModalElement =
+    hardwareTypePickerMode === 'dialog' ? hardwareTypePickerDialog : hardwareTypePickerFallback;
+}
+
 function getHardwareTypeOptionElements() {
-  if (!hardwareTypePickerList) {
+  if (!hardwareTypePickerSurface) {
     return [];
   }
-  return Array.from(hardwareTypePickerList.querySelectorAll('[role="option"]'));
+  return Array.from(
+    hardwareTypePickerSurface.querySelectorAll('[data-hardware-type-option="true"]:not([hidden])'),
+  );
+}
+
+function updateHardwareTypeActiveOptionFromDom() {
+  const options = getHardwareTypeOptionElements();
+  const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const activeOption = activeElement && options.includes(activeElement) ? activeElement : null;
+  const tabIndexed = options.find(option => option.tabIndex === 0) || null;
+  const selectedOption = options.find(option => option.classList.contains('is-selected')) || null;
+  const fallbackOption = options[0] || null;
+  const candidate = activeOption || tabIndexed || selectedOption || fallbackOption;
+
+  hardwareTypeActiveOptionIndex = candidate ? options.indexOf(candidate) : -1;
+  options.forEach((option, index) => {
+    option.tabIndex = index === hardwareTypeActiveOptionIndex ? 0 : -1;
+  });
+}
+
+function updateHardwareTypeTrapElements() {
+  if (!hardwareTypePickerSurface) {
+    hardwareTypeTrapElements = [];
+    return;
+  }
+  const selector =
+    'button:not([disabled]):not([hidden]), [href], input:not([disabled]):not([hidden]), select:not([disabled]):not([hidden]), textarea:not([disabled]):not([hidden]), [tabindex]:not([tabindex="-1"])';
+  hardwareTypeTrapElements = Array.from(hardwareTypePickerSurface.querySelectorAll(selector));
 }
 
 function focusHardwareTypeOption(option) {
@@ -136,80 +185,36 @@ function focusHardwareTypeOption(option) {
   options.forEach(opt => {
     opt.tabIndex = opt === option ? 0 : -1;
   });
-  option.focus();
+  hardwareTypeActiveOptionIndex = options.indexOf(option);
+  option.focus({ preventScroll: false });
   if (typeof option.scrollIntoView === 'function') {
     option.scrollIntoView({ block: 'nearest' });
   }
 }
 
-function openHardwareTypePicker() {
-  if (!hardwareTypePicker || !hardwareTypePickerButton || !hardwareTypePickerList) {
-    return;
-  }
-  if (hardwareTypePickerButton.disabled) {
-    return;
-  }
-  if (hardwareTypePickerOpen) {
-    return;
-  }
-  hardwareTypePickerOpen = true;
-  hardwareTypePicker.classList.add('is-open');
-  hardwareTypePickerList.hidden = false;
-  hardwareTypePickerButton.setAttribute('aria-expanded', 'true');
-  syncHardwareTypePicker();
-
+function focusHardwareTypeDefaultOption() {
   const options = getHardwareTypeOptionElements();
   if (options.length === 0) {
+    hardwareTypeActiveOptionIndex = -1;
     return;
   }
   const currentValue = typeof state.hardwareType === 'string' ? state.hardwareType : '';
-  const selectedOption = options.find(option => option.dataset.value === currentValue);
-  focusHardwareTypeOption(selectedOption || options[0]);
-}
-
-function closeHardwareTypePicker({ focusButton = false } = {}) {
-  if (!hardwareTypePicker || !hardwareTypePickerButton || !hardwareTypePickerList) {
-    return;
-  }
-  if (!hardwareTypePickerOpen) {
-    if (focusButton && !hardwareTypePickerButton.disabled) {
-      hardwareTypePickerButton.focus();
-    }
-    return;
-  }
-  hardwareTypePickerOpen = false;
-  hardwareTypePicker.classList.remove('is-open');
-  hardwareTypePickerList.hidden = true;
-  hardwareTypePickerButton.setAttribute('aria-expanded', 'false');
-  if (focusButton && !hardwareTypePickerButton.disabled) {
-    hardwareTypePickerButton.focus();
-  }
-}
-
-function toggleHardwareTypePicker() {
-  if (hardwareTypePickerOpen) {
-    closeHardwareTypePicker({ focusButton: false });
-  } else {
-    openHardwareTypePicker();
-  }
+  const selected = options.find(option => option.dataset.value === currentValue) || options[0];
+  focusHardwareTypeOption(selected);
 }
 
 function moveHardwareTypeOption(delta) {
-  if (!hardwareTypePickerList) {
-    return;
-  }
   const options = getHardwareTypeOptionElements();
   if (options.length === 0) {
     return;
   }
-  const active = document.activeElement;
-  const activeOption = active && hardwareTypePickerList.contains(active)
-    ? active.closest('[role="option"]')
-    : null;
-  let index = activeOption ? options.indexOf(activeOption) : -1;
-  if (index === -1) {
+  let index = hardwareTypeActiveOptionIndex;
+  if (index < 0 || index >= options.length) {
     const currentValue = typeof state.hardwareType === 'string' ? state.hardwareType : '';
     index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  if (index < 0) {
+    index = 0;
   }
   let nextIndex = index + delta;
   if (nextIndex < 0) {
@@ -217,122 +222,304 @@ function moveHardwareTypeOption(delta) {
   } else if (nextIndex >= options.length) {
     nextIndex = 0;
   }
-  const nextOption = options[nextIndex];
-  if (nextOption) {
-    focusHardwareTypeOption(nextOption);
-  }
+  focusHardwareTypeOption(options[nextIndex]);
 }
 
-function handleHardwareTypeButtonKeydown(event) {
-  const { key } = event;
-  if (key === 'ArrowDown') {
-    event.preventDefault();
-    openHardwareTypePicker();
-    moveHardwareTypeOption(1);
+function openHardwareTypePicker() {
+  if (!hardwareTypePickerButton || !hardwareTypePickerSurface) {
     return;
   }
-  if (key === 'ArrowUp') {
-    event.preventDefault();
-    openHardwareTypePicker();
-    moveHardwareTypeOption(-1);
+  updateHardwareTypePickerMode();
+  const modalRoot = hardwareTypeModalElement;
+  if (!modalRoot || hardwareTypePickerOpen) {
     return;
   }
-  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
-    event.preventDefault();
-    toggleHardwareTypePicker();
+  hardwareTypePickerOpen = true;
+  hardwareTypePreviouslyFocusedElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  hardwareTypePickerButton.setAttribute('aria-expanded', 'true');
+  document.body.classList.add('part-type-picker-open');
+
+  syncHardwareTypePicker();
+  updateHardwareTypeActiveOptionFromDom();
+  updateHardwareTypeTrapElements();
+
+  if (hardwareTypePickerMode === 'dialog' && modalRoot instanceof HTMLDialogElement) {
+    modalRoot.addEventListener('cancel', handleHardwareTypeDialogCancel);
+    if (!modalRoot.open) {
+      modalRoot.showModal();
+    }
+  } else {
+    modalRoot.hidden = false;
+    modalRoot.classList.add('is-open');
+    modalRoot.setAttribute('aria-hidden', 'false');
+  }
+
+  if (hardwareTypePickerSearch) {
+    hardwareTypePickerSearch.focus();
+    hardwareTypePickerSearch.select();
+  } else {
+    focusHardwareTypeDefaultOption();
+  }
+  updateHardwareTypeTrapElements();
+}
+
+function closeHardwareTypePicker({ focusButton = true } = {}) {
+  if (!hardwareTypePickerOpen) {
     return;
   }
-  if (key === 'Escape' && hardwareTypePickerOpen) {
+  hardwareTypePickerOpen = false;
+  if (hardwareTypeSearchTimeoutId) {
+    window.clearTimeout(hardwareTypeSearchTimeoutId);
+    hardwareTypeSearchTimeoutId = 0;
+  }
+
+  if (hardwareTypePickerButton) {
+    hardwareTypePickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  const modalRoot = hardwareTypeModalElement || (hardwareTypePickerMode === 'dialog'
+    ? hardwareTypePickerDialog
+    : hardwareTypePickerFallback);
+
+  if (hardwareTypePickerMode === 'dialog' && modalRoot instanceof HTMLDialogElement) {
+    modalRoot.removeEventListener('cancel', handleHardwareTypeDialogCancel);
+    if (modalRoot.open) {
+      modalRoot.close();
+    }
+  } else if (modalRoot) {
+    modalRoot.classList.remove('is-open');
+    modalRoot.hidden = true;
+    modalRoot.setAttribute('aria-hidden', 'true');
+  }
+
+  document.body.classList.remove('part-type-picker-open');
+  hardwareTypeTrapElements = [];
+  hardwareTypeActiveOptionIndex = -1;
+
+  if (focusButton && hardwareTypePickerButton) {
+    hardwareTypePickerButton.focus();
+  } else if (!focusButton && hardwareTypePreviouslyFocusedElement) {
+    hardwareTypePreviouslyFocusedElement.focus();
+  }
+  hardwareTypePreviouslyFocusedElement = null;
+  hardwareTypeModalElement = null;
+}
+
+function handleHardwareTypeDialogCancel(event) {
+  event.preventDefault();
+  closeHardwareTypePicker({ focusButton: true });
+}
+
+function handleHardwareTypeFallbackClick(event) {
+  if (!hardwareTypePickerOpen) {
+    return;
+  }
+  if (event.target === hardwareTypePickerFallback) {
     event.preventDefault();
     closeHardwareTypePicker({ focusButton: true });
   }
 }
 
-function handleHardwareTypeListKeydown(event) {
-  const { key } = event;
-  if (key === 'ArrowDown') {
-    event.preventDefault();
-    moveHardwareTypeOption(1);
+function selectHardwareTypeOption(value) {
+  if (!hardwareTypeSelect) {
     return;
   }
-  if (key === 'ArrowUp') {
-    event.preventDefault();
-    moveHardwareTypeOption(-1);
-    return;
-  }
-  if (key === 'Home') {
-    event.preventDefault();
-    const options = getHardwareTypeOptionElements();
-    if (options.length > 0) {
-      focusHardwareTypeOption(options[0]);
-    }
-    return;
-  }
-  if (key === 'End') {
-    event.preventDefault();
-    const options = getHardwareTypeOptionElements();
-    if (options.length > 0) {
-      focusHardwareTypeOption(options[options.length - 1]);
-    }
-    return;
-  }
-  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
-    event.preventDefault();
-    const target = event.target;
-    if (target && target instanceof HTMLElement) {
-      const option = target.closest('[role="option"]');
-      if (option) {
-        applyHardwareTypeSelection(option.dataset.value || '');
-        closeHardwareTypePicker({ focusButton: true });
-      }
-    }
-    return;
-  }
-  if (key === 'Escape') {
-    event.preventDefault();
+  const nextValue = typeof value === 'string' ? value.trim() : '';
+  if (!nextValue) {
     closeHardwareTypePicker({ focusButton: true });
     return;
   }
-  if (key === 'Tab') {
-    closeHardwareTypePicker();
+  if (hardwareTypeSelect.value !== nextValue) {
+    hardwareTypeSelect.value = nextValue;
+    hardwareTypeSelect.dispatchEvent(new Event('input', { bubbles: true }));
+    hardwareTypeSelect.dispatchEvent(new Event('change', { bubbles: true }));
   }
+  closeHardwareTypePicker({ focusButton: true });
 }
 
-function handleHardwareTypeListClick(event) {
-  if (!hardwareTypePickerList) {
+function handleHardwareTypeOptionClick(event) {
+  if (!hardwareTypePickerOpen) {
     return;
   }
   const target = event.target;
   if (!(target instanceof HTMLElement)) {
     return;
   }
-  const option = target.closest('[role="option"]');
-  if (!option || !hardwareTypePickerList.contains(option)) {
+  const option = target.closest('[data-hardware-type-option="true"]');
+  if (!option) {
     return;
   }
   event.preventDefault();
-  applyHardwareTypeSelection(option.dataset.value || '');
-  closeHardwareTypePicker({ focusButton: true });
+  const value = option.dataset.value || '';
+  if (value) {
+    selectHardwareTypeOption(value);
+  }
 }
 
-function handleHardwareTypeListFocusOut() {
+function queueHardwareTypeSearchUpdate(value) {
+  if (hardwareTypeSearchTimeoutId) {
+    window.clearTimeout(hardwareTypeSearchTimeoutId);
+  }
+  hardwareTypeSearchTimeoutId = window.setTimeout(() => {
+    hardwareTypeSearchTimeoutId = 0;
+    setHardwareTypeSearchQuery(value);
+    updateHardwareTypeActiveOptionFromDom();
+    updateHardwareTypeTrapElements();
+  }, HARDWARE_TYPE_SEARCH_DELAY);
+}
+
+function handleHardwareTypeSearchInput() {
+  if (!hardwareTypePickerSearch) {
+    return;
+  }
+  queueHardwareTypeSearchUpdate(hardwareTypePickerSearch.value);
+}
+
+function handleHardwareTypeSearchKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    focusHardwareTypeDefaultOption();
+  }
+}
+
+function handleHardwareTypeFilterClick(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const button = target.closest('.part-type-picker__filter');
+  if (!button || !hardwareTypePickerFilters || !hardwareTypePickerFilters.contains(button)) {
+    return;
+  }
+  event.preventDefault();
+  const category = typeof button.dataset.category === 'string' ? button.dataset.category : '';
+  setHardwareTypeFilterCategory(category);
+  updateHardwareTypeActiveOptionFromDom();
+  updateHardwareTypeTrapElements();
+}
+
+function handleHardwareTypeSurfaceKeydown(event) {
   if (!hardwareTypePickerOpen) {
     return;
   }
-  setTimeout(() => {
-    if (!hardwareTypePickerOpen) {
-      return;
-    }
-    if (!hardwareTypePicker) {
-      closeHardwareTypePicker();
-      return;
-    }
+  const target = event.target;
+  const { key } = event;
+
+  if (key === 'Tab' && hardwareTypeTrapElements.length > 0) {
+    const first = hardwareTypeTrapElements[0];
+    const last = hardwareTypeTrapElements[hardwareTypeTrapElements.length - 1];
     const active = document.activeElement;
-    if (!active || !hardwareTypePicker.contains(active)) {
-      closeHardwareTypePicker();
+    if (event.shiftKey) {
+      if (active === first || !hardwareTypePickerSurface.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !hardwareTypePickerSurface.contains(active)) {
+      event.preventDefault();
+      first.focus();
     }
-  }, 0);
+    return;
+  }
+
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeHardwareTypePicker({ focusButton: true });
+    return;
+  }
+
+  if (hardwareTypePickerSearch && target === hardwareTypePickerSearch) {
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      focusHardwareTypeDefaultOption();
+    }
+    return;
+  }
+
+  if (target instanceof HTMLElement && target.dataset.hardwareTypeOption === 'true') {
+    if (key === 'ArrowDown' || key === 'ArrowRight') {
+      event.preventDefault();
+      moveHardwareTypeOption(1);
+      return;
+    }
+    if (key === 'ArrowUp' || key === 'ArrowLeft') {
+      event.preventDefault();
+      moveHardwareTypeOption(-1);
+      return;
+    }
+    if (key === 'Home') {
+      event.preventDefault();
+      const options = getHardwareTypeOptionElements();
+      if (options.length > 0) {
+        focusHardwareTypeOption(options[0]);
+      }
+      return;
+    }
+    if (key === 'End') {
+      event.preventDefault();
+      const options = getHardwareTypeOptionElements();
+      if (options.length > 0) {
+        focusHardwareTypeOption(options[options.length - 1]);
+      }
+      return;
+    }
+    if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+      event.preventDefault();
+      selectHardwareTypeOption(target.dataset.value || '');
+      return;
+    }
+  }
+
+  const isEditableTarget =
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable);
+
+  if (!isEditableTarget) {
+    if (key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      event.preventDefault();
+      if (hardwareTypePickerSearch) {
+        hardwareTypePickerSearch.focus();
+        hardwareTypePickerSearch.select();
+        const nextValue = hardwareTypePickerSearch.value + key;
+        hardwareTypePickerSearch.value = nextValue;
+        const cursor = nextValue.length;
+        hardwareTypePickerSearch.setSelectionRange(cursor, cursor);
+        queueHardwareTypeSearchUpdate(nextValue);
+      }
+      return;
+    }
+    if (key === 'Backspace') {
+      event.preventDefault();
+      if (hardwareTypePickerSearch) {
+        hardwareTypePickerSearch.focus();
+        hardwareTypePickerSearch.select();
+        const nextValue = hardwareTypePickerSearch.value.slice(0, -1);
+        hardwareTypePickerSearch.value = nextValue;
+        const cursor = nextValue.length;
+        hardwareTypePickerSearch.setSelectionRange(cursor, cursor);
+        queueHardwareTypeSearchUpdate(nextValue);
+      }
+    }
+  }
 }
+
+function handleHardwareTypeButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown' || key === 'ArrowUp') {
+    event.preventDefault();
+    openHardwareTypePicker();
+    moveHardwareTypeOption(key === 'ArrowDown' ? 1 : -1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    openHardwareTypePicker();
+  }
+}
+
 
 function getFuseTypeOptionElements() {
   if (!fuseTypePickerList) {
@@ -2654,11 +2841,6 @@ function handleNutTypeListFocusOut() {
 
 function handleDocumentPointer(event) {
   const target = event.target;
-  if (hardwareTypePickerOpen && hardwareTypePicker) {
-    if (!(target instanceof Node) || !hardwareTypePicker.contains(target)) {
-      closeHardwareTypePicker();
-    }
-  }
   if (fuseTypePickerOpen && fuseTypePicker) {
     if (!(target instanceof Node) || !fuseTypePicker.contains(target)) {
       closeFuseTypePicker();
@@ -2718,11 +2900,6 @@ function handleDocumentPointer(event) {
 
 function handleDocumentFocusIn(event) {
   const target = event.target;
-  if (hardwareTypePickerOpen && hardwareTypePicker) {
-    if (!(target instanceof Node) || !hardwareTypePicker.contains(target)) {
-      closeHardwareTypePicker();
-    }
-  }
   if (fuseTypePickerOpen && fuseTypePicker) {
     if (!(target instanceof Node) || !fuseTypePicker.contains(target)) {
       closeFuseTypePicker();
@@ -2797,15 +2974,39 @@ export function initEventHandlers() {
     hardwareTypeSelect.addEventListener('input', handleSelectChange);
   }
 
-  if (hardwareTypePickerButton && hardwareTypePickerList) {
+  updateHardwareTypePickerMode();
+
+  if (hardwareTypePickerButton) {
     hardwareTypePickerButton.addEventListener('click', event => {
       event.preventDefault();
-      toggleHardwareTypePicker();
+      openHardwareTypePicker();
     });
     hardwareTypePickerButton.addEventListener('keydown', handleHardwareTypeButtonKeydown);
-    hardwareTypePickerList.addEventListener('click', handleHardwareTypeListClick);
-    hardwareTypePickerList.addEventListener('keydown', handleHardwareTypeListKeydown);
-    hardwareTypePickerList.addEventListener('focusout', handleHardwareTypeListFocusOut);
+  }
+
+  if (hardwareTypePickerCloseButton) {
+    hardwareTypePickerCloseButton.addEventListener('click', event => {
+      event.preventDefault();
+      closeHardwareTypePicker({ focusButton: true });
+    });
+  }
+
+  if (hardwareTypePickerSearch) {
+    hardwareTypePickerSearch.addEventListener('input', handleHardwareTypeSearchInput);
+    hardwareTypePickerSearch.addEventListener('keydown', handleHardwareTypeSearchKeydown);
+  }
+
+  if (hardwareTypePickerFilters) {
+    hardwareTypePickerFilters.addEventListener('click', handleHardwareTypeFilterClick);
+  }
+
+  if (hardwareTypePickerSurface) {
+    hardwareTypePickerSurface.addEventListener('keydown', handleHardwareTypeSurfaceKeydown);
+    hardwareTypePickerSurface.addEventListener('click', handleHardwareTypeOptionClick);
+  }
+
+  if (hardwareTypePickerFallback) {
+    hardwareTypePickerFallback.addEventListener('click', handleHardwareTypeFallbackClick);
   }
 
   if (fuseTypePickerButton && fuseTypePickerList) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -108,14 +108,39 @@ const {
   defaultStandardLabel,
   hardwareTypeRadios,
   hardwareTypeSelect,
+  hardwareTypePicker,
   hardwareTypePickerButton,
+  hardwareTypePickerDialog,
+  hardwareTypePickerFallback,
+  hardwareTypePickerSurface,
+  hardwareTypePickerSearch,
+  hardwareTypePickerFilters,
+  hardwareTypePickerRecentSection,
+  hardwareTypePickerRecent,
   hardwareTypePickerList,
+  hardwareTypePickerEmpty,
   hardwareTypeOptions,
   systemTypeRadios,
   componentCategoryRadios,
 } = elements;
 
-const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select hardware…';
+const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select part type…';
+const HARDWARE_TYPE_ALL_FILTER = 'All';
+const HARDWARE_TYPE_DEFAULT_CATEGORY = 'Uncategorized';
+const HARDWARE_TYPE_RECENT_STORAGE_KEY = 'gridfinity.recentHardwareTypes';
+const HARDWARE_TYPE_RECENT_LIMIT = 5;
+const PART_TYPE_PLACEHOLDER_IMAGE =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80"%3E%3Crect width="80" height="80" rx="14" fill="%23e2e8f0"/%3E%3Cpath fill="%2394a3b8" d="M24 26h32v8H24zm0 16h32v8H24zm0 16h32v8H24z"/%3E%3C/svg%3E';
+const hardwareTypeOptionRecords = new Map();
+const hardwareTypeFilterButtons = new Map();
+const hardwareTypeFilterState = {
+  category: HARDWARE_TYPE_ALL_FILTER,
+  query: '',
+};
+let hardwareTypeCategories = [];
+let hardwareTypeRecentValues = [];
+let hardwareTypeSelectListenerAttached = false;
+let hardwareTypeDialogMode = 'dialog';
 const BOLT_DRIVE_PLACEHOLDER_TEXT = 'Select drive…';
 const BOLT_HEAD_PLACEHOLDER_TEXT = 'Select head…';
 const SCREW_TYPE_PLACEHOLDER_TEXT = 'Select type…';
@@ -161,95 +186,393 @@ function getFastenerHeadImagePath(option) {
   return `${basePath}/${option.image}.svg`;
 }
 
-function createHardwareTypeOption(optionElement) {
-  if (!hardwareTypePickerList) {
-    return;
-  }
-  const value = optionElement.value;
-  if (!value) {
-    return;
-  }
-
-  const item = document.createElement('li');
-  item.className = 'bolt-drive-picker__option';
-  item.dataset.value = value;
-  item.setAttribute('role', 'option');
-  item.setAttribute('aria-selected', 'false');
-  item.tabIndex = -1;
-
-  const icon = document.createElement('span');
-  icon.className = 'bolt-drive-picker__option-icon';
-
-  const imageSrc = hardwareTypeImageMap[value];
-  if (imageSrc) {
-    const image = document.createElement('img');
-    image.className = 'bolt-drive-picker__option-icon-image';
-    if (value === 'Bolt' || value === 'Screw') {
-      image.classList.add('is-rotated-90');
-    }
-    image.src = imageSrc;
-    image.alt = '';
-    image.loading = 'lazy';
-    image.decoding = 'async';
-    icon.appendChild(image);
-  } else {
-    icon.classList.add('is-empty');
-  }
-
-  const label = document.createElement('span');
-  label.className = 'bolt-drive-picker__option-label';
-  label.textContent = optionElement.textContent.trim();
-
-  item.appendChild(icon);
-  item.appendChild(label);
-
-  hardwareTypePickerList.appendChild(item);
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-export function populateHardwareTypePicker() {
-  if (!hardwareTypePickerList) {
+function getOptionCategory(optionElement) {
+  if (!optionElement) {
+    return HARDWARE_TYPE_DEFAULT_CATEGORY;
+  }
+  const rawCategory = optionElement.dataset.cat;
+  if (typeof rawCategory === 'string' && rawCategory.trim()) {
+    return rawCategory.trim();
+  }
+  const parent = optionElement.parentElement;
+  if (parent instanceof HTMLOptGroupElement && parent.label) {
+    return parent.label.trim() || HARDWARE_TYPE_DEFAULT_CATEGORY;
+  }
+  return HARDWARE_TYPE_DEFAULT_CATEGORY;
+}
+
+function getOptionImage(optionElement) {
+  if (!optionElement) {
+    return '';
+  }
+  const rawImage = optionElement.dataset.img;
+  if (typeof rawImage === 'string' && rawImage.trim()) {
+    return rawImage.trim();
+  }
+  return hardwareTypeImageMap[optionElement.value] || '';
+}
+
+function createPartTypeCard(record, { variant = 'grid' } = {}) {
+  const card = document.createElement('button');
+  card.type = 'button';
+  card.className = 'part-type-card';
+  if (variant === 'recent') {
+    card.classList.add('part-type-card--recent');
+  }
+  card.dataset.value = record.value;
+  card.dataset.category = record.category;
+  card.dataset.label = record.normalizedLabel;
+  card.dataset.variant = variant;
+  card.dataset.hardwareTypeOption = 'true';
+  card.dataset.hasCustomImage = record.hasCustomImage ? 'true' : 'false';
+  card.setAttribute('role', 'option');
+  card.setAttribute('aria-selected', 'false');
+  card.tabIndex = -1;
+
+  const thumb = document.createElement('span');
+  thumb.className = 'part-type-card__thumb';
+
+  const image = document.createElement('img');
+  image.className = 'part-type-card__image';
+  image.alt = '';
+  image.decoding = 'async';
+  image.loading = 'lazy';
+  image.src = record.image;
+  thumb.appendChild(image);
+
+  const label = document.createElement('span');
+  label.className = 'part-type-card__label';
+  label.textContent = record.label;
+
+  card.appendChild(thumb);
+  card.appendChild(label);
+
+  return card;
+}
+
+function loadHardwareTypeRecentValues() {
+  try {
+    const stored = localStorage.getItem(HARDWARE_TYPE_RECENT_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map(value => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function saveHardwareTypeRecentValues(values) {
+  try {
+    if (!Array.isArray(values) || values.length === 0) {
+      localStorage.removeItem(HARDWARE_TYPE_RECENT_STORAGE_KEY);
+      return;
+    }
+    localStorage.setItem(HARDWARE_TYPE_RECENT_STORAGE_KEY, JSON.stringify(values));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function updateHardwareTypeRecentUi() {
+  if (!hardwareTypePickerRecentSection || !hardwareTypePickerRecent) {
     return;
   }
 
-  hardwareTypePickerList.innerHTML = '';
+  hardwareTypePickerRecent.innerHTML = '';
+  hardwareTypeOptionRecords.forEach(record => {
+    record.recentElement = null;
+  });
 
+  const sanitizedValues = hardwareTypeRecentValues.filter(value =>
+    hardwareTypeOptionRecords.has(value),
+  );
+  const limitedValues = sanitizedValues.slice(0, HARDWARE_TYPE_RECENT_LIMIT);
+  hardwareTypeRecentValues = limitedValues;
+
+  limitedValues.forEach(value => {
+    const record = hardwareTypeOptionRecords.get(value);
+    if (!record) {
+      return;
+    }
+    const recentCard = createPartTypeCard(record, { variant: 'recent' });
+    record.recentElement = recentCard;
+    hardwareTypePickerRecent.appendChild(recentCard);
+  });
+
+  const hasRecent = hardwareTypePickerRecent.children.length > 0;
+  hardwareTypePickerRecentSection.hidden = !hasRecent;
+
+  if (sanitizedValues.length !== limitedValues.length) {
+    saveHardwareTypeRecentValues(hardwareTypeRecentValues);
+  }
+}
+
+function setHardwareTypeOptionVisibility(record, isVisible) {
+  const shouldHide = !isVisible;
+  if (record.mainElement) {
+    record.mainElement.classList.toggle('is-hidden', shouldHide);
+    record.mainElement.toggleAttribute('hidden', shouldHide);
+  }
+  if (record.recentElement) {
+    record.recentElement.classList.toggle('is-hidden', shouldHide);
+    record.recentElement.toggleAttribute('hidden', shouldHide);
+  }
+}
+
+function updateHardwareTypeOptionTabState() {
+  if (!hardwareTypePicker) {
+    return;
+  }
+  const optionElements = Array.from(
+    hardwareTypePicker.querySelectorAll('[data-hardware-type-option="true"]'),
+  );
+  let firstVisible = null;
+  optionElements.forEach(optionElement => {
+    const hidden =
+      optionElement.hasAttribute('hidden') || optionElement.classList.contains('is-hidden');
+    if (!hidden && !firstVisible) {
+      firstVisible = optionElement;
+    }
+    optionElement.tabIndex = -1;
+  });
+  if (firstVisible) {
+    firstVisible.tabIndex = 0;
+  }
+}
+
+function applyHardwareTypeFilters() {
+  const categoryFilter = hardwareTypeFilterState.category.toLowerCase();
+  const queryFilter = hardwareTypeFilterState.query;
+  let visibleCount = 0;
+
+  hardwareTypeOptionRecords.forEach(record => {
+    const matchesCategory =
+      categoryFilter === HARDWARE_TYPE_ALL_FILTER.toLowerCase() ||
+      record.normalizedCategory === categoryFilter;
+    const matchesQuery = !queryFilter || record.normalizedLabel.includes(queryFilter);
+    const isVisible = matchesCategory && matchesQuery;
+
+    setHardwareTypeOptionVisibility(record, isVisible);
+    if (isVisible) {
+      visibleCount += 1;
+    }
+  });
+
+  if (hardwareTypePickerEmpty) {
+    hardwareTypePickerEmpty.hidden = visibleCount > 0;
+  }
+
+  if (hardwareTypePickerRecentSection && hardwareTypePickerRecent) {
+    const hasVisibleRecent = Array.from(hardwareTypePickerRecent.children).some(element => {
+      if (!(element instanceof HTMLElement)) {
+        return false;
+      }
+      return !element.hasAttribute('hidden') && !element.classList.contains('is-hidden');
+    });
+    hardwareTypePickerRecentSection.hidden = !hasVisibleRecent;
+  }
+
+  updateHardwareTypeOptionTabState();
+
+  return visibleCount;
+}
+
+function renderHardwareTypeFilterChips() {
+  if (!hardwareTypePickerFilters) {
+    return;
+  }
+
+  hardwareTypePickerFilters.innerHTML = '';
+  hardwareTypeFilterButtons.clear();
+
+  const categories = [HARDWARE_TYPE_ALL_FILTER, ...hardwareTypeCategories];
+  categories.forEach(category => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'part-type-picker__filter';
+    button.textContent = category;
+    button.dataset.category = category;
+    const isActive = category === hardwareTypeFilterState.category;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    hardwareTypePickerFilters.appendChild(button);
+    hardwareTypeFilterButtons.set(category.toLowerCase(), button);
+  });
+}
+
+function rememberHardwareTypeSelection(value) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed || !hardwareTypeOptionRecords.has(trimmed)) {
+    return;
+  }
+
+  const existingIndex = hardwareTypeRecentValues.indexOf(trimmed);
+  if (existingIndex !== -1) {
+    hardwareTypeRecentValues.splice(existingIndex, 1);
+  }
+  hardwareTypeRecentValues.unshift(trimmed);
+  if (hardwareTypeRecentValues.length > HARDWARE_TYPE_RECENT_LIMIT) {
+    hardwareTypeRecentValues = hardwareTypeRecentValues.slice(0, HARDWARE_TYPE_RECENT_LIMIT);
+  }
+  saveHardwareTypeRecentValues(hardwareTypeRecentValues);
+  updateHardwareTypeRecentUi();
+  applyHardwareTypeFilters();
+}
+
+function setupHardwareTypeDialogMode() {
+  if (!hardwareTypePicker) {
+    return;
+  }
+
+  hardwareTypeDialogMode = 'dialog';
+  if (hardwareTypePickerDialog && typeof hardwareTypePickerDialog.showModal === 'function') {
+    hardwareTypePicker.dataset.dialogMode = 'dialog';
+    hardwareTypePickerDialog.setAttribute('aria-modal', 'true');
+    return;
+  }
+
+  if (hardwareTypePickerFallback && hardwareTypePickerSurface) {
+    if (!hardwareTypePickerFallback.contains(hardwareTypePickerSurface)) {
+      hardwareTypePickerFallback.appendChild(hardwareTypePickerSurface);
+    }
+    hardwareTypePickerFallback.setAttribute('role', 'dialog');
+    hardwareTypePickerFallback.setAttribute('aria-modal', 'true');
+    hardwareTypePickerFallback.setAttribute('aria-labelledby', 'hardware-type-picker-title');
+    hardwareTypePickerFallback.hidden = true;
+    hardwareTypePicker.dataset.dialogMode = 'overlay';
+    hardwareTypeDialogMode = 'overlay';
+  }
+}
+
+function handleHardwareTypeSelectChangeForRecents() {
   if (!hardwareTypeSelect) {
     return;
   }
+  rememberHardwareTypeSelection(hardwareTypeSelect.value);
+}
 
-  const children = Array.from(hardwareTypeSelect.children);
-  children.forEach(child => {
-    if (!child || !(child instanceof Element)) {
-      return;
+export function getHardwareTypePickerMode() {
+  return hardwareTypeDialogMode;
+}
+
+export function setHardwareTypeFilterCategory(nextCategory) {
+  const normalized = normalizeText(nextCategory);
+  let resolvedCategory = HARDWARE_TYPE_ALL_FILTER;
+  if (normalized && normalized !== HARDWARE_TYPE_ALL_FILTER.toLowerCase()) {
+    const match = hardwareTypeCategories.find(
+      category => category.toLowerCase() === normalized,
+    );
+    if (match) {
+      resolvedCategory = match;
     }
-    const tagName = child.tagName.toLowerCase();
-    if (tagName === 'optgroup') {
-      const optionElements = Array.from(child.children).filter(
-        option => option instanceof HTMLOptionElement,
-      );
-      if (optionElements.length === 0) {
-        return;
-      }
-      const header = document.createElement('li');
-      header.className = 'bolt-drive-picker__group';
-      header.textContent = child.label;
-      header.setAttribute('role', 'presentation');
-      hardwareTypePickerList.appendChild(header);
-      optionElements.forEach(option => {
-        createHardwareTypeOption(option);
-      });
-      return;
-    }
-    if (tagName === 'option') {
-      createHardwareTypeOption(child);
-    }
+  }
+  hardwareTypeFilterState.category = resolvedCategory;
+
+  hardwareTypeFilterButtons.forEach((button, key) => {
+    const isActive = key === resolvedCategory.toLowerCase();
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
+
+  applyHardwareTypeFilters();
+}
+
+export function setHardwareTypeSearchQuery(nextQuery) {
+  hardwareTypeFilterState.query = normalizeText(nextQuery);
+  applyHardwareTypeFilters();
+}
+
+export function populateHardwareTypePicker() {
+  if (!hardwareTypePickerList || !hardwareTypeSelect) {
+    return;
+  }
+
+  hardwareTypeSelect.classList.add('visually-hidden');
+
+  hardwareTypeOptionRecords.clear();
+  hardwareTypeFilterButtons.clear();
+  hardwareTypePickerList.innerHTML = '';
+  if (hardwareTypePickerRecent) {
+    hardwareTypePickerRecent.innerHTML = '';
+  }
+  if (hardwareTypePickerFilters) {
+    hardwareTypePickerFilters.innerHTML = '';
+  }
+
+  const optionElements = Array.from(hardwareTypeSelect.querySelectorAll('option'));
+  const categorySet = new Set();
+
+  optionElements.forEach(option => {
+    if (!(option instanceof HTMLOptionElement)) {
+      return;
+    }
+    const value = option.value.trim();
+    if (!value) {
+      return;
+    }
+
+    const label = option.textContent.trim() || value;
+    const category = getOptionCategory(option);
+    const normalizedCategory = normalizeText(category);
+    const rawImage = getOptionImage(option);
+
+    const record = {
+      value,
+      label,
+      normalizedLabel: normalizeText(label),
+      category,
+      normalizedCategory,
+      image: rawImage || PART_TYPE_PLACEHOLDER_IMAGE,
+      hasCustomImage: Boolean(rawImage),
+      mainElement: null,
+      recentElement: null,
+    };
+
+    const card = createPartTypeCard(record, { variant: 'grid' });
+    record.mainElement = card;
+    hardwareTypePickerList.appendChild(card);
+    hardwareTypeOptionRecords.set(value, record);
+    categorySet.add(category);
+  });
+
+  hardwareTypeCategories = Array.from(categorySet).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' }),
+  );
+
+  hardwareTypeFilterState.category = HARDWARE_TYPE_ALL_FILTER;
+  hardwareTypeFilterState.query = '';
+  if (hardwareTypePickerSearch) {
+    hardwareTypePickerSearch.value = '';
+  }
+
+  renderHardwareTypeFilterChips();
+
+  hardwareTypeRecentValues = loadHardwareTypeRecentValues();
+  updateHardwareTypeRecentUi();
+
+  applyHardwareTypeFilters();
+  setupHardwareTypeDialogMode();
 
   if (hardwareTypePickerButton) {
     hardwareTypePickerButton.disabled = false;
     hardwareTypePickerButton.setAttribute('aria-expanded', 'false');
   }
-  hardwareTypePickerList.hidden = true;
+
+  if (!hardwareTypeSelectListenerAttached) {
+    hardwareTypeSelect.addEventListener('change', handleHardwareTypeSelectChangeForRecents);
+    hardwareTypeSelectListenerAttached = true;
+  }
 
   syncHardwareTypePicker();
 }

--- a/style.css
+++ b/style.css
@@ -1107,3 +1107,410 @@ main {
     padding-right: 1rem;
   }
 }
+
+.part-type-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.part-type-picker__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem 0.4rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--bs-border-color, rgba(148, 163, 184, 0.38));
+  background-color: var(--bs-body-bg, #ffffff);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 2.25rem;
+  max-width: 100%;
+}
+
+.part-type-picker__chip:focus-visible {
+  outline: none;
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-ring-color);
+}
+
+.part-type-picker__chip:hover {
+  background-color: rgba(148, 163, 184, 0.08);
+}
+
+.part-type-picker__chip[aria-expanded='true'] {
+  border-color: rgba(59, 130, 246, 0.35);
+  background-color: rgba(59, 130, 246, 0.12);
+}
+
+.part-type-picker__chip-thumbnail {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.part-type-picker__chip-image {
+  width: 1.75rem;
+  height: 1.75rem;
+  object-fit: contain;
+  filter: var(--form-icon-filter);
+}
+
+.part-type-picker__chip-fallback {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.32), rgba(148, 163, 184, 0.18));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.part-type-picker__chip-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.part-type-picker__dialog {
+  border: none;
+  border-radius: 1.25rem;
+  padding: 0;
+  max-width: min(640px, calc(100vw - 2rem));
+  width: min(640px, calc(100vw - 2rem));
+  box-shadow: 0 32px 56px rgba(15, 23, 42, 0.22);
+  background: transparent;
+  color: inherit;
+}
+
+.part-type-picker__dialog::backdrop {
+  background: rgba(15, 23, 42, 0.48);
+  backdrop-filter: blur(3px);
+}
+
+.part-type-picker__dialog-surface {
+  background-color: var(--bs-body-bg, #ffffff);
+  border-radius: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 720px);
+  overflow-y: auto;
+  box-shadow: 0 32px 56px rgba(15, 23, 42, 0.22);
+}
+
+.part-type-picker__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 1rem;
+}
+
+.part-type-picker__title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.part-type-picker__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(100, 116, 139, 0.95);
+}
+
+.part-type-picker__close {
+  border: none;
+  background: rgba(148, 163, 184, 0.16);
+  color: inherit;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.part-type-picker__close:hover {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.part-type-picker__close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-ring-color);
+}
+
+.part-type-picker__search-row {
+  padding: 0 1.5rem 0;
+}
+
+.part-type-picker__search {
+  width: 100%;
+  border-radius: 0.85rem;
+  border: 1px solid var(--bs-border-color, rgba(148, 163, 184, 0.38));
+  background-color: var(--bs-body-bg, #ffffff);
+  padding: 0.6rem 0.85rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.part-type-picker__search:focus {
+  outline: none;
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-ring-color);
+}
+
+.part-type-picker__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem 0.75rem;
+}
+
+.part-type-picker__filter {
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  background: rgba(148, 163, 184, 0.16);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.part-type-picker__filter:hover {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.part-type-picker__filter.is-active,
+.part-type-picker__filter[aria-pressed='true'] {
+  background: rgba(59, 130, 246, 0.24);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: var(--bs-body-color, #0f172a);
+}
+
+.part-type-picker__recent {
+  padding: 0.5rem 1.5rem 0.5rem;
+}
+
+.part-type-picker__section-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: rgba(71, 85, 105, 0.95);
+}
+
+.part-type-picker__recent-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(108px, 1fr);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.part-type-picker__grid {
+  padding: 0 1.5rem 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 1rem;
+}
+
+.part-type-picker__empty {
+  padding: 0 1.5rem;
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(100, 116, 139, 0.95);
+}
+
+.part-type-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(148, 163, 184, 0.12);
+  padding: 0.85rem 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  min-height: 7.25rem;
+  text-align: center;
+  color: inherit;
+}
+
+.part-type-card:focus-visible {
+  outline: none;
+  border-color: var(--focus-ring-border);
+  box-shadow: 0 0 0 var(--focus-outline-width) var(--focus-ring-color);
+}
+
+.part-type-card:hover {
+  border-color: rgba(59, 130, 246, 0.55);
+  transform: translateY(-2px);
+}
+
+.part-type-card.is-selected {
+  border-color: rgba(59, 130, 246, 0.75);
+  background: rgba(59, 130, 246, 0.16);
+  box-shadow: 0 0 0 0.15rem rgba(59, 130, 246, 0.18);
+}
+
+.part-type-card__thumb {
+  width: 100%;
+  height: 4.5rem;
+  border-radius: 0.85rem;
+  background: rgba(148, 163, 184, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.part-type-card__image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  filter: var(--form-icon-filter);
+}
+
+.part-type-card__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: inherit;
+  line-height: 1.25;
+}
+
+.part-type-card--recent {
+  min-width: 7rem;
+}
+
+.part-type-picker__fallback-backdrop {
+  position: fixed;
+  inset: 0;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.48);
+  backdrop-filter: blur(3px);
+  z-index: 1050;
+}
+
+.part-type-picker__fallback-backdrop[hidden] {
+  display: none;
+}
+
+body.part-type-picker-open {
+  overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .part-type-picker__dialog-surface {
+    max-height: calc(100vh - 2rem);
+  }
+  .part-type-picker__grid {
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  }
+  .part-type-picker__header {
+    padding: 1.15rem 1rem 0.85rem;
+  }
+  .part-type-picker__search-row,
+  .part-type-picker__filters,
+  .part-type-picker__recent,
+  .part-type-picker__grid,
+  .part-type-picker__empty {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+:root[data-theme='dark'] .part-type-picker__chip {
+  background-color: rgba(15, 23, 42, 0.85);
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+:root[data-theme='dark'] .part-type-picker__chip:hover {
+  background-color: rgba(148, 163, 184, 0.18);
+}
+
+:root[data-theme='dark'] .part-type-picker__chip[aria-expanded='true'] {
+  background-color: rgba(59, 130, 246, 0.22);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+:root[data-theme='dark'] .part-type-picker__chip-thumbnail {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+:root[data-theme='dark'] .part-type-picker__dialog-surface {
+  background-color: rgba(15, 23, 42, 0.98);
+  box-shadow: 0 32px 56px rgba(2, 6, 23, 0.65);
+}
+
+:root[data-theme='dark'] .part-type-picker__subtitle,
+:root[data-theme='dark'] .part-type-picker__section-title,
+:root[data-theme='dark'] .part-type-picker__empty {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+:root[data-theme='dark'] .part-type-picker__close {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+:root[data-theme='dark'] .part-type-picker__close:hover {
+  background: rgba(59, 130, 246, 0.35);
+}
+
+:root[data-theme='dark'] .part-type-picker__search {
+  background-color: rgba(15, 23, 42, 0.85);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.95);
+}
+
+:root[data-theme='dark'] .part-type-picker__filter {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(71, 85, 105, 0.3);
+}
+
+:root[data-theme='dark'] .part-type-picker__filter.is-active,
+:root[data-theme='dark'] .part-type-picker__filter[aria-pressed='true'] {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.7);
+  color: rgba(226, 232, 240, 0.95);
+}
+
+:root[data-theme='dark'] .part-type-card {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.7);
+}
+
+:root[data-theme='dark'] .part-type-card:hover {
+  border-color: rgba(96, 165, 250, 0.75);
+}
+
+:root[data-theme='dark'] .part-type-card.is-selected {
+  border-color: rgba(96, 165, 250, 0.95);
+  background: rgba(37, 99, 235, 0.32);
+}
+
+:root[data-theme='dark'] .part-type-card__thumb {
+  background: rgba(30, 41, 59, 0.85);
+}


### PR DESCRIPTION
## Summary
- ensure the hardware type select stays visible before JavaScript enhances the picker
- hide the select once the modal picker initializes so the enhanced UI continues to work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd5a183448329a258f59bcc734965