### PR TITLE
Tidy part picker styling and placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
                         />
                         <span class="part-type-picker__chip-fallback" aria-hidden="true"></span>
                       </span>
-                      <span class="part-type-picker__chip-label">Select part type…</span>
+                      <span class="part-type-picker__chip-label">&nbsp;</span>
                     </button>
                     <dialog
                       class="part-type-picker__dialog"
@@ -380,7 +380,7 @@
                           class="visually-hidden"
                           aria-labelledby="component-mount-picker-button"
                         >
-                          <option value="">Select mounting…</option>
+                          <option value="">&nbsp;</option>
                           <option value="Through-Hole">Through-Hole</option>
                           <option value="SMD">SMD</option>
                         </select>
@@ -401,7 +401,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select mounting…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>
@@ -424,7 +424,7 @@
                           class="visually-hidden"
                           aria-labelledby="resistor-value-picker-button"
                         >
-                          <option value="">Select value…</option>
+                          <option value="">&nbsp;</option>
                         </select>
                         <button
                           type="button"
@@ -444,7 +444,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select value…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>
@@ -471,7 +471,7 @@
                           class="visually-hidden"
                           aria-labelledby="capacitor-value-picker-button"
                         >
-                          <option value="">Select value…</option>
+                          <option value="">&nbsp;</option>
                         </select>
                         <button
                           type="button"
@@ -491,7 +491,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select value…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>
@@ -518,7 +518,7 @@
                           class="visually-hidden"
                           aria-labelledby="diode-value-picker-button"
                         >
-                          <option value="">Select value…</option>
+                          <option value="">&nbsp;</option>
                         </select>
                         <button
                           type="button"
@@ -538,7 +538,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select value…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>
@@ -595,7 +595,7 @@
                           />
                         </span>
                         <span class="bolt-drive-picker__current-label"
-                          >Select bearing…</span
+                          >&nbsp;</span
                         >
                       </span>
                       <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
@@ -674,7 +674,7 @@
                             class="bolt-drive-picker__current-icon is-empty"
                             aria-hidden="true"
                           ></span>
-                          <span class="bolt-drive-picker__current-label">Select size…</span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                       </button>
@@ -718,7 +718,7 @@
                               hidden
                             />
                           </span>
-                          <span class="bolt-drive-picker__current-label">Select type…</span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                       </button>
@@ -791,7 +791,7 @@
                             />
                           </span>
                           <span class="bolt-drive-picker__current-label"
-                            >Select fuse type…</span
+                            >&nbsp;</span
                           >
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
@@ -828,7 +828,7 @@
                             class="bolt-drive-picker__current-icon is-empty"
                             aria-hidden="true"
                           ></span>
-                          <span class="bolt-drive-picker__current-label">Select value…</span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                       </button>
@@ -863,7 +863,7 @@
                       >Glass &amp; Ceramic Fuse Size</label
                     >
                     <select id="glass-size-select" class="form-select">
-                      <option value="">Select size…</option>
+                      <option value="">&nbsp;</option>
                       <option value="5 × 20 mm">5 × 20 mm</option>
                       <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
                         6.3 × 32 mm (1/4″ × 1-1/4″)
@@ -907,7 +907,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select drive…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>
@@ -945,7 +945,7 @@
                                 hidden
                               />
                             </span>
-                            <span class="bolt-drive-picker__current-label">Select head…</span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
                           </span>
                           <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
                         </button>

--- a/js/data.js
+++ b/js/data.js
@@ -509,8 +509,9 @@ export const connectorCatalog = [
 // Match the 300 DPI artwork emitted by gridfinitylabels.com.
 export const pxPerMm = 300 / 25.4;
 
-export const STANDARD_PLACEHOLDER_TEXT = 'Select standard… (type to filter, Esc clears)';
-export const CONNECTOR_PLACEHOLDER_TEXT = 'Select connector series… (type to filter, Esc clears)';
+export const STANDARD_PLACEHOLDER_TEXT = '\u00a0';
+export const CONNECTOR_PLACEHOLDER_TEXT = '\u00a0';
+// Non-breaking space placeholders maintain control sizing while hiding helper text.
 
 export function findConnectorCategory(id) {
   return connectorCatalog.find(category => category.id === id);

--- a/js/forms.js
+++ b/js/forms.js
@@ -124,7 +124,9 @@ const {
   componentCategoryRadios,
 } = elements;
 
-const HARDWARE_TYPE_PLACEHOLDER_TEXT = 'Select part type…';
+const PLACEHOLDER_BLANK = '\u00a0';
+// Non-breaking space keeps custom pickers aligned without displaying placeholder copy.
+const HARDWARE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const HARDWARE_TYPE_ALL_FILTER = 'All';
 const HARDWARE_TYPE_DEFAULT_CATEGORY = 'Uncategorized';
 const HARDWARE_TYPE_RECENT_STORAGE_KEY = 'gridfinity.recentHardwareTypes';
@@ -141,31 +143,31 @@ let hardwareTypeCategories = [];
 let hardwareTypeRecentValues = [];
 let hardwareTypeSelectListenerAttached = false;
 let hardwareTypeDialogMode = 'dialog';
-const BOLT_DRIVE_PLACEHOLDER_TEXT = 'Select drive…';
-const BOLT_HEAD_PLACEHOLDER_TEXT = 'Select head…';
-const SCREW_TYPE_PLACEHOLDER_TEXT = 'Select type…';
+const BOLT_DRIVE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const BOLT_HEAD_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const SCREW_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validBoltDriveIds = new Set(boltDriveOptions.map(option => option.id));
 const validBoltHeadIds = new Set(
   boltHeadOptions.concat(screwTypeOptions).map(option => option.id),
 );
-const NUT_TYPE_PLACEHOLDER_TEXT = 'Select type…';
+const NUT_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
-const FUSE_TYPE_PLACEHOLDER_TEXT = 'Select fuse type…';
+const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const DEFAULT_FUSE_TYPE = 'Glass';
 const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
-const FUSE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const FUSE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
-const COMPONENT_MOUNT_PLACEHOLDER_TEXT = 'Select mounting…';
+const COMPONENT_MOUNT_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validComponentMounts = new Set(componentMountOptions.map(option => option.id));
-const RESISTOR_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const RESISTOR_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validResistorValues = new Set(resistorValueOptions.map(option => option.id));
-const CAPACITOR_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const CAPACITOR_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validCapacitorValues = new Set(capacitorValueOptions.map(option => option.id));
-const DIODE_VALUE_PLACEHOLDER_TEXT = 'Select value…';
+const DIODE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validDiodeValues = new Set(diodeValueOptions.map(option => option.id));
-const BEARING_TYPE_PLACEHOLDER_TEXT = 'Select bearing…';
+const BEARING_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validBearingCodes = new Set(bearingOptions.map(option => option.code));
 
 function getFastenerHeadOptions() {
@@ -1849,7 +1851,7 @@ export function populateConnectorCategories() {
   connectorCategorySelect.innerHTML = '';
   const placeholder = document.createElement('option');
   placeholder.value = '';
-  placeholder.textContent = 'Select connector category…';
+  placeholder.textContent = PLACEHOLDER_BLANK;
   placeholder.disabled = true;
   placeholder.selected = !state.connectorCategory;
   connectorCategorySelect.appendChild(placeholder);

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -14,7 +14,8 @@ const {
   threadSizePickerList,
 } = elements;
 
-const THREAD_SIZE_PLACEHOLDER_TEXT = 'Select size…';
+const THREAD_SIZE_PLACEHOLDER_TEXT = '\u00a0';
+// Non-breaking space preserves control height without visible placeholder text.
 const THREAD_SIZE_NOT_APPLICABLE_TEXT = 'Not applicable';
 
 let validThreadSizes = new Set();

--- a/style.css
+++ b/style.css
@@ -1116,19 +1116,24 @@ main {
 }
 
 .part-type-picker__chip {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.85rem 0.4rem 0.6rem;
-  border-radius: 999px;
+  gap: 0.75rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.75rem;
   border: 1px solid var(--bs-border-color, rgba(148, 163, 184, 0.38));
   background-color: var(--bs-body-bg, #ffffff);
   color: inherit;
   font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.35;
   cursor: pointer;
   transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-  min-height: 2.25rem;
+  min-height: var(--picker-control-height);
+  height: var(--picker-control-height);
+  width: 100%;
   max-width: 100%;
+  justify-content: flex-start;
 }
 
 .part-type-picker__chip:focus-visible {
@@ -1149,8 +1154,8 @@ main {
 .part-type-picker__chip-thumbnail {
   width: 2.25rem;
   height: 2.25rem;
-  border-radius: 50%;
-  background: rgba(148, 163, 184, 0.18);
+  border-radius: 0.65rem;
+  background: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1183,10 +1188,11 @@ main {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.95rem;
+  font-size: 1rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1 1 auto;
 }
 
 .part-type-picker__dialog {
@@ -1461,7 +1467,7 @@ body.part-type-picker-open {
 }
 
 :root[data-theme='dark'] .part-type-picker__chip-thumbnail {
-  background: rgba(148, 163, 184, 0.28);
+  background: none;
 }
 
 :root[data-theme='dark'] .part-type-picker__dialog-surface {


### PR DESCRIPTION
## Summary
- restyle the part type picker so it matches other form controls and removes the circular icon backdrop
- replace "Select…" placeholder copy across picker buttons and selects with blank spacers in markup and scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe87453b48329a768350d7ad0bdda