### PR TITLE
Improve hardware picker usability on mobile

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -118,6 +118,15 @@ const {
 
 let hardwareTypePickerOpen = false;
 let fuseTypePickerOpen = false;
+
+const coarsePointerMediaQuery =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(hover: none) and (pointer: coarse)')
+    : null;
+
+function isCoarsePointerDevice() {
+  return Boolean(coarsePointerMediaQuery && coarsePointerMediaQuery.matches);
+}
 let threadSizePickerOpen = false;
 let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
@@ -255,10 +264,13 @@ function openHardwareTypePicker() {
     modalRoot.setAttribute('aria-hidden', 'false');
   }
 
-  if (hardwareTypePickerSearch) {
+  if (hardwareTypePickerSearch && !isCoarsePointerDevice()) {
     hardwareTypePickerSearch.focus();
     hardwareTypePickerSearch.select();
   } else {
+    if (hardwareTypePickerSearch) {
+      hardwareTypePickerSearch.blur();
+    }
     focusHardwareTypeDefaultOption();
   }
   updateHardwareTypeTrapElements();
@@ -297,9 +309,21 @@ function closeHardwareTypePicker({ focusButton = true } = {}) {
   hardwareTypeTrapElements = [];
   hardwareTypeActiveOptionIndex = -1;
 
-  if (focusButton && hardwareTypePickerButton) {
+  if (hardwareTypePickerSearch) {
+    hardwareTypePickerSearch.blur();
+  }
+
+  const suppressFocusRestore = isCoarsePointerDevice();
+  if (suppressFocusRestore) {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      activeElement.blur();
+    }
+  }
+
+  if (!suppressFocusRestore && focusButton && hardwareTypePickerButton) {
     hardwareTypePickerButton.focus();
-  } else if (!focusButton && hardwareTypePreviouslyFocusedElement) {
+  } else if (!suppressFocusRestore && !focusButton && hardwareTypePreviouslyFocusedElement) {
     hardwareTypePreviouslyFocusedElement.focus();
   }
   hardwareTypePreviouslyFocusedElement = null;

--- a/style.css
+++ b/style.css
@@ -1317,7 +1317,12 @@ main {
 }
 
 .part-type-picker__recent {
-  padding: 0.5rem 1.5rem 0.5rem;
+  padding: 1rem 1.5rem 1.5rem;
+  margin: 0 1.5rem 1.75rem;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 1.25rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
 }
 
 .part-type-picker__section-title {
@@ -1354,16 +1359,19 @@ main {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   border-radius: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.32);
   background: rgba(148, 163, 184, 0.12);
-  padding: 0.85rem 0.75rem;
+  padding: 0.75rem;
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  min-height: 7.25rem;
   text-align: center;
   color: inherit;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  box-sizing: border-box;
 }
 
 .part-type-card:focus-visible {
@@ -1385,7 +1393,7 @@ main {
 
 .part-type-card__thumb {
   width: 100%;
-  height: 4.5rem;
+  height: min(4rem, 52%);
   border-radius: 0;
   background: transparent;
   display: flex;
@@ -1450,6 +1458,10 @@ body.part-type-picker-open {
     padding-left: 1rem;
     padding-right: 1rem;
   }
+  .part-type-picker__recent {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
 }
 
 :root[data-theme='dark'] .part-type-picker__chip {
@@ -1473,6 +1485,12 @@ body.part-type-picker-open {
 :root[data-theme='dark'] .part-type-picker__dialog-surface {
   background-color: rgba(15, 23, 42, 0.98);
   box-shadow: 0 32px 56px rgba(2, 6, 23, 0.65);
+}
+
+:root[data-theme='dark'] .part-type-picker__recent {
+  background: rgba(15, 23, 42, 0.72);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.65);
 }
 
 :root[data-theme='dark'] .part-type-picker__subtitle,


### PR DESCRIPTION
## Summary
- prevent the part picker search field from stealing focus on touch devices to avoid mobile keyboard pop ups and lingering zoom
- ensure focus is cleared when the picker closes so Safari on iOS stops zooming the page after a selection
- restyle the picker cards and “recently used” section to create visual separation and square tiles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbecbb7e508329946b1aa47c829504