### PR TITLE
Add washer type picker and validation to washer labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,6 +735,52 @@
                       class="validation-message text-danger small mt-2 d-none"
                     ></div>
                   </div>
+                  <div
+                    class="col-12 col-sm-6 thread-length-field d-none"
+                    id="washer-type-container"
+                  >
+                    <label for="washer-type-select" class="form-label fw-semibold"
+                      >Washer Type</label
+                    >
+                    <div class="bolt-drive-picker" id="washer-type-picker">
+                      <select id="washer-type-select" class="visually-hidden"></select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="washer-type-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="washer-type-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span
+                            class="bolt-drive-picker__current-icon is-empty"
+                            aria-hidden="true"
+                          >
+                            <img
+                              class="bolt-drive-picker__current-icon-image"
+                              src=""
+                              alt=""
+                              hidden
+                            />
+                          </span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                        </span>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="washer-type-picker-list"
+                        role="listbox"
+                        aria-labelledby="washer-type-picker-button"
+                        hidden
+                      ></ul>
+                    </div>
+                    <div
+                      id="washer-type-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
                   <div class="col-12 col-sm-6 thread-length-field" id="length-container">
                     <label for="length-input" class="form-label fw-semibold">Length</label>
                     <input

--- a/js/controls.js
+++ b/js/controls.js
@@ -11,11 +11,13 @@ import {
   populateResistorValues,
   populateCapacitorValues,
   populateDiodeValues,
+  populateWasherTypeOptions,
   updateCustomImageUi,
   onHardwareTypeChange,
   setBoltDriveSelection,
   setBoltHeadSelection,
   setNutTypeSelection,
+  setWasherTypeSelection,
   setBearingTypeSelection,
   setFuseTypeSelection,
   setThreadSizeSelection,
@@ -50,6 +52,7 @@ function applyStateToControls() {
     heightRadios,
     connectorCategorySelect,
     nutTypeSelect,
+    washerTypeSelect,
   } = elements;
 
   if (Array.isArray(systemTypeRadios)) {
@@ -76,6 +79,9 @@ function applyStateToControls() {
   if (nutTypeSelect) {
     nutTypeSelect.value = state.nutType || '';
   }
+  if (washerTypeSelect) {
+    washerTypeSelect.value = state.washerType || '';
+  }
   setBearingTypeSelection(state.bearingType || '', { triggerUpdate: false });
   setComponentMountSelection(state.componentMount || 'Through-Hole', { triggerUpdate: false });
   setResistorValueSelection(state.resistorValue || '', { triggerUpdate: false });
@@ -101,6 +107,7 @@ function applyStateToControls() {
   setBoltHeadSelection(state.boltHead || '', { triggerUpdate: false });
   setBoltDriveSelection(state.boltDrive || '', { triggerUpdate: false });
   setNutTypeSelection(state.nutType || '', { triggerUpdate: false });
+  setWasherTypeSelection(state.washerType || '', { triggerUpdate: false });
   if (standardToggle) {
     standardToggle.checked = state.showStandard;
   }
@@ -138,6 +145,7 @@ function init() {
   populateResistorValues();
   populateCapacitorValues();
   populateDiodeValues();
+  populateWasherTypeOptions();
   updateCustomImageUi();
   onHardwareTypeChange();
   applyStateToControls();

--- a/js/data.js
+++ b/js/data.js
@@ -283,6 +283,15 @@ export const nutTypeOptions = [
 
 export const nutTypeMap = new Map(nutTypeOptions.map(option => [option.id, option]));
 
+export const washerTypeOptions = [
+  { id: 'plain_washer', label: 'Plain Washer', image: 'plain_washer' },
+  { id: 'spring_washer', label: 'Spring Washer', image: 'spring_washer' },
+];
+
+export const washerTypeMap = new Map(
+  washerTypeOptions.map(option => [option.id, option]),
+);
+
 export const bearingOptions = [
   { code: '608ZZ', description: '8 × 22 × 7 mm, metal shields' },
   { code: '608-2RS', description: '8 × 22 × 7 mm, rubber seals' },

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -22,6 +22,12 @@ const nutTypePickerButton = document.getElementById('nut-type-picker-button');
 const nutTypePickerList = document.getElementById('nut-type-picker-list');
 const nutTypeSelect = document.getElementById('nut-type-select');
 const nutTypeMessage = document.getElementById('nut-type-message');
+const washerTypeContainer = document.getElementById('washer-type-container');
+const washerTypePicker = document.getElementById('washer-type-picker');
+const washerTypePickerButton = document.getElementById('washer-type-picker-button');
+const washerTypePickerList = document.getElementById('washer-type-picker-list');
+const washerTypeSelect = document.getElementById('washer-type-select');
+const washerTypeMessage = document.getElementById('washer-type-message');
 const fuseSelectionRow = document.getElementById('fuse-selection-row');
 const fuseTypeContainer = document.getElementById('fuse-type-container');
 const fuseTypeSelect = document.getElementById('fuse-type-select');
@@ -180,6 +186,12 @@ export const elements = {
   nutTypePickerList,
   nutTypeSelect,
   nutTypeMessage,
+  washerTypeContainer,
+  washerTypePicker,
+  washerTypePickerButton,
+  washerTypePickerList,
+  washerTypeSelect,
+  washerTypeMessage,
   fuseSelectionRow,
   fuseTypeContainer,
   fuseTypeSelect,

--- a/js/events.js
+++ b/js/events.js
@@ -17,6 +17,8 @@ import {
   syncBoltHeadPicker,
   setNutTypeSelection,
   syncNutTypePicker,
+  setWasherTypeSelection,
+  syncWasherTypePicker,
   syncHardwareTypePicker,
   setHardwareTypeFilterCategory,
   setHardwareTypeSearchQuery,
@@ -103,6 +105,10 @@ const {
   nutTypePicker,
   nutTypePickerButton,
   nutTypePickerList,
+  washerTypeSelect,
+  washerTypePicker,
+  washerTypePickerButton,
+  washerTypePickerList,
   standardSelect,
   standardToggle,
   imageToggle,
@@ -131,6 +137,7 @@ let threadSizePickerOpen = false;
 let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
+let washerTypePickerOpen = false;
 let fuseValuePickerOpen = false;
 let componentMountPickerOpen = false;
 let resistorValuePickerOpen = false;
@@ -2863,6 +2870,195 @@ function handleNutTypeListFocusOut() {
   }, 0);
 }
 
+function getWasherTypeOptionElements() {
+  if (!washerTypePickerList) {
+    return [];
+  }
+  return Array.from(washerTypePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusWasherTypeOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getWasherTypeOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openWasherTypePicker() {
+  if (!washerTypePicker || !washerTypePickerButton || !washerTypePickerList) {
+    return;
+  }
+  if (washerTypePickerButton.disabled) {
+    return;
+  }
+  if (washerTypePickerOpen) {
+    return;
+  }
+  washerTypePickerOpen = true;
+  washerTypePicker.classList.add('is-open');
+  washerTypePickerList.hidden = false;
+  washerTypePickerButton.setAttribute('aria-expanded', 'true');
+  syncWasherTypePicker({ isValid: true });
+
+  const options = getWasherTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.washerType === 'string' ? state.washerType : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusWasherTypeOption(selectedOption || options[0]);
+}
+
+function closeWasherTypePicker({ focusButton = false } = {}) {
+  if (!washerTypePicker || !washerTypePickerButton || !washerTypePickerList) {
+    return;
+  }
+  if (!washerTypePickerOpen) {
+    if (focusButton && !washerTypePickerButton.disabled) {
+      washerTypePickerButton.focus();
+    }
+    return;
+  }
+  washerTypePickerOpen = false;
+  washerTypePicker.classList.remove('is-open');
+  washerTypePickerList.hidden = true;
+  washerTypePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !washerTypePickerButton.disabled) {
+    washerTypePickerButton.focus();
+  }
+}
+
+function toggleWasherTypePicker() {
+  if (washerTypePickerOpen) {
+    closeWasherTypePicker({ focusButton: false });
+  } else {
+    openWasherTypePicker();
+  }
+}
+
+function moveWasherTypeOption(delta) {
+  const options = getWasherTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeIndex = options.findIndex(option => option === active);
+  let nextIndex = activeIndex + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  }
+  if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  focusWasherTypeOption(options[nextIndex]);
+}
+
+function handleWasherTypeButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown' || key === 'ArrowUp' || key === 'Enter' || key === ' ') {
+    event.preventDefault();
+    openWasherTypePicker();
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeWasherTypePicker({ focusButton: true });
+  }
+}
+
+function handleWasherTypeListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveWasherTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveWasherTypeOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getWasherTypeOptionElements();
+    if (options.length > 0) {
+      focusWasherTypeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getWasherTypeOptionElements();
+    if (options.length > 0) {
+      focusWasherTypeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setWasherTypeSelection(option.dataset.value || '');
+        closeWasherTypePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeWasherTypePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeWasherTypePicker();
+  }
+}
+
+function handleWasherTypeListClick(event) {
+  if (!washerTypePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !washerTypePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setWasherTypeSelection(option.dataset.value || '');
+  closeWasherTypePicker({ focusButton: true });
+}
+
+function handleWasherTypeListFocusOut() {
+  if (!washerTypePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!washerTypePickerOpen) {
+      return;
+    }
+    if (!washerTypePicker) {
+      closeWasherTypePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !washerTypePicker.contains(active)) {
+      closeWasherTypePicker();
+    }
+  }, 0);
+}
+
 function handleDocumentPointer(event) {
   const target = event.target;
   if (fuseTypePickerOpen && fuseTypePicker) {
@@ -2888,6 +3084,11 @@ function handleDocumentPointer(event) {
   if (nutTypePickerOpen && nutTypePicker) {
     if (!(target instanceof Node) || !nutTypePicker.contains(target)) {
       closeNutTypePicker();
+    }
+  }
+  if (washerTypePickerOpen && washerTypePicker) {
+    if (!(target instanceof Node) || !washerTypePicker.contains(target)) {
+      closeWasherTypePicker();
     }
   }
   if (fuseValuePickerOpen && fuseValuePicker) {
@@ -3307,6 +3508,11 @@ export function initEventHandlers() {
       setNutTypeSelection(nutTypeSelect.value);
     });
   }
+  if (washerTypeSelect) {
+    washerTypeSelect.addEventListener('change', () => {
+      setWasherTypeSelection(washerTypeSelect.value);
+    });
+  }
 
   if (boltHeadSelect) {
     boltHeadSelect.addEventListener('change', () => {
@@ -3349,6 +3555,16 @@ export function initEventHandlers() {
     nutTypePickerList.addEventListener('click', handleNutTypeListClick);
     nutTypePickerList.addEventListener('keydown', handleNutTypeListKeydown);
     nutTypePickerList.addEventListener('focusout', handleNutTypeListFocusOut);
+  }
+  if (washerTypePickerButton && washerTypePickerList) {
+    washerTypePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleWasherTypePicker();
+    });
+    washerTypePickerButton.addEventListener('keydown', handleWasherTypeButtonKeydown);
+    washerTypePickerList.addEventListener('click', handleWasherTypeListClick);
+    washerTypePickerList.addEventListener('keydown', handleWasherTypeListKeydown);
+    washerTypePickerList.addEventListener('focusout', handleWasherTypeListFocusOut);
   }
   if (
     hardwareTypePicker ||

--- a/js/forms.js
+++ b/js/forms.js
@@ -8,6 +8,7 @@ import {
   boltDriveOptions,
   screwTypeOptions,
   nutTypeOptions,
+  washerTypeOptions,
   hardwareCatalog,
   hardwareTypeImageMap,
   connectorCatalog,
@@ -53,6 +54,11 @@ const {
   nutTypePickerButton,
   nutTypePickerList,
   nutTypeSelect,
+  washerTypeContainer,
+  washerTypePicker,
+  washerTypePickerButton,
+  washerTypePickerList,
+  washerTypeSelect,
   measurementSystemContainer,
   connectorCategoryContainer,
   connectorCategorySelect,
@@ -152,6 +158,8 @@ const validBoltHeadIds = new Set(
 );
 const NUT_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
+const WASHER_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validWasherTypeIds = new Set(washerTypeOptions.map(option => option.id));
 const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const DEFAULT_FUSE_TYPE = 'Glass';
 const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
@@ -1844,6 +1852,166 @@ export function populateNutTypeOptions() {
   syncNutTypePicker({ isValid: true });
 }
 
+export function syncWasherTypePicker({ isValid = true } = {}) {
+  if (!washerTypeSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.washerType === 'string' ? state.washerType : '';
+  const sanitizedValue = validWasherTypeIds.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.washerType = sanitizedValue;
+  }
+
+  washerTypeSelect.value = sanitizedValue;
+  if (!sanitizedValue && washerTypeSelect.options.length > 0) {
+    washerTypeSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = sanitizedValue
+    ? washerTypeOptions.find(option => option.id === sanitizedValue) || null
+    : null;
+
+  if (washerTypePickerButton) {
+    const label = washerTypePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = washerTypePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = washerTypePickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = selectedOption
+        ? selectedOption.label
+        : WASHER_TYPE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption) {
+        iconImage.src = `images/washers/${selectedOption.image}.svg`;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      washerTypePickerButton.classList.remove('is-invalid');
+      washerTypePickerButton.removeAttribute('aria-invalid');
+    } else {
+      washerTypePickerButton.classList.add('is-invalid');
+      washerTypePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (washerTypePicker) {
+    washerTypePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (washerTypePickerList) {
+    const optionElements = Array.from(
+      washerTypePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setWasherTypeSelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validWasherTypeIds.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.washerType === 'string' ? state.washerType : '';
+
+  state.washerType = sanitizedValue;
+  syncWasherTypePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updatePreview();
+    updateDownloadState();
+  }
+}
+
+export function populateWasherTypeOptions() {
+  if (!washerTypeSelect) {
+    state.washerType = '';
+    return;
+  }
+
+  const previousType = typeof state.washerType === 'string' ? state.washerType : '';
+
+  washerTypeSelect.innerHTML = '';
+  if (washerTypePickerList) {
+    washerTypePickerList.innerHTML = '';
+  }
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = WASHER_TYPE_PLACEHOLDER_TEXT;
+  placeholder.disabled = true;
+  placeholder.selected = !previousType;
+  washerTypeSelect.appendChild(placeholder);
+
+  washerTypeOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    washerTypeSelect.appendChild(opt);
+
+    if (washerTypePickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      const image = document.createElement('img');
+      image.className = 'bolt-drive-picker__option-icon-image';
+      image.src = `images/washers/${option.image}.svg`;
+      image.alt = '';
+      image.loading = 'lazy';
+      image.decoding = 'async';
+      icon.appendChild(image);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      washerTypePickerList.appendChild(item);
+    }
+  });
+
+  const sanitizedValue = validWasherTypeIds.has(previousType) ? previousType : '';
+  state.washerType = sanitizedValue;
+  washerTypeSelect.value = sanitizedValue;
+  if (!sanitizedValue) {
+    placeholder.selected = true;
+  }
+
+  washerTypeSelect.disabled = false;
+  washerTypeSelect.title = 'Select washer style';
+  washerTypeSelect.setAttribute('aria-required', 'true');
+
+  if (washerTypePickerButton) {
+    washerTypePickerButton.disabled = false;
+    washerTypePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (washerTypePickerList) {
+    washerTypePickerList.hidden = true;
+  }
+
+  syncWasherTypePicker({ isValid: true });
+}
+
 export function populateConnectorCategories() {
   if (!connectorCategorySelect) {
     return;
@@ -2446,6 +2614,20 @@ export function populateStandards() {
     return;
   }
 
+  if (state.hardwareType === 'Washer') {
+    if (standardSelect) {
+      standardSelect.innerHTML = '';
+      standardSelect.disabled = true;
+      standardSelect.title = '';
+      standardSelect.value = '';
+    }
+    state.standard = '';
+    state.standardCode = '';
+    populateWasherTypeOptions();
+    updatePreview();
+    return;
+  }
+
   if (!standardSelect) {
     return;
   }
@@ -2714,6 +2896,7 @@ export function onHardwareTypeChange() {
   const showScrewFields = type === 'Screw';
   const showFastenerFields = showBoltFields || showScrewFields;
   const showNutFields = type === 'Nut';
+  const showWasherFields = type === 'Washer';
 
   if (lengthContainer) {
     lengthContainer.style.display = requiresThreadDetails ? '' : 'none';
@@ -2863,7 +3046,8 @@ export function onHardwareTypeChange() {
         !showCustomFields &&
         !showBearingFields &&
         !showComponentFields &&
-        !showNutFields,
+        !showNutFields &&
+        !showWasherFields,
     );
     threadLengthRow.style.display = hideThreadLength ? 'none' : '';
   }
@@ -3059,6 +3243,34 @@ export function onHardwareTypeChange() {
   if (!showNutFields) {
     state.nutType = '';
     syncNutTypePicker({ isValid: true });
+  }
+  if (washerTypeContainer) {
+    const hidden = !showWasherFields;
+    washerTypeContainer.classList.toggle('d-none', hidden);
+    washerTypeContainer.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+  }
+  if (washerTypeSelect) {
+    washerTypeSelect.disabled = !showWasherFields;
+    if (!showWasherFields) {
+      washerTypeSelect.removeAttribute('aria-required');
+      washerTypeSelect.title = '';
+    }
+  }
+  if (washerTypePickerButton) {
+    washerTypePickerButton.disabled = !showWasherFields;
+    if (!showWasherFields) {
+      washerTypePickerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+  if (washerTypePickerList) {
+    washerTypePickerList.hidden = true;
+  }
+  if (washerTypePicker) {
+    washerTypePicker.classList.toggle('is-disabled', !showWasherFields);
+  }
+  if (!showWasherFields) {
+    state.washerType = '';
+    syncWasherTypePicker({ isValid: true });
   }
   if (notesInput) {
     if (showConnectorFields) {

--- a/js/render.js
+++ b/js/render.js
@@ -9,6 +9,7 @@ import {
   syncResistorValuePicker,
   syncCapacitorValuePicker,
   syncBearingTypePicker,
+  syncWasherTypePicker,
 } from './forms.js';
 import {
   pxPerMm,
@@ -18,6 +19,7 @@ import {
   boltHeadMap,
   boltDriveMap,
   nutTypeMap,
+  washerTypeMap,
   screwTypeMap,
   electricalComponentTypes,
   componentImageMap,
@@ -45,6 +47,9 @@ const {
   nutTypeSelect,
   nutTypeContainer,
   nutTypeMessage,
+  washerTypeSelect,
+  washerTypeContainer,
+  washerTypeMessage,
   fuseValueSelect,
   fuseValueContainer,
   connectorCategorySelect,
@@ -906,6 +911,11 @@ export function isLabelReady() {
     const detailsSatisfied = !detailsRequired || (hasHead && hasDrive);
     return Boolean(hasThread && hasLength && detailsSatisfied);
   }
+  if (state.hardwareType === 'Washer') {
+    const hasThread = Boolean(state.threadSize);
+    const hasType = Boolean(state.washerType);
+    return Boolean(hasThread && hasType);
+  }
   if (state.hardwareType === 'Nut') {
     const hasThread = Boolean(state.threadSize);
     const detailsRequired = Boolean(state.showImage || state.showStandard);
@@ -1038,6 +1048,28 @@ function applyValidationFeedback(disabled) {
     });
     syncBoltHeadPicker({ isValid: true });
     syncBoltDrivePicker({ isValid: true });
+  }
+
+  if (hardwareType === 'Washer') {
+    const typeValid = Boolean(state.washerType);
+    updateInputFieldState({
+      input: washerTypeSelect,
+      container: washerTypeContainer,
+      messageElement: washerTypeMessage,
+      valid: typeValid,
+    });
+    syncWasherTypePicker({ isValid: typeValid });
+    if (!typeValid) {
+      requirements.push('choose a washer type');
+    }
+  } else {
+    updateInputFieldState({
+      input: washerTypeSelect,
+      container: washerTypeContainer,
+      messageElement: washerTypeMessage,
+      valid: true,
+    });
+    syncWasherTypePicker({ isValid: true });
   }
 
   if (hardwareType === 'Nut' && (state.showImage || state.showStandard)) {
@@ -1420,6 +1452,23 @@ function resolveHardwareImageInfo() {
       alt: 'Threaded heat insert reference illustration',
     };
   }
+  if (state.hardwareType === 'Washer') {
+    const typeId = (state.washerType || '').trim();
+    const typeEntry = washerTypeMap.get(typeId);
+    if (!typeEntry) {
+      return null;
+    }
+    const image = (typeEntry.image || '').trim();
+    if (!image) {
+      return null;
+    }
+    const label = typeEntry.label || '';
+    return {
+      type: 'photo',
+      src: `images/washers/${image}.svg`,
+      alt: label ? `${label} reference illustration` : 'Washer reference illustration',
+    };
+  }
   if (state.hardwareType === 'Nut') {
     const typeId = (state.nutType || '').trim();
     const typeEntry = nutTypeMap.get(typeId);
@@ -1633,6 +1682,16 @@ function buildTextLines() {
     const showType = Boolean(state.showStandard && typeLabel);
     const line2 = showType ? typeLabel : notes;
     const line3 = showType ? notes : '';
+    return { line1, line2, line3 };
+  }
+
+  if (state.hardwareType === 'Washer') {
+    const line1 = state.threadSize || 'Washer';
+    const typeEntry = washerTypeMap.get((state.washerType || '').trim());
+    const typeLabel = typeEntry ? typeEntry.label : '';
+    const notes = state.notes || '';
+    const line2 = typeLabel;
+    const line3 = notes;
     return { line1, line2, line3 };
   }
 

--- a/js/state.js
+++ b/js/state.js
@@ -13,6 +13,7 @@ export const state = {
   boltHead: '',
   boltDrive: '',
   nutType: '',
+  washerType: '',
   showStandard: true,
   showImage: true,
   showQr: false,


### PR DESCRIPTION
## Summary
- add a washer type picker alongside thread size for washers and populate plain/spring washer options
- extend application state, control initialization, and event handlers to support selecting washer types and validating the requirement
- update rendering logic so washer previews and text require both thread size and washer type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc42fcd9e083299e3673569adb5929