### PR TITLE
Require nut thread size and type selections for label generation

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -10,6 +10,7 @@ import {
   syncCapacitorValuePicker,
   syncBearingTypePicker,
   syncWasherTypePicker,
+  syncNutTypePicker,
 } from './forms.js';
 import {
   pxPerMm,
@@ -918,10 +919,8 @@ export function isLabelReady() {
   }
   if (state.hardwareType === 'Nut') {
     const hasThread = Boolean(state.threadSize);
-    const detailsRequired = Boolean(state.showImage || state.showStandard);
     const hasType = Boolean(state.nutType);
-    const detailsSatisfied = !detailsRequired || hasType;
-    return Boolean(hasThread && detailsSatisfied);
+    return Boolean(hasThread && hasType);
   }
   if (state.hardwareType === 'Threaded Heat Insert') {
     return Boolean(state.threadSize && state.length);
@@ -1072,7 +1071,7 @@ function applyValidationFeedback(disabled) {
     syncWasherTypePicker({ isValid: true });
   }
 
-  if (hardwareType === 'Nut' && (state.showImage || state.showStandard)) {
+  if (hardwareType === 'Nut') {
     const typeValid = Boolean(state.nutType);
     updateInputFieldState({
       input: nutTypeSelect,
@@ -1080,6 +1079,7 @@ function applyValidationFeedback(disabled) {
       messageElement: nutTypeMessage,
       valid: typeValid,
     });
+    syncNutTypePicker({ isValid: typeValid });
     if (!typeValid) {
       requirements.push('choose a nut type');
     }
@@ -1090,6 +1090,7 @@ function applyValidationFeedback(disabled) {
       messageElement: nutTypeMessage,
       valid: true,
     });
+    syncNutTypePicker({ isValid: true });
   }
 
   if (hardwareType === 'Connector') {


### PR DESCRIPTION
## Summary
- require nut thread size and type selections before marking nut labels ready
- keep the nut type picker validation in sync regardless of detail toggle state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc4923a16883299c4dcf41358da041