### PR TITLE
Require fuse selections and adjust mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
                   </div>
                 </div>
                 <div id="fuse-selection-row" class="row g-3 d-none">
-                  <div class="col-12 col-sm-6" id="fuse-type-container">
+                  <div class="col-6" id="fuse-type-container">
                     <label
                       for="fuse-type-select"
                       id="fuse-type-label"
@@ -850,8 +850,12 @@
                         hidden
                       ></ul>
                     </div>
+                    <div
+                      id="fuse-type-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
                   </div>
-                  <div class="col-12 col-sm-6" id="fuse-value-container">
+                  <div class="col-6" id="fuse-value-container">
                     <label for="fuse-value-select" class="form-label fw-semibold"
                       >Fuse Value (amps)</label
                     >
@@ -1236,12 +1240,6 @@
           </div>
         </div>
       </section>
-      <div
-        id="form-status-message"
-        class="alert alert-warning d-none mt-4"
-        role="status"
-        aria-live="polite"
-      ></div>
       <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
         <button
           id="download-button"
@@ -1255,17 +1253,6 @@
           <span>Download</span>
         </button>
         <button
-          id="share-button"
-          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
-          type="button"
-          disabled
-          aria-label="Share a link to this label"
-          title="Share a link to this label"
-        >
-          <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
-          <span>Share</span>
-        </button>
-        <button
           id="print-button"
           class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
           type="button"
@@ -1275,6 +1262,17 @@
         >
           <i class="fa-solid fa-print me-2" aria-hidden="true"></i>
           <span>Print</span>
+        </button>
+        <button
+          id="share-button"
+          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+          type="button"
+          disabled
+          aria-label="Share a link to this label"
+          title="Share a link to this label"
+        >
+          <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
+          <span>Share</span>
         </button>
       </div>
     </main>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -35,6 +35,7 @@ const fuseTypePicker = document.getElementById('fuse-type-picker');
 const fuseTypePickerButton = document.getElementById('fuse-type-picker-button');
 const fuseTypePickerList = document.getElementById('fuse-type-picker-list');
 const fuseValueContainer = document.getElementById('fuse-value-container');
+const fuseTypeMessage = document.getElementById('fuse-type-message');
 const glassOptionsContainer = document.getElementById('glass-options-container');
 const fuseValueSelect = document.getElementById('fuse-value-select');
 const fuseValuePicker = document.getElementById('fuse-value-picker');
@@ -164,7 +165,6 @@ const componentCategoryRadios = Array.from(
 );
 const componentCategoryMessage = document.getElementById('component-category-message');
 const componentMountMessage = document.getElementById('component-mount-message');
-const formStatusMessage = document.getElementById('form-status-message');
 
 export const elements = {
   themeToggleButton,
@@ -198,6 +198,7 @@ export const elements = {
   fuseTypePicker,
   fuseTypePickerButton,
   fuseTypePickerList,
+  fuseTypeMessage,
   fuseValueContainer,
   glassOptionsContainer,
   fuseValueSelect,
@@ -314,5 +315,4 @@ export const elements = {
   componentCategoryRadios,
   componentCategoryMessage,
   componentMountMessage,
-  formStatusMessage,
 };

--- a/js/render.js
+++ b/js/render.js
@@ -4,6 +4,7 @@ import {
   syncBoltDrivePicker,
   syncBoltHeadPicker,
   syncThreadSizePicker,
+  syncFuseTypePicker,
   syncFuseValuePicker,
   syncComponentMountPicker,
   syncResistorValuePicker,
@@ -51,6 +52,9 @@ const {
   washerTypeSelect,
   washerTypeContainer,
   washerTypeMessage,
+  fuseTypeSelect,
+  fuseTypeContainer,
+  fuseTypeMessage,
   fuseValueSelect,
   fuseValueContainer,
   connectorCategorySelect,
@@ -86,7 +90,6 @@ const {
   threadSizeMessage,
   lengthMessage,
   fuseValueMessage,
-  formStatusMessage,
 } = elements;
 
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
@@ -867,20 +870,9 @@ function updateRadioGroupFeedback({ radios, container, messageElement, valid, me
   setMessageVisibility(messageElement, normalized, shouldShow);
 }
 
-function formatRequirementSummary(requirements) {
-  if (!Array.isArray(requirements) || requirements.length === 0) {
-    return '';
-  }
-  if (requirements.length === 1) {
-    return requirements[0];
-  }
-  const allButLast = requirements.slice(0, -1);
-  const last = requirements[requirements.length - 1];
-  return `${allButLast.join(', ')} and ${last}`;
-}
 export function isLabelReady() {
   if (state.hardwareType === 'Fuse') {
-    return Boolean(state.fuseValue);
+    return Boolean(state.fuseType && state.fuseValue);
   }
   if (state.hardwareType === 'Connector') {
     return Boolean(state.connectorCategory);
@@ -928,8 +920,7 @@ export function isLabelReady() {
   return Boolean(state.threadSize);
 }
 
-function applyValidationFeedback(disabled) {
-  const requirements = [];
+function applyValidationFeedback() {
   const hardwareType = state.hardwareType;
   const requiresThread =
     hardwareType === 'Bolt' ||
@@ -947,9 +938,6 @@ function applyValidationFeedback(disabled) {
       valid,
     });
     syncThreadSizePicker({ isValid: valid });
-    if (!valid) {
-      requirements.push('select a size');
-    }
   } else {
     updateInputFieldState({
       input: threadSizeSelect,
@@ -972,9 +960,6 @@ function applyValidationFeedback(disabled) {
       messageElement: lengthMessage,
       valid,
     });
-    if (!valid) {
-      requirements.push('add a length');
-    }
   } else {
     updateInputFieldState({
       input: lengthInput,
@@ -985,18 +970,31 @@ function applyValidationFeedback(disabled) {
   }
 
   if (hardwareType === 'Fuse') {
-    const valid = Boolean(state.fuseValue);
+    const typeValid = Boolean(state.fuseType);
+    updateInputFieldState({
+      input: fuseTypeSelect,
+      container: fuseTypeContainer,
+      messageElement: fuseTypeMessage,
+      valid: typeValid,
+    });
+    syncFuseTypePicker({ isValid: typeValid });
+    const valueValid = Boolean(state.fuseValue);
     updateInputFieldState({
       input: fuseValueSelect,
       container: fuseValueContainer,
       messageElement: fuseValueMessage,
-      valid,
+      valid: valueValid,
     });
-    syncFuseValuePicker({ isValid: valid });
-    if (!valid) {
-      requirements.push('choose a fuse value');
-    }
+    syncFuseValuePicker({ isValid: valueValid });
   } else {
+    updateInputFieldState({
+      input: fuseTypeSelect,
+      container: fuseTypeContainer,
+      messageElement: fuseTypeMessage,
+      valid: true,
+    });
+    syncFuseTypePicker({ isValid: true });
+
     updateInputFieldState({
       input: fuseValueSelect,
       container: fuseValueContainer,
@@ -1026,12 +1024,6 @@ function applyValidationFeedback(disabled) {
     });
     syncBoltHeadPicker({ isValid: headValid });
     syncBoltDrivePicker({ isValid: driveValid });
-    if (!headValid) {
-      requirements.push(hardwareType === 'Screw' ? 'choose a screw type' : 'select a head style');
-    }
-    if (!driveValid) {
-      requirements.push('select a drive style');
-    }
   } else {
     updateInputFieldState({
       input: boltHeadSelect,
@@ -1058,9 +1050,6 @@ function applyValidationFeedback(disabled) {
       valid: typeValid,
     });
     syncWasherTypePicker({ isValid: typeValid });
-    if (!typeValid) {
-      requirements.push('choose a washer type');
-    }
   } else {
     updateInputFieldState({
       input: washerTypeSelect,
@@ -1080,9 +1069,6 @@ function applyValidationFeedback(disabled) {
       valid: typeValid,
     });
     syncNutTypePicker({ isValid: typeValid });
-    if (!typeValid) {
-      requirements.push('choose a nut type');
-    }
   } else {
     updateInputFieldState({
       input: nutTypeSelect,
@@ -1107,9 +1093,6 @@ function applyValidationFeedback(disabled) {
       messageElement: connectorNotesMessage,
       valid: true,
     });
-    if (!categoryValid) {
-      requirements.push('choose a connector category');
-    }
   } else {
     updateInputFieldState({
       input: connectorCategorySelect,
@@ -1134,9 +1117,6 @@ function applyValidationFeedback(disabled) {
       valid,
     });
     syncBearingTypePicker({ isValid: valid });
-    if (!valid) {
-      requirements.push('select a bearing');
-    }
   } else {
     updateInputFieldState({
       input: bearingTypeSelect,
@@ -1163,9 +1143,6 @@ function applyValidationFeedback(disabled) {
       message: mountValid ? '' : 'Choose a mounting style',
     });
     syncComponentMountPicker({ isValid: mountValid });
-    if (!mountValid) {
-      requirements.push('choose a mounting style');
-    }
 
     const category = (state.componentCategory || state.hardwareType || '').trim();
     const requiresResistorValue = category === 'Resistor';
@@ -1188,12 +1165,6 @@ function applyValidationFeedback(disabled) {
     });
     syncResistorValuePicker({ isValid: resistorValid });
     syncCapacitorValuePicker({ isValid: capacitorValid });
-    if (requiresResistorValue && !resistorValid) {
-      requirements.push('select a resistor value');
-    }
-    if (requiresCapacitorValue && !capacitorValid) {
-      requirements.push('select a capacitor value');
-    }
   } else {
     updateRadioGroupFeedback({
       radios: componentCategoryRadios,
@@ -1236,9 +1207,6 @@ function applyValidationFeedback(disabled) {
       messageElement: customLine1Message,
       valid,
     });
-    if (!valid) {
-      requirements.push('add a custom label title');
-    }
   } else {
     updateInputFieldState({
       input: customLine1Input,
@@ -1248,19 +1216,6 @@ function applyValidationFeedback(disabled) {
     });
   }
 
-  if (formStatusMessage) {
-    if (disabled) {
-      const summary =
-        requirements.length > 0
-          ? formatRequirementSummary(requirements)
-          : 'complete the required fields';
-      formStatusMessage.textContent = `To enable Download and Print, ${summary}.`;
-      formStatusMessage.classList.remove('d-none');
-    } else {
-      formStatusMessage.textContent = '';
-      formStatusMessage.classList.add('d-none');
-    }
-  }
 }
 
 export function updateDownloadState() {
@@ -1290,7 +1245,7 @@ export function updateDownloadState() {
       ? 'Complete the label details to enable sharing.'
       : label;
   }
-  applyValidationFeedback(disabled);
+  applyValidationFeedback();
 }
 
 export function updateQrContentVisibility(options = {}) {

--- a/style.css
+++ b/style.css
@@ -199,6 +199,29 @@ main {
   gap: 0.2rem;
 }
 
+@media (max-width: 575.98px) {
+  #fuse-selection-row {
+    --bs-gutter-x: 0.75rem;
+  }
+
+  #fuse-selection-row > [class*='col-'] {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .actions {
+    flex-wrap: nowrap !important;
+    gap: 0.75rem;
+  }
+
+  .actions .btn {
+    flex: 1 1 0;
+    min-width: 0;
+    padding-inline: 0.75rem;
+    font-size: 0.95rem;
+  }
+}
+
 .fuse-type-option__title {
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- require both fuse type and value before enabling label actions and remove the warning banner
- add validation feedback for the fuse type picker and keep the action buttons disabled until the label is ready
- tweak the fuse section and action buttons layout so mobile screens show controls side by side

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc55cecf2083298e9f1611b03e38ce