### PR TITLE
Improve disabled styling and alignment for label action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1243,35 +1243,35 @@
       <div class="actions d-flex flex-wrap justify-content-center gap-3 mt-4">
         <button
           id="download-button"
-          class="btn btn-primary btn-lg px-4 d-inline-flex align-items-center"
+          class="btn btn-primary btn-lg px-4 d-inline-flex align-items-center justify-content-center gap-2"
           type="button"
           disabled
           aria-label="Download label as a PNG image"
           title="Download label as a PNG image"
         >
-          <i class="fa-solid fa-download me-2" aria-hidden="true"></i>
+          <i class="fa-solid fa-download" aria-hidden="true"></i>
           <span>Download</span>
         </button>
         <button
           id="print-button"
-          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center justify-content-center gap-2"
           type="button"
           disabled
           aria-label="Open a print-ready preview of the label"
           title="Open a print-ready preview of the label"
         >
-          <i class="fa-solid fa-print me-2" aria-hidden="true"></i>
+          <i class="fa-solid fa-print" aria-hidden="true"></i>
           <span>Print</span>
         </button>
         <button
           id="share-button"
-          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center"
+          class="btn btn-outline-primary btn-lg px-4 d-inline-flex align-items-center justify-content-center gap-2"
           type="button"
           disabled
           aria-label="Share a link to this label"
           title="Share a link to this label"
         >
-          <i class="fa-solid fa-share-nodes me-2" aria-hidden="true"></i>
+          <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
           <span>Share</span>
         </button>
       </div>

--- a/style.css
+++ b/style.css
@@ -199,6 +199,29 @@ main {
   gap: 0.2rem;
 }
 
+.actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.actions .btn:disabled,
+.actions .btn.disabled {
+  color: var(--bs-secondary-color);
+  background-color: var(--bs-tertiary-bg);
+  border-color: var(--bs-border-color);
+  box-shadow: none;
+}
+
+.actions .btn.btn-primary:disabled,
+.actions .btn.btn-primary.disabled,
+.actions .btn.btn-outline-primary:disabled,
+.actions .btn.btn-outline-primary.disabled {
+  color: var(--bs-secondary-color);
+}
+
 @media (max-width: 575.98px) {
   #fuse-selection-row {
     --bs-gutter-x: 0.75rem;


### PR DESCRIPTION
## Summary
- center the icons and text within the label action buttons for consistent alignment
- add shared button styles so disabled download, print, and share actions render with a neutral grey treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc64c753fc8329bbb6cf10262fa0c4