### PR TITLE
Show Font Awesome glyph previews in icon picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,27 +297,94 @@
                   </div>
                 </div>
                 <div id="custom-fields" class="d-none">
-                  <label for="custom-image-input" class="form-label d-block fw-semibold"
-                    >Custom Image</label
-                  >
-                  <input
-                    type="file"
-                    class="form-control"
-                    id="custom-image-input"
-                    accept="image/*"
-                  />
-                  <div class="form-text">
-                    Square images work best. PNG, JPG and SVG files are supported.
+                  <div class="mb-3">
+                    <span class="form-label d-block fw-semibold">Custom Graphic</span>
+                    <div
+                      class="btn-group"
+                      role="group"
+                      aria-label="Select custom graphic source"
+                    >
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="custom-graphic-source"
+                        id="custom-graphic-source-image"
+                        value="image"
+                        checked
+                      />
+                      <label class="btn btn-outline-secondary btn-sm" for="custom-graphic-source-image">
+                        <i class="fa-solid fa-image me-1" aria-hidden="true"></i>
+                        Upload image
+                      </label>
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="custom-graphic-source"
+                        id="custom-graphic-source-icon"
+                        value="icon"
+                      />
+                      <label class="btn btn-outline-secondary btn-sm" for="custom-graphic-source-icon">
+                        <i class="fa-solid fa-icons me-1" aria-hidden="true"></i>
+                        Font Awesome icon
+                      </label>
+                    </div>
                   </div>
-                  <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                  <div id="custom-image-fields">
+                    <label for="custom-image-input" class="form-label fw-semibold"
+                      >Upload image</label
+                    >
+                    <input
+                      type="file"
+                      class="form-control"
+                      id="custom-image-input"
+                      accept="image/*"
+                    />
+                    <div class="form-text">
+                      Square images work best. PNG, JPG and SVG files are supported.
+                    </div>
+                  </div>
+                  <div id="custom-icon-fields" class="d-none">
+                    <label for="custom-icon-style" class="form-label fw-semibold">Icon style</label>
+                    <select class="form-select" id="custom-icon-style">
+                      <option value="solid" selected>Solid</option>
+                      <option value="regular">Regular</option>
+                      <option value="brands">Brands</option>
+                    </select>
+                    <div class="mt-3">
+                      <label for="custom-icon-search" class="form-label fw-semibold">Search icons</label>
+                      <input
+                        type="search"
+                        class="form-control"
+                        id="custom-icon-search"
+                        placeholder="Search by name or keyword"
+                        aria-describedby="custom-icon-help custom-icon-status"
+                      />
+                      <div class="form-text" id="custom-icon-help">
+                        Browse the complete Font Awesome Free collection. Results update as you type.
+                      </div>
+                    </div>
+                    <select
+                      class="form-select mt-3"
+                      id="custom-icon-select"
+                      size="8"
+                      aria-describedby="custom-icon-status"
+                    ></select>
+                    <div class="form-text mt-2" id="custom-icon-status" aria-live="polite"></div>
+                  </div>
+                  <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
                     <button
                       type="button"
                       class="btn btn-outline-secondary btn-sm"
                       id="custom-image-clear"
                       disabled
                     >
-                      Remove image
+                      Clear selection
                     </button>
+                    <span
+                      id="custom-icon-preview"
+                      class="custom-icon-preview d-none"
+                      aria-hidden="true"
+                    ></span>
                     <span id="custom-image-name" class="text-muted small d-none"></span>
                   </div>
                   <div class="mt-3" id="custom-line1-field">

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -84,9 +84,19 @@ const bearingTypePickerList = document.getElementById('bearing-type-picker-list'
 const bearingTypeSelect = document.getElementById('bearing-type-select');
 const bearingTypeMessage = document.getElementById('bearing-type-message');
 const customFieldsContainer = document.getElementById('custom-fields');
+const customGraphicSourceRadios = Array.from(
+  document.querySelectorAll('input[name="custom-graphic-source"]'),
+);
+const customImageFields = document.getElementById('custom-image-fields');
 const customImageInput = document.getElementById('custom-image-input');
 const customImageClearButton = document.getElementById('custom-image-clear');
 const customImageNameDisplay = document.getElementById('custom-image-name');
+const customIconFields = document.getElementById('custom-icon-fields');
+const customIconStyleSelect = document.getElementById('custom-icon-style');
+const customIconSearchInput = document.getElementById('custom-icon-search');
+const customIconSelect = document.getElementById('custom-icon-select');
+const customIconStatus = document.getElementById('custom-icon-status');
+const customIconPreview = document.getElementById('custom-icon-preview');
 const customLine1Input = document.getElementById('custom-line1-input');
 const customLine2Input = document.getElementById('custom-line2-input');
 const customLine1Field = document.getElementById('custom-line1-field');
@@ -248,9 +258,17 @@ export const elements = {
   bearingTypeSelect,
   bearingTypeMessage,
   customFieldsContainer,
+  customGraphicSourceRadios,
+  customImageFields,
   customImageInput,
   customImageClearButton,
   customImageNameDisplay,
+  customIconFields,
+  customIconStyleSelect,
+  customIconSearchInput,
+  customIconSelect,
+  customIconStatus,
+  customIconPreview,
   customLine1Input,
   customLine2Input,
   customLine1Field,

--- a/js/events.js
+++ b/js/events.js
@@ -7,6 +7,10 @@ import {
   updateConnectorCategoryUi,
   handleCustomImageFile,
   clearCustomImage,
+  setCustomGraphicSource,
+  setCustomIconStyle,
+  setCustomIconSelection,
+  refreshCustomIconOptions,
   handleStandardSelectKeydown,
   clearStandardFilter,
   setThreadSizeSelection,
@@ -89,6 +93,10 @@ const {
   glassSizeSelect,
   lengthInput,
   notesInput,
+  customGraphicSourceRadios,
+  customIconStyleSelect,
+  customIconSearchInput,
+  customIconSelect,
   customLine1Input,
   customLine2Input,
   customImageInput,
@@ -3468,6 +3476,58 @@ export function initEventHandlers() {
     customLine2Input.addEventListener('input', () => {
       state.customLine2 = customLine2Input.value;
       updatePreview();
+    });
+  }
+
+  if (Array.isArray(customGraphicSourceRadios)) {
+    customGraphicSourceRadios.forEach(radio => {
+      if (!radio) {
+        return;
+      }
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          setCustomGraphicSource(radio.value);
+        }
+      });
+    });
+  }
+
+  if (customIconStyleSelect) {
+    customIconStyleSelect.addEventListener('change', () => {
+      setCustomIconStyle(customIconStyleSelect.value);
+    });
+  }
+
+  if (customIconSearchInput) {
+    let iconSearchTimeoutId = 0;
+    const scheduleIconSearch = () => {
+      if (typeof window !== 'undefined' && typeof window.clearTimeout === 'function' && typeof window.setTimeout === 'function') {
+        if (iconSearchTimeoutId) {
+          window.clearTimeout(iconSearchTimeoutId);
+        }
+        iconSearchTimeoutId = window.setTimeout(() => {
+          refreshCustomIconOptions({ preserveSelection: true });
+        }, 120);
+      } else {
+        refreshCustomIconOptions({ preserveSelection: true });
+      }
+    };
+    customIconSearchInput.addEventListener('input', scheduleIconSearch);
+  }
+
+  if (customIconSelect) {
+    customIconSelect.addEventListener('change', () => {
+      const selected = customIconSelect.selectedOptions[0];
+      if (!selected) {
+        setCustomIconSelection({ name: '', unicode: '', label: '', style: customIconStyleSelect ? customIconStyleSelect.value : undefined });
+        return;
+      }
+      setCustomIconSelection({
+        name: selected.value,
+        unicode: selected.dataset.unicode || '',
+        label: selected.dataset.label || selected.textContent || selected.value,
+        style: selected.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+      });
     });
   }
 

--- a/js/fontawesome-icons.js
+++ b/js/fontawesome-icons.js
@@ -1,0 +1,156 @@
+const ICONS_ENDPOINT =
+  'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/metadata/icons.json';
+
+const VALID_STYLES = ['solid', 'regular', 'brands'];
+
+let metadataPromise = null;
+let metadataCache = null;
+const iconListCache = new Map();
+
+function normalizeStyle(style) {
+  if (typeof style !== 'string') {
+    return 'solid';
+  }
+  const trimmed = style.trim().toLowerCase();
+  return VALID_STYLES.includes(trimmed) ? trimmed : 'solid';
+}
+
+async function loadMetadata() {
+  if (metadataCache) {
+    return metadataCache;
+  }
+  if (!metadataPromise) {
+    metadataPromise = fetch(ICONS_ENDPOINT)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to load Font Awesome metadata: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then(data => {
+        metadataCache = data && typeof data === 'object' ? data : {};
+        return metadataCache;
+      })
+      .catch(error => {
+        metadataPromise = null;
+        throw error;
+      });
+  }
+  return metadataPromise;
+}
+
+function buildIconCollection(style, metadata) {
+  const icons = [];
+  const index = new Map();
+  const entries = Object.entries(metadata || {});
+  entries.forEach(([name, details]) => {
+    if (!details || typeof details !== 'object') {
+      return;
+    }
+    const freeStyles = Array.isArray(details.free) ? details.free : [];
+    if (!freeStyles.includes(style)) {
+      return;
+    }
+    const unicode = typeof details.unicode === 'string' ? details.unicode.trim() : '';
+    if (!unicode) {
+      return;
+    }
+    const label =
+      typeof details.label === 'string' && details.label.trim().length > 0
+        ? details.label.trim()
+        : name;
+    const searchTerms = Array.isArray(details.search && details.search.terms)
+      ? details.search.terms
+      : [];
+    const aliasNames = Array.isArray(details.aliases && details.aliases.names)
+      ? details.aliases.names
+      : [];
+    const keywords = searchTerms.concat(aliasNames).filter(term => typeof term === 'string');
+    const iconRecord = {
+      name,
+      label,
+      unicode,
+      keywords,
+      style,
+    };
+    icons.push(iconRecord);
+    index.set(name, iconRecord);
+  });
+  icons.sort((a, b) => {
+    const labelCompare = a.label.localeCompare(b.label, undefined, {
+      sensitivity: 'base',
+    });
+    if (labelCompare !== 0) {
+      return labelCompare;
+    }
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+  return { icons, index };
+}
+
+async function ensureCollection(style) {
+  const normalized = normalizeStyle(style);
+  if (iconListCache.has(normalized)) {
+    return iconListCache.get(normalized);
+  }
+  const metadata = await loadMetadata();
+  const collection = buildIconCollection(normalized, metadata);
+  iconListCache.set(normalized, collection);
+  return collection;
+}
+
+export function getValidIconStyles() {
+  return [...VALID_STYLES];
+}
+
+export async function loadIconsForStyle(style) {
+  return ensureCollection(style);
+}
+
+export async function findIcon(style, name) {
+  const collection = await ensureCollection(style);
+  if (!name) {
+    return null;
+  }
+  const normalizedName = String(name).trim();
+  if (!normalizedName) {
+    return null;
+  }
+  return collection.index.get(normalizedName) || null;
+}
+
+export function filterIcons(icons, query) {
+  if (!Array.isArray(icons)) {
+    return [];
+  }
+  const normalizedQuery = typeof query === 'string' ? query.trim().toLowerCase() : '';
+  if (!normalizedQuery) {
+    return icons;
+  }
+  return icons.filter(icon => {
+    if (!icon || typeof icon !== 'object') {
+      return false;
+    }
+    const nameMatch = icon.name.toLowerCase().includes(normalizedQuery);
+    if (nameMatch) {
+      return true;
+    }
+    const labelMatch = icon.label.toLowerCase().includes(normalizedQuery);
+    if (labelMatch) {
+      return true;
+    }
+    if (Array.isArray(icon.keywords)) {
+      return icon.keywords.some(keyword => {
+        if (typeof keyword !== 'string') {
+          return false;
+        }
+        return keyword.toLowerCase().includes(normalizedQuery);
+      });
+    }
+    return false;
+  });
+}
+
+export function normalizeIconStyle(style) {
+  return normalizeStyle(style);
+}

--- a/js/forms.js
+++ b/js/forms.js
@@ -24,6 +24,12 @@ import {
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 import {
+  loadIconsForStyle,
+  filterIcons,
+  normalizeIconStyle,
+  findIcon,
+} from './fontawesome-icons.js';
+import {
   populateThreadSizes,
   syncThreadSizePicker,
   setThreadSizeSelection,
@@ -91,9 +97,17 @@ const {
   bearingTypePickerList,
   bearingTypeSelect,
   customFieldsContainer,
+  customGraphicSourceRadios,
+  customImageFields,
   customImageInput,
   customImageClearButton,
   customImageNameDisplay,
+  customIconFields,
+  customIconStyleSelect,
+  customIconSearchInput,
+  customIconSelect,
+  customIconStatus,
+  customIconPreview,
   notesField,
   standardField,
   boltStandardGroup,
@@ -158,6 +172,16 @@ const validBoltHeadIds = new Set(
 );
 const NUT_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
+const CUSTOM_GRAPHIC_SOURCES = new Set(['image', 'icon']);
+const DEFAULT_CUSTOM_GRAPHIC_SOURCE = 'image';
+const DEFAULT_ICON_STYLE = 'solid';
+const FONT_AWESOME_STYLE_CLASSES = {
+  solid: 'fa-solid',
+  regular: 'fa-regular',
+  brands: 'fa-brands',
+};
+let customIconRequestId = 0;
+let lastIconCollection = { style: '', total: 0 };
 const WASHER_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validWasherTypeIds = new Set(washerTypeOptions.map(option => option.id));
 const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -2391,27 +2415,367 @@ export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
   }
 }
 
-export function updateCustomImageUi() {
-  const hasImage = !!state.customImageData;
-  if (customImageClearButton) {
-    customImageClearButton.disabled = !hasImage;
+function normalizeCustomGraphicSource(value) {
+  if (typeof value !== 'string') {
+    return DEFAULT_CUSTOM_GRAPHIC_SOURCE;
+  }
+  const normalized = value.trim().toLowerCase();
+  return CUSTOM_GRAPHIC_SOURCES.has(normalized) ? normalized : DEFAULT_CUSTOM_GRAPHIC_SOURCE;
+}
+
+function getCurrentIconStyle() {
+  const normalized = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+  state.customIconStyle = normalized;
+  return normalized;
+}
+
+function setIconSelectEnabled(enabled) {
+  if (!customIconSelect) {
+    return;
+  }
+  customIconSelect.disabled = !enabled;
+}
+
+function setIconSearchEnabled(enabled) {
+  if (!customIconSearchInput) {
+    return;
+  }
+  customIconSearchInput.disabled = !enabled;
+}
+
+function setIconControlsBusy(isBusy) {
+  if (!customIconSelect) {
+    return;
+  }
+  if (isBusy) {
+    customIconSelect.setAttribute('aria-busy', 'true');
+  } else {
+    customIconSelect.removeAttribute('aria-busy');
+  }
+}
+
+function clearCustomIconPreview() {
+  if (!customIconPreview) {
+    return;
+  }
+  const previousIconClass = customIconPreview.dataset.iconClass;
+  if (previousIconClass) {
+    customIconPreview.classList.remove(previousIconClass);
+    delete customIconPreview.dataset.iconClass;
+  }
+  Object.values(FONT_AWESOME_STYLE_CLASSES).forEach(cls => {
+    customIconPreview.classList.remove(cls);
+  });
+  customIconPreview.classList.add('d-none');
+}
+
+function setCustomIconPreview(style, iconName) {
+  if (!customIconPreview) {
+    return;
+  }
+  clearCustomIconPreview();
+  const styleClass = FONT_AWESOME_STYLE_CLASSES[style] || FONT_AWESOME_STYLE_CLASSES.solid;
+  customIconPreview.classList.remove('d-none');
+  customIconPreview.classList.add(styleClass);
+  const iconClass = `fa-${iconName}`;
+  customIconPreview.classList.add(iconClass);
+  customIconPreview.dataset.iconClass = iconClass;
+}
+
+function setCustomIconStatus(message, { isError = false, isLoading = false } = {}) {
+  if (!customIconStatus) {
+    return;
+  }
+  const normalized = typeof message === 'string' ? message : '';
+  customIconStatus.textContent = normalized;
+  customIconStatus.classList.remove('text-danger', 'fw-semibold', 'text-muted');
+  if (isError) {
+    customIconStatus.classList.add('text-danger', 'fw-semibold');
+  } else if (isLoading) {
+    customIconStatus.classList.add('text-muted');
+  }
+}
+
+function applyCustomGraphicInfoDisplay() {
+  const source = normalizeCustomGraphicSource(state.customGraphicSource);
+  const style = getCurrentIconStyle();
+  if (customIconStyleSelect) {
+    customIconStyleSelect.value = style;
   }
   if (customImageNameDisplay) {
-    if (state.customImageName) {
-      customImageNameDisplay.textContent = state.customImageName;
+    let displayText = '';
+    if (source === 'image' && state.customImageName) {
+      displayText = state.customImageName;
+    } else if (source === 'icon' && state.customIconName) {
+      const label = state.customIconLabel || state.customIconName;
+      const styleLabel = style.charAt(0).toUpperCase() + style.slice(1);
+      displayText = `${label} · ${styleLabel}`;
+    }
+    if (displayText) {
+      customImageNameDisplay.textContent = displayText;
       customImageNameDisplay.classList.remove('d-none');
     } else {
       customImageNameDisplay.textContent = '';
       customImageNameDisplay.classList.add('d-none');
     }
   }
+  if (source === 'icon' && state.customIconName && state.customIconUnicode) {
+    setCustomIconPreview(style, state.customIconName);
+  } else {
+    clearCustomIconPreview();
+  }
+  if (customIconSelect) {
+    if (source === 'icon' && state.customIconName && state.customIconStyle === style) {
+      customIconSelect.value = state.customIconName;
+    } else if (source !== 'icon') {
+      customIconSelect.value = '';
+      customIconSelect.selectedIndex = -1;
+    }
+  }
+}
+
+export async function refreshCustomIconOptions({ preserveSelection = true } = {}) {
+  if (!customIconSelect) {
+    return;
+  }
+  const source = normalizeCustomGraphicSource(state.customGraphicSource);
+  if (source !== 'icon') {
+    return;
+  }
+  const style = getCurrentIconStyle();
+  const query = customIconSearchInput ? customIconSearchInput.value : '';
+  const requestId = (customIconRequestId += 1);
+  setIconControlsBusy(true);
+  setIconSelectEnabled(false);
+  setIconSearchEnabled(false);
+  setCustomIconStatus('Loading icons…', { isLoading: true });
+  try {
+    const collection = await loadIconsForStyle(style);
+    if (requestId !== customIconRequestId) {
+      return;
+    }
+    lastIconCollection = { style, total: collection.icons.length };
+    const filtered = filterIcons(collection.icons, query);
+    customIconSelect.innerHTML = '';
+    filtered.forEach(icon => {
+      const option = document.createElement('option');
+      option.value = icon.name;
+      let glyph = '';
+      if (icon.unicode && icon.unicode.length) {
+        const codePoint = parseInt(icon.unicode, 16);
+        if (!Number.isNaN(codePoint)) {
+          try {
+            glyph = String.fromCodePoint(codePoint);
+          } catch {
+            glyph = '';
+          }
+        }
+      }
+      const labelText = `${icon.label} (${icon.name})`;
+      option.textContent = glyph ? `${glyph}  ${labelText}` : labelText;
+      option.dataset.label = icon.label;
+      option.dataset.unicode = icon.unicode;
+      option.dataset.style = icon.style;
+      if (glyph) {
+        const isBrands = icon.style === 'brands';
+        const fontStack = isBrands
+          ? '"Font Awesome 6 Brands", "Font Awesome 6 Free", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif'
+          : '"Font Awesome 6 Free", "Font Awesome 6 Brands", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif';
+        option.style.fontFamily = fontStack;
+        if (!isBrands) {
+          option.style.fontWeight = icon.style === 'solid' ? '900' : '400';
+        }
+      }
+      customIconSelect.appendChild(option);
+    });
+    if (filtered.length === 0) {
+      setCustomIconStatus('No icons match your search.');
+      customIconSelect.value = '';
+      customIconSelect.selectedIndex = -1;
+      setIconSelectEnabled(false);
+    } else {
+      const total = collection.icons.length;
+      const message =
+        filtered.length === total
+          ? `Showing ${filtered.length.toLocaleString()} icons.`
+          : `Showing ${filtered.length.toLocaleString()} of ${total.toLocaleString()} icons.`;
+      setCustomIconStatus(message);
+      if (preserveSelection && state.customIconName && state.customIconStyle === style) {
+        customIconSelect.value = state.customIconName;
+        if (customIconSelect.selectedIndex === -1) {
+          state.customIconName = '';
+          state.customIconUnicode = '';
+          state.customIconLabel = '';
+        }
+      } else {
+        customIconSelect.value = '';
+        customIconSelect.selectedIndex = -1;
+      }
+      setIconSelectEnabled(true);
+    }
+    setIconControlsBusy(false);
+    setIconSearchEnabled(true);
+    applyCustomGraphicInfoDisplay();
+  } catch (error) {
+    if (requestId !== customIconRequestId) {
+      return;
+    }
+    console.error('Unable to load Font Awesome icons', error);
+    customIconSelect.innerHTML = '';
+    setIconControlsBusy(false);
+    setIconSelectEnabled(false);
+    setIconSearchEnabled(true);
+    setCustomIconStatus('Unable to load Font Awesome icons. Check your connection and try again.', {
+      isError: true,
+    });
+  }
+}
+
+export function setCustomGraphicSource(source, options = {}) {
+  const normalized = normalizeCustomGraphicSource(source);
+  const previous = normalizeCustomGraphicSource(state.customGraphicSource);
+  state.customGraphicSource = normalized;
+  if (normalized === 'icon' && !state.customIconStyle) {
+    state.customIconStyle = DEFAULT_ICON_STYLE;
+  }
+  updateCustomImageUi();
+  if (normalized === 'icon' && previous !== 'icon') {
+    refreshCustomIconOptions({ preserveSelection: true });
+  }
+  if (options.triggerUpdate !== false) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function setCustomIconStyle(style, { preserveSelection = true } = {}) {
+  const normalized = normalizeIconStyle(style || DEFAULT_ICON_STYLE);
+  if (state.customIconStyle === normalized) {
+    refreshCustomIconOptions({ preserveSelection });
+    applyCustomGraphicInfoDisplay();
+    return;
+  }
+  state.customIconStyle = normalized;
+  if (!preserveSelection) {
+    state.customIconName = '';
+    state.customIconUnicode = '';
+    state.customIconLabel = '';
+  }
+  refreshCustomIconOptions({ preserveSelection });
+  applyCustomGraphicInfoDisplay();
+  updateDownloadState();
+  updatePreview();
+}
+
+export function setCustomIconSelection(icon = {}) {
+  const style = normalizeIconStyle(icon.style || state.customIconStyle || DEFAULT_ICON_STYLE);
+  const name = typeof icon.name === 'string' ? icon.name : '';
+  const unicode = typeof icon.unicode === 'string' ? icon.unicode : '';
+  const label = typeof icon.label === 'string' && icon.label.trim().length > 0 ? icon.label : name;
+  state.customGraphicSource = 'icon';
+  state.customIconStyle = style;
+  state.customIconName = name;
+  state.customIconUnicode = unicode;
+  state.customIconLabel = label;
+  applyCustomGraphicInfoDisplay();
+  if (!state.customIconUnicode && state.customIconName) {
+    findIcon(style, state.customIconName)
+      .then(record => {
+        if (!record) {
+          return;
+        }
+        if (state.customIconName !== record.name || state.customIconStyle !== record.style) {
+          return;
+        }
+        state.customIconUnicode = record.unicode;
+        state.customIconLabel = record.label;
+        applyCustomGraphicInfoDisplay();
+        updatePreview();
+        updateDownloadState();
+      })
+      .catch(error => {
+        console.error('Unable to resolve Font Awesome icon', error);
+      });
+  }
+  updateCustomImageUi();
+  updateDownloadState();
+  updatePreview();
+}
+
+export function updateCustomImageUi() {
+  const source = normalizeCustomGraphicSource(state.customGraphicSource);
+  state.customGraphicSource = source;
+  if (Array.isArray(customGraphicSourceRadios)) {
+    customGraphicSourceRadios.forEach(radio => {
+      if (!radio) {
+        return;
+      }
+      radio.checked = radio.value === source;
+    });
+  }
+  if (customImageFields) {
+    customImageFields.classList.toggle('d-none', source !== 'image');
+  }
+  if (customIconFields) {
+    customIconFields.classList.toggle('d-none', source !== 'icon');
+  }
+  const hasImage = source === 'image' && Boolean(state.customImageData);
+  const hasIcon = source === 'icon' && Boolean(state.customIconUnicode);
+  if (customImageClearButton) {
+    const label = source === 'icon' ? 'Remove icon' : 'Remove image';
+    customImageClearButton.disabled = !(hasImage || hasIcon);
+    customImageClearButton.textContent = label;
+    customImageClearButton.setAttribute('aria-label', label);
+  }
+  if (source === 'icon') {
+    const style = getCurrentIconStyle();
+    const needsRefresh =
+      !lastIconCollection ||
+      lastIconCollection.style !== style ||
+      !customIconSelect ||
+      customIconSelect.options.length === 0;
+    if (needsRefresh) {
+      refreshCustomIconOptions({ preserveSelection: true });
+    } else {
+      setIconControlsBusy(false);
+      const enableSelect =
+        !!customIconSelect && !customIconSelect.disabled && customIconSelect.options.length > 0;
+      setIconSelectEnabled(enableSelect);
+      setIconSearchEnabled(true);
+    }
+  } else {
+    setIconControlsBusy(false);
+    setIconSelectEnabled(false);
+    setIconSearchEnabled(false);
+    setCustomIconStatus('');
+  }
+  if (source === 'image' && state.customImageName && customImageNameDisplay) {
+    customImageNameDisplay.textContent = state.customImageName;
+    customImageNameDisplay.classList.remove('d-none');
+  }
+  if (source === 'image' && !state.customImageName && customImageNameDisplay) {
+    customImageNameDisplay.textContent = '';
+    customImageNameDisplay.classList.add('d-none');
+  }
+  applyCustomGraphicInfoDisplay();
 }
 
 export function clearCustomImage({ resetInput = true } = {}) {
-  state.customImageData = '';
-  state.customImageName = '';
-  if (resetInput && customImageInput) {
-    customImageInput.value = '';
+  const source = normalizeCustomGraphicSource(state.customGraphicSource);
+  if (source === 'icon') {
+    state.customIconName = '';
+    state.customIconUnicode = '';
+    state.customIconLabel = '';
+    if (customIconSelect) {
+      customIconSelect.value = '';
+      customIconSelect.selectedIndex = -1;
+    }
+  } else {
+    state.customImageData = '';
+    state.customImageName = '';
+    if (resetInput && customImageInput) {
+      customImageInput.value = '';
+    }
   }
   updateCustomImageUi();
   updatePreview();
@@ -2433,6 +2797,10 @@ export function handleCustomImageFile(file) {
   const reader = new FileReader();
   reader.onload = () => {
     const result = typeof reader.result === 'string' ? reader.result : '';
+    state.customGraphicSource = 'image';
+    state.customIconName = '';
+    state.customIconUnicode = '';
+    state.customIconLabel = '';
     state.customImageData = result;
     state.customImageName = file.name || 'Custom image';
     updateCustomImageUi();

--- a/js/render.js
+++ b/js/render.js
@@ -436,31 +436,55 @@ function layoutHardware(imageInfo, options) {
   let usedWidth = 0;
   const safeGap = Math.max(0, gap || 0);
 
-  if (imageInfo.type === 'custom') {
+  if (imageInfo.type === 'custom-image' || imageInfo.type === 'custom-icon') {
     const targetWidth = Math.min(maxWidth, Math.max(height * 0.75, Math.min(height, maxWidth)));
     if (!(targetWidth > 0)) {
       return { width: 0, elements: [] };
     }
-    const top = y + (height - height) / 2;
-    if (imageInfo.hasImage && imageInfo.src) {
-      elements.push({
-        type: 'image',
-        href: imageInfo.src,
-        x,
-        y: top,
-        width: targetWidth,
-        height,
-        title: imageInfo.alt || 'Custom image',
-      });
-    } else {
-      elements.push({
-        type: 'placeholder',
-        x,
-        y: top,
-        width: targetWidth,
-        height,
-        label: 'Add image',
-      });
+    const top = y;
+    if (imageInfo.type === 'custom-image') {
+      if (imageInfo.hasImage && imageInfo.src) {
+        elements.push({
+          type: 'image',
+          href: imageInfo.src,
+          x,
+          y: top,
+          width: targetWidth,
+          height,
+          title: imageInfo.alt || 'Custom image',
+        });
+      } else {
+        elements.push({
+          type: 'placeholder',
+          x,
+          y: top,
+          width: targetWidth,
+          height,
+          label: 'Add image',
+        });
+      }
+    } else if (imageInfo.type === 'custom-icon') {
+      if (imageInfo.hasIcon && imageInfo.iconUnicode) {
+        elements.push({
+          type: 'icon',
+          x,
+          y: top,
+          width: targetWidth,
+          height,
+          unicode: imageInfo.iconUnicode,
+          style: imageInfo.iconStyle || 'solid',
+          label: imageInfo.iconLabel || 'Custom icon',
+        });
+      } else {
+        elements.push({
+          type: 'placeholder',
+          x,
+          y: top,
+          width: targetWidth,
+          height,
+          label: 'Choose icon',
+        });
+      }
     }
     usedWidth = targetWidth;
     return { width: usedWidth, elements };
@@ -670,6 +694,18 @@ async function buildLabelSvg() {
         `<text x="${formatNumber(centerX)}" y="${formatNumber(centerY)}" font-size="${placeholderFont}" font-weight="700" text-anchor="middle" fill="${LABEL_TEXT_COLOR}" font-family=${JSON.stringify(
           LABEL_FONT_FAMILY,
         )}>${escapeXml(element.label || 'Add image')}</text>`,
+      );
+    } else if (element.type === 'icon') {
+      const fontFamily =
+        element.style === 'brands' ? 'Font Awesome 6 Brands' : 'Font Awesome 6 Free';
+      const fontWeight = element.style === 'regular' ? 400 : element.style === 'solid' ? 900 : 400;
+      const iconSize = Math.max(12, Math.min(element.width, element.height) * 0.8);
+      const centerX = element.x + element.width / 2;
+      const centerY = element.y + element.height / 2;
+      const glyph = element.unicode ? `&#x${element.unicode};` : '';
+      const title = element.label ? `<title>${escapeXml(element.label)}</title>` : '';
+      svgParts.push(
+        `<g>${title}<text x="${formatNumber(centerX)}" y="${formatNumber(centerY)}" font-family=${JSON.stringify(fontFamily)} font-weight="${fontWeight}" font-size="${formatNumber(iconSize)}" text-anchor="middle" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${glyph}</text></g>`,
       );
     }
   }
@@ -1278,9 +1314,21 @@ function resolveHardwareImageInfo() {
     return null;
   }
   if (state.hardwareType === 'Custom') {
+    const source = state.customGraphicSource === 'icon' ? 'icon' : 'image';
+    if (source === 'icon') {
+      const hasIcon = Boolean(state.customIconUnicode && state.customIconName);
+      return {
+        type: 'custom-icon',
+        hasIcon,
+        iconName: state.customIconName || '',
+        iconUnicode: state.customIconUnicode || '',
+        iconStyle: state.customIconStyle || 'solid',
+        iconLabel: state.customIconLabel || state.customIconName || 'Custom icon',
+      };
+    }
     const hasImage = Boolean(state.customImageData);
     return {
-      type: 'custom',
+      type: 'custom-image',
       hasImage,
       src: state.customImageData || '',
       alt: state.customImageName || 'Custom image',

--- a/js/state.js
+++ b/js/state.js
@@ -30,6 +30,11 @@ export const state = {
   bearingDetails: '',
   customLine1: '',
   customLine2: '',
+  customGraphicSource: 'image',
+  customIconStyle: 'solid',
+  customIconName: '',
+  customIconUnicode: '',
+  customIconLabel: '',
   customImageData: '',
   customImageName: '',
 };

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -48,6 +48,11 @@ const FIELD_MAP = {
   bearingDetails: 'bd',
   customLine1: 'c1',
   customLine2: 'c2',
+  customGraphicSource: 'cgs',
+  customIconStyle: 'cis',
+  customIconName: 'cinm',
+  customIconUnicode: 'ciu',
+  customIconLabel: 'cil',
   customImageData: 'cid',
   customImageName: 'cin',
 };
@@ -96,6 +101,7 @@ const boltHeadIds = new Set(
   boltHeadOptions.concat(screwTypeOptions).map(option => option.id),
 );
 const boltDriveIds = new Set(boltDriveOptions.map(option => option.id));
+const iconStyleOptions = new Set(['solid', 'regular', 'brands']);
 
 function encodeToBase64Url(input) {
   const encoder = new TextEncoder();
@@ -233,6 +239,22 @@ function sanitizeCustomImageName(value) {
     return '';
   }
   return value.slice(0, 200);
+}
+
+function sanitizeCustomGraphicSource(value) {
+  if (typeof value !== 'string') {
+    return 'image';
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'icon' ? 'icon' : 'image';
+}
+
+function sanitizeIconStyle(value) {
+  if (typeof value !== 'string') {
+    return 'solid';
+  }
+  const normalized = value.trim().toLowerCase();
+  return iconStyleOptions.has(normalized) ? normalized : 'solid';
 }
 
 function sanitizeWidth(value) {
@@ -435,6 +457,21 @@ function applyExpandedPayload(expanded) {
   }
   if (typeof expanded.customLine2 === 'string') {
     state.customLine2 = expanded.customLine2.slice(0, 120);
+  }
+  if (typeof expanded.customGraphicSource === 'string') {
+    state.customGraphicSource = sanitizeCustomGraphicSource(expanded.customGraphicSource);
+  }
+  if (typeof expanded.customIconStyle === 'string') {
+    state.customIconStyle = sanitizeIconStyle(expanded.customIconStyle);
+  }
+  if (typeof expanded.customIconName === 'string') {
+    state.customIconName = expanded.customIconName.slice(0, 120);
+  }
+  if (typeof expanded.customIconUnicode === 'string') {
+    state.customIconUnicode = expanded.customIconUnicode.slice(0, 20);
+  }
+  if (typeof expanded.customIconLabel === 'string') {
+    state.customIconLabel = sanitizeShortText(expanded.customIconLabel);
   }
   if (typeof expanded.customImageData === 'string') {
     state.customImageData = expanded.customImageData;

--- a/style.css
+++ b/style.css
@@ -106,6 +106,24 @@ main {
   margin: 0.5rem auto 0;
 }
 
+.custom-icon-preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  border-radius: 0.75rem;
+  background-color: rgba(15, 23, 42, 0.08);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  color: inherit;
+}
+
+:root[data-theme='dark'] .custom-icon-preview {
+  background-color: rgba(148, 163, 184, 0.2);
+}
+
 .title-section h1 {
   font-family: 'Tagesschrift', sans-serif;
   font-size: clamp(1.35rem, 6vw, 4.5rem);


### PR DESCRIPTION
## Summary
- render glyph previews alongside each Font Awesome icon option in the custom graphic picker
- apply Font Awesome font stacks and weights to keep the glyph preview visible for each style

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc724b9ff48329b37aebb4747e17e1