### PR TITLE
Improve Font Awesome custom icon picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,12 +363,42 @@
                         Browse the complete Font Awesome Free collection. Results update as you type.
                       </div>
                     </div>
-                    <select
-                      class="form-select mt-3"
-                      id="custom-icon-select"
-                      size="8"
-                      aria-describedby="custom-icon-status"
-                    ></select>
+                    <div class="mt-3">
+                      <div class="bolt-drive-picker" id="custom-icon-picker">
+                        <select
+                          id="custom-icon-select"
+                          class="visually-hidden"
+                          aria-labelledby="custom-icon-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="custom-icon-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="custom-icon-picker-list"
+                          aria-describedby="custom-icon-status"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <span class="bolt-drive-picker__current-icon-glyph"></span>
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="custom-icon-picker-list"
+                          role="listbox"
+                          aria-labelledby="custom-icon-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                    </div>
                     <div class="form-text mt-2" id="custom-icon-status" aria-live="polite"></div>
                   </div>
                   <div class="d-flex flex-wrap align-items-center gap-2 mt-3">

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -95,6 +95,9 @@ const customIconFields = document.getElementById('custom-icon-fields');
 const customIconStyleSelect = document.getElementById('custom-icon-style');
 const customIconSearchInput = document.getElementById('custom-icon-search');
 const customIconSelect = document.getElementById('custom-icon-select');
+const customIconPicker = document.getElementById('custom-icon-picker');
+const customIconPickerButton = document.getElementById('custom-icon-picker-button');
+const customIconPickerList = document.getElementById('custom-icon-picker-list');
 const customIconStatus = document.getElementById('custom-icon-status');
 const customIconPreview = document.getElementById('custom-icon-preview');
 const customLine1Input = document.getElementById('custom-line1-input');
@@ -267,6 +270,9 @@ export const elements = {
   customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
+  customIconPicker,
+  customIconPickerButton,
+  customIconPickerList,
   customIconStatus,
   customIconPreview,
   customLine1Input,

--- a/js/events.js
+++ b/js/events.js
@@ -97,6 +97,9 @@ const {
   customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
+  customIconPicker,
+  customIconPickerButton,
+  customIconPickerList,
   customLine1Input,
   customLine2Input,
   customImageInput,
@@ -152,6 +155,7 @@ let resistorValuePickerOpen = false;
 let capacitorValuePickerOpen = false;
 let diodeValuePickerOpen = false;
 let bearingTypePickerOpen = false;
+let customIconPickerOpen = false;
 
 const HARDWARE_TYPE_SEARCH_DELAY = 120;
 let hardwareTypePickerMode = 'dialog';
@@ -1398,6 +1402,228 @@ function handleComponentMountListFocusOut() {
     const active = document.activeElement;
     if (!active || !componentMountPicker.contains(active)) {
       closeComponentMountPicker();
+    }
+  }, 0);
+}
+
+function getCustomIconOptionElements() {
+  if (!customIconPickerList) {
+    return [];
+  }
+  return Array.from(customIconPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusCustomIconOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getCustomIconOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus({ preventScroll: false });
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openCustomIconPicker() {
+  if (!customIconPicker || !customIconPickerButton || !customIconPickerList) {
+    return;
+  }
+  if (customIconPickerButton.disabled) {
+    return;
+  }
+  if (customIconPickerOpen) {
+    return;
+  }
+  customIconPickerOpen = true;
+  customIconPicker.classList.add('is-open');
+  customIconPickerList.hidden = false;
+  customIconPickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getCustomIconOptionElements();
+  const currentName = typeof state.customIconName === 'string' ? state.customIconName : '';
+  const selectedOption = options.find(option => option.dataset.value === currentName);
+  focusCustomIconOption(selectedOption || options[0]);
+}
+
+function closeCustomIconPicker({ focusButton = false } = {}) {
+  if (!customIconPicker || !customIconPickerButton || !customIconPickerList) {
+    return;
+  }
+  if (!customIconPickerOpen) {
+    if (focusButton && !customIconPickerButton.disabled) {
+      customIconPickerButton.focus();
+    }
+    return;
+  }
+  customIconPickerOpen = false;
+  customIconPicker.classList.remove('is-open');
+  customIconPickerList.hidden = true;
+  customIconPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !customIconPickerButton.disabled) {
+    customIconPickerButton.focus();
+  }
+}
+
+function toggleCustomIconPicker() {
+  if (customIconPickerOpen) {
+    closeCustomIconPicker({ focusButton: false });
+  } else {
+    openCustomIconPicker();
+  }
+}
+
+function moveCustomIconOption(delta) {
+  if (!customIconPickerList) {
+    return;
+  }
+  const options = getCustomIconOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const activeElement = document.activeElement;
+  const activeOption =
+    activeElement && customIconPickerList.contains(activeElement)
+      ? activeElement.closest('[role="option"]')
+      : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentName = typeof state.customIconName === 'string' ? state.customIconName : '';
+    index = options.findIndex(option => option.dataset.value === currentName);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusCustomIconOption(nextOption);
+  }
+}
+
+function handleCustomIconButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openCustomIconPicker();
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openCustomIconPicker();
+    const options = getCustomIconOptionElements();
+    if (options.length > 0) {
+      focusCustomIconOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleCustomIconPicker();
+    return;
+  }
+  if (key === 'Escape' && customIconPickerOpen) {
+    event.preventDefault();
+    closeCustomIconPicker({ focusButton: true });
+  }
+}
+
+function handleCustomIconListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveCustomIconOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveCustomIconOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getCustomIconOptionElements();
+    if (options.length > 0) {
+      focusCustomIconOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getCustomIconOptionElements();
+    if (options.length > 0) {
+      focusCustomIconOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setCustomIconSelection({
+          name: option.dataset.value || '',
+          unicode: option.dataset.unicode || '',
+          label: option.dataset.label || option.textContent || option.dataset.value || '',
+          style: option.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+        });
+        closeCustomIconPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeCustomIconPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeCustomIconPicker();
+  }
+}
+
+function handleCustomIconListClick(event) {
+  if (!customIconPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !customIconPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setCustomIconSelection({
+    name: option.dataset.value || '',
+    unicode: option.dataset.unicode || '',
+    label: option.dataset.label || option.textContent || option.dataset.value || '',
+    style: option.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+  });
+  closeCustomIconPicker({ focusButton: true });
+}
+
+function handleCustomIconListFocusOut() {
+  if (!customIconPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!customIconPickerOpen) {
+      return;
+    }
+    if (!customIconPicker) {
+      closeCustomIconPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !customIconPicker.contains(active)) {
+      closeCustomIconPicker();
     }
   }, 0);
 }
@@ -3129,6 +3355,11 @@ function handleDocumentPointer(event) {
       closeBearingTypePicker();
     }
   }
+  if (customIconPickerOpen && customIconPicker) {
+    if (!(target instanceof Node) || !customIconPicker.contains(target)) {
+      closeCustomIconPicker();
+    }
+  }
 }
 
 function handleDocumentFocusIn(event) {
@@ -3186,6 +3417,11 @@ function handleDocumentFocusIn(event) {
   if (bearingTypePickerOpen && bearingTypePicker) {
     if (!(target instanceof Node) || !bearingTypePicker.contains(target)) {
       closeBearingTypePicker();
+    }
+  }
+  if (customIconPickerOpen && customIconPicker) {
+    if (!(target instanceof Node) || !customIconPicker.contains(target)) {
+      closeCustomIconPicker();
     }
   }
 }
@@ -3520,6 +3756,7 @@ export function initEventHandlers() {
       const selected = customIconSelect.selectedOptions[0];
       if (!selected) {
         setCustomIconSelection({ name: '', unicode: '', label: '', style: customIconStyleSelect ? customIconStyleSelect.value : undefined });
+        closeCustomIconPicker();
         return;
       }
       setCustomIconSelection({
@@ -3528,6 +3765,7 @@ export function initEventHandlers() {
         label: selected.dataset.label || selected.textContent || selected.value,
         style: selected.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
       });
+      closeCustomIconPicker();
     });
   }
 
@@ -3626,6 +3864,16 @@ export function initEventHandlers() {
     washerTypePickerList.addEventListener('keydown', handleWasherTypeListKeydown);
     washerTypePickerList.addEventListener('focusout', handleWasherTypeListFocusOut);
   }
+  if (customIconPickerButton && customIconPickerList) {
+    customIconPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleCustomIconPicker();
+    });
+    customIconPickerButton.addEventListener('keydown', handleCustomIconButtonKeydown);
+    customIconPickerList.addEventListener('click', handleCustomIconListClick);
+    customIconPickerList.addEventListener('keydown', handleCustomIconListKeydown);
+    customIconPickerList.addEventListener('focusout', handleCustomIconListFocusOut);
+  }
   if (
     hardwareTypePicker ||
     fuseTypePicker ||
@@ -3633,10 +3881,14 @@ export function initEventHandlers() {
     boltDrivePicker ||
     boltHeadPicker ||
     nutTypePicker ||
+    washerTypePicker ||
     fuseValuePicker ||
     componentMountPicker ||
     resistorValuePicker ||
-    capacitorValuePicker
+    capacitorValuePicker ||
+    diodeValuePicker ||
+    bearingTypePicker ||
+    customIconPicker
   ) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);
@@ -3651,6 +3903,10 @@ export function initEventHandlers() {
     closeComponentMountPicker();
     closeResistorValuePicker();
     closeCapacitorValuePicker();
+  });
+
+  document.addEventListener('gridfinity:custom-icon-picker-close', () => {
+    closeCustomIconPicker();
   });
 
   if (standardToggle) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -106,6 +106,9 @@ const {
   customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
+  customIconPicker,
+  customIconPickerButton,
+  customIconPickerList,
   customIconStatus,
   customIconPreview,
   notesField,
@@ -175,6 +178,7 @@ const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
 const CUSTOM_GRAPHIC_SOURCES = new Set(['image', 'icon']);
 const DEFAULT_CUSTOM_GRAPHIC_SOURCE = 'image';
 const DEFAULT_ICON_STYLE = 'solid';
+const CUSTOM_ICON_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const FONT_AWESOME_STYLE_CLASSES = {
   solid: 'fa-solid',
   regular: 'fa-regular',
@@ -2430,10 +2434,24 @@ function getCurrentIconStyle() {
 }
 
 function setIconSelectEnabled(enabled) {
-  if (!customIconSelect) {
-    return;
+  if (customIconSelect) {
+    customIconSelect.disabled = !enabled;
   }
-  customIconSelect.disabled = !enabled;
+  if (customIconPickerButton) {
+    customIconPickerButton.disabled = !enabled;
+    if (!enabled) {
+      customIconPickerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+  if (customIconPickerList) {
+    customIconPickerList.hidden = true;
+  }
+  if (customIconPicker) {
+    customIconPicker.classList.toggle('is-disabled', !enabled);
+  }
+  if (!enabled && typeof document !== 'undefined') {
+    document.dispatchEvent(new CustomEvent('gridfinity:custom-icon-picker-close'));
+  }
 }
 
 function setIconSearchEnabled(enabled) {
@@ -2444,13 +2462,139 @@ function setIconSearchEnabled(enabled) {
 }
 
 function setIconControlsBusy(isBusy) {
-  if (!customIconSelect) {
+  if (customIconSelect) {
+    if (isBusy) {
+      customIconSelect.setAttribute('aria-busy', 'true');
+    } else {
+      customIconSelect.removeAttribute('aria-busy');
+    }
+  }
+  if (customIconPickerButton) {
+    if (isBusy) {
+      customIconPickerButton.setAttribute('aria-busy', 'true');
+    } else {
+      customIconPickerButton.removeAttribute('aria-busy');
+    }
+  }
+  if (isBusy && typeof document !== 'undefined') {
+    document.dispatchEvent(new CustomEvent('gridfinity:custom-icon-picker-close'));
+  }
+}
+
+function findCustomIconOption(name) {
+  if (!customIconSelect || !name) {
+    return null;
+  }
+  const options = Array.from(customIconSelect.options);
+  return options.find(option => option.value === name) || null;
+}
+
+function getGlyphFromUnicode(unicode) {
+  if (!unicode || typeof unicode !== 'string') {
+    return '';
+  }
+  const segments = unicode.split('-').filter(Boolean);
+  if (segments.length === 0) {
+    return '';
+  }
+  try {
+    const codePoints = segments.map(segment => parseInt(segment, 16)).filter(codePoint => {
+      return Number.isFinite(codePoint) && !Number.isNaN(codePoint);
+    });
+    if (codePoints.length === 0) {
+      return '';
+    }
+    return String.fromCodePoint(...codePoints);
+  } catch {
+    return '';
+  }
+}
+
+function applyGlyphFont(target, style) {
+  if (!target) {
     return;
   }
-  if (isBusy) {
-    customIconSelect.setAttribute('aria-busy', 'true');
+  const normalized = normalizeIconStyle(style || state.customIconStyle || DEFAULT_ICON_STYLE);
+  const isBrands = normalized === 'brands';
+  const fontStack = isBrands
+    ? '"Font Awesome 6 Brands", "Font Awesome 6 Free", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif'
+    : '"Font Awesome 6 Free", "Font Awesome 6 Brands", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif';
+  target.style.fontFamily = fontStack;
+  if (isBrands) {
+    target.style.fontWeight = '400';
   } else {
-    customIconSelect.removeAttribute('aria-busy');
+    target.style.fontWeight = normalized === 'solid' ? '900' : '400';
+  }
+}
+
+function syncCustomIconPickerDisplay() {
+  if (!customIconPickerButton) {
+    return;
+  }
+  const name = typeof state.customIconName === 'string' ? state.customIconName : '';
+  const labelFromState = typeof state.customIconLabel === 'string' ? state.customIconLabel : '';
+  const unicodeFromState = typeof state.customIconUnicode === 'string' ? state.customIconUnicode : '';
+  let resolvedLabel = labelFromState;
+  let resolvedUnicode = unicodeFromState;
+  let resolvedStyle = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+  let resolvedGlyph = '';
+
+  const option = name ? findCustomIconOption(name) : null;
+  if (option) {
+    if (!resolvedLabel) {
+      resolvedLabel = option.dataset.label || option.textContent || name;
+    }
+    if (!resolvedUnicode) {
+      resolvedUnicode = option.dataset.unicode || '';
+    }
+    if (option.dataset.style) {
+      resolvedStyle = normalizeIconStyle(option.dataset.style);
+    }
+    if (option.dataset.glyph) {
+      resolvedGlyph = option.dataset.glyph;
+    }
+  }
+
+  if (!resolvedGlyph && resolvedUnicode) {
+    resolvedGlyph = getGlyphFromUnicode(resolvedUnicode);
+  }
+
+  const labelElement = customIconPickerButton.querySelector('.bolt-drive-picker__current-label');
+  const iconWrapper = customIconPickerButton.querySelector('.bolt-drive-picker__current-icon');
+  const glyphElement = customIconPickerButton.querySelector('.bolt-drive-picker__current-icon-glyph');
+
+  const styleLabel = resolvedStyle.charAt(0).toUpperCase() + resolvedStyle.slice(1);
+  const buttonLabel = name
+    ? `${(resolvedLabel || name).trim()} (${name}) · ${styleLabel}`
+    : CUSTOM_ICON_PLACEHOLDER_TEXT;
+
+  if (labelElement) {
+    labelElement.textContent = buttonLabel;
+  }
+
+  if (glyphElement) {
+    if (resolvedGlyph) {
+      glyphElement.textContent = resolvedGlyph;
+      applyGlyphFont(glyphElement, resolvedStyle);
+    } else {
+      glyphElement.textContent = '';
+      glyphElement.style.fontFamily = '';
+      glyphElement.style.fontWeight = '';
+    }
+  }
+
+  if (iconWrapper) {
+    iconWrapper.classList.toggle('is-empty', !resolvedGlyph);
+  }
+
+  if (customIconPickerList) {
+    const items = Array.from(customIconPickerList.querySelectorAll('[role="option"]'));
+    items.forEach(item => {
+      const isSelected = item.dataset.value === name;
+      item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      item.classList.toggle('is-selected', isSelected);
+      item.tabIndex = -1;
+    });
   }
 }
 
@@ -2532,6 +2676,7 @@ function applyCustomGraphicInfoDisplay() {
       customIconSelect.selectedIndex = -1;
     }
   }
+  syncCustomIconPickerDisplay();
 }
 
 export async function refreshCustomIconOptions({ preserveSelection = true } = {}) {
@@ -2549,6 +2694,9 @@ export async function refreshCustomIconOptions({ preserveSelection = true } = {}
   setIconSelectEnabled(false);
   setIconSearchEnabled(false);
   setCustomIconStatus('Loading icons…', { isLoading: true });
+  if (customIconPickerList) {
+    customIconPickerList.innerHTML = '';
+  }
   try {
     const collection = await loadIconsForStyle(style);
     if (requestId !== customIconRequestId) {
@@ -2557,37 +2705,80 @@ export async function refreshCustomIconOptions({ preserveSelection = true } = {}
     lastIconCollection = { style, total: collection.icons.length };
     const filtered = filterIcons(collection.icons, query);
     customIconSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = CUSTOM_ICON_PLACEHOLDER_TEXT;
+    customIconSelect.appendChild(placeholder);
+
+    if (customIconPickerList) {
+      customIconPickerList.innerHTML = '';
+    }
+
     filtered.forEach(icon => {
       const option = document.createElement('option');
       option.value = icon.name;
-      let glyph = '';
-      if (icon.unicode && icon.unicode.length) {
-        const codePoint = parseInt(icon.unicode, 16);
-        if (!Number.isNaN(codePoint)) {
-          try {
-            glyph = String.fromCodePoint(codePoint);
-          } catch {
-            glyph = '';
-          }
-        }
-      }
+      const glyph = getGlyphFromUnicode(icon.unicode);
       const labelText = `${icon.label} (${icon.name})`;
       option.textContent = glyph ? `${glyph}  ${labelText}` : labelText;
       option.dataset.label = icon.label;
       option.dataset.unicode = icon.unicode;
       option.dataset.style = icon.style;
+      option.dataset.glyph = glyph;
       if (glyph) {
         const isBrands = icon.style === 'brands';
         const fontStack = isBrands
           ? '"Font Awesome 6 Brands", "Font Awesome 6 Free", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif'
           : '"Font Awesome 6 Free", "Font Awesome 6 Brands", "Barlow", "Segoe UI", "Helvetica Neue", Arial, sans-serif';
         option.style.fontFamily = fontStack;
-        if (!isBrands) {
-          option.style.fontWeight = icon.style === 'solid' ? '900' : '400';
-        }
+        option.style.fontWeight = isBrands ? '400' : icon.style === 'solid' ? '900' : '400';
+      } else {
+        option.style.fontFamily = '';
+        option.style.fontWeight = '';
       }
       customIconSelect.appendChild(option);
+
+      if (customIconPickerList) {
+        const item = document.createElement('li');
+        item.className = 'bolt-drive-picker__option';
+        item.dataset.value = icon.name;
+        item.dataset.label = icon.label;
+        item.dataset.unicode = icon.unicode;
+        item.dataset.style = icon.style;
+        item.dataset.glyph = glyph;
+        item.setAttribute('role', 'option');
+        item.setAttribute('aria-selected', 'false');
+        item.tabIndex = -1;
+
+        const iconWrapper = document.createElement('span');
+        iconWrapper.className = glyph
+          ? 'bolt-drive-picker__option-icon'
+          : 'bolt-drive-picker__option-icon is-empty';
+        iconWrapper.setAttribute('aria-hidden', 'true');
+
+        const glyphElement = document.createElement('span');
+        glyphElement.className = 'bolt-drive-picker__option-icon-glyph';
+        glyphElement.textContent = glyph;
+        if (glyph) {
+          applyGlyphFont(glyphElement, icon.style);
+        } else {
+          glyphElement.style.fontFamily = '';
+          glyphElement.style.fontWeight = '';
+        }
+        iconWrapper.appendChild(glyphElement);
+        item.appendChild(iconWrapper);
+
+        const labelElement = document.createElement('span');
+        labelElement.className = 'bolt-drive-picker__option-label';
+        labelElement.textContent = labelText;
+        item.appendChild(labelElement);
+
+        customIconPickerList.appendChild(item);
+      }
     });
+
+    if (customIconPickerList) {
+      customIconPickerList.hidden = true;
+    }
     if (filtered.length === 0) {
       setCustomIconStatus('No icons match your search.');
       customIconSelect.value = '';
@@ -2615,6 +2806,7 @@ export async function refreshCustomIconOptions({ preserveSelection = true } = {}
     }
     setIconControlsBusy(false);
     setIconSearchEnabled(true);
+    syncCustomIconPickerDisplay();
     applyCustomGraphicInfoDisplay();
   } catch (error) {
     if (requestId !== customIconRequestId) {
@@ -2622,12 +2814,17 @@ export async function refreshCustomIconOptions({ preserveSelection = true } = {}
     }
     console.error('Unable to load Font Awesome icons', error);
     customIconSelect.innerHTML = '';
+    if (customIconPickerList) {
+      customIconPickerList.innerHTML = '';
+      customIconPickerList.hidden = true;
+    }
     setIconControlsBusy(false);
     setIconSelectEnabled(false);
     setIconSearchEnabled(true);
     setCustomIconStatus('Unable to load Font Awesome icons. Check your connection and try again.', {
       isError: true,
     });
+    syncCustomIconPickerDisplay();
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -433,6 +433,14 @@ main {
   transition: filter 0.2s ease;
 }
 
+.bolt-drive-picker__current-icon-glyph {
+  display: inline-block;
+  min-width: 1.5rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  text-align: center;
+}
+
 .bolt-drive-picker__chevron {
   display: inline-flex;
   align-items: center;
@@ -529,6 +537,14 @@ main {
   display: block;
   filter: var(--form-icon-filter);
   transition: filter 0.2s ease;
+}
+
+.bolt-drive-picker__option-icon-glyph {
+  display: inline-block;
+  min-width: 1.5rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  text-align: center;
 }
 
 .bolt-drive-picker__option-label {


### PR DESCRIPTION
## Summary
- swap the Font Awesome select box for the shared picker UI so glyphs appear in the dropdown
- keep the picker button and selected icon label in sync with the chosen style and glyph
- add keyboard and click handling for the custom icon picker to match other pickers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc8bca8930832983c4e4a8a0217116