### PR TITLE
Render custom icons using embedded Font Awesome SVGs

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -13,6 +13,7 @@ import {
   populateDiodeValues,
   populateWasherTypeOptions,
   updateCustomImageUi,
+  ensureCustomIconAsset,
   onHardwareTypeChange,
   setBoltDriveSelection,
   setBoltHeadSelection,
@@ -147,6 +148,7 @@ function init() {
   populateDiodeValues();
   populateWasherTypeOptions();
   updateCustomImageUi();
+  ensureCustomIconAsset();
   onHardwareTypeChange();
   applyStateToControls();
   initEventHandlers();

--- a/js/fontawesome-icons.js
+++ b/js/fontawesome-icons.js
@@ -2,10 +2,13 @@ const ICONS_ENDPOINT =
   'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/metadata/icons.json';
 
 const VALID_STYLES = ['solid', 'regular', 'brands'];
+const ICON_SVG_BASE_URL =
+  'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs';
 
 let metadataPromise = null;
 let metadataCache = null;
 const iconListCache = new Map();
+const iconSvgCache = new Map();
 
 function normalizeStyle(style) {
   if (typeof style !== 'string') {
@@ -153,4 +156,66 @@ export function filterIcons(icons, query) {
 
 export function normalizeIconStyle(style) {
   return normalizeStyle(style);
+}
+
+function sanitizeIconSvg(markup) {
+  if (typeof markup !== 'string') {
+    return '';
+  }
+  const trimmed = markup.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed
+    .replace(/currentColor/gi, '#000000')
+    .replace(/\sstroke="currentColor"/gi, ' stroke="#000000"')
+    .replace(/\sfill="\s*"/gi, '');
+}
+
+function svgMarkupToDataUrl(svgMarkup) {
+  const encoded = encodeURIComponent(svgMarkup)
+    .replace(/'/g, '%27')
+    .replace(/"/g, '%22')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29');
+  return `data:image/svg+xml;charset=utf-8,${encoded}`;
+}
+
+export async function loadIconSvg(style, name) {
+  const normalizedStyle = normalizeStyle(style);
+  const normalizedName = typeof name === 'string' ? name.trim() : '';
+  if (!normalizedName) {
+    return Promise.resolve(null);
+  }
+  const cacheKey = `${normalizedStyle}:${normalizedName}`;
+  if (iconSvgCache.has(cacheKey)) {
+    return iconSvgCache.get(cacheKey);
+  }
+  if (typeof fetch !== 'function') {
+    return Promise.resolve(null);
+  }
+  const svgUrl = `${ICON_SVG_BASE_URL}/${normalizedStyle}/${normalizedName}.svg`;
+  const request = fetch(svgUrl, { cache: 'force-cache' })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Failed to load Font Awesome icon SVG: ${response.status}`);
+      }
+      return response.text();
+    })
+    .then(markup => {
+      const sanitized = sanitizeIconSvg(markup);
+      if (!sanitized) {
+        throw new Error('Font Awesome icon SVG was empty');
+      }
+      return {
+        markup: sanitized,
+        dataUrl: svgMarkupToDataUrl(sanitized),
+      };
+    })
+    .catch(error => {
+      iconSvgCache.delete(cacheKey);
+      throw error;
+    });
+  iconSvgCache.set(cacheKey, request);
+  return request;
 }

--- a/js/forms.js
+++ b/js/forms.js
@@ -28,6 +28,7 @@ import {
   filterIcons,
   normalizeIconStyle,
   findIcon,
+  loadIconSvg,
 } from './fontawesome-icons.js';
 import {
   populateThreadSizes,
@@ -158,6 +159,7 @@ const PART_TYPE_PLACEHOLDER_IMAGE =
   'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80"%3E%3Crect width="80" height="80" rx="14" fill="%23e2e8f0"/%3E%3Cpath fill="%2394a3b8" d="M24 26h32v8H24zm0 16h32v8H24zm0 16h32v8H24z"/%3E%3C/svg%3E';
 const hardwareTypeOptionRecords = new Map();
 const hardwareTypeFilterButtons = new Map();
+let customIconAssetRequestId = 0;
 const hardwareTypeFilterState = {
   category: HARDWARE_TYPE_ALL_FILTER,
   query: '',
@@ -2527,6 +2529,49 @@ function applyGlyphFont(target, style) {
   }
 }
 
+function resetCustomIconSvgData() {
+  customIconAssetRequestId += 1;
+  state.customIconSvgData = '';
+}
+
+function refreshSelectedCustomIconAsset() {
+  const style = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+  const name = typeof state.customIconName === 'string' ? state.customIconName.trim() : '';
+  resetCustomIconSvgData();
+  if (!name) {
+    return;
+  }
+  const requestId = customIconAssetRequestId;
+  loadIconSvg(style, name)
+    .then(result => {
+      if (customIconAssetRequestId !== requestId) {
+        return;
+      }
+      const currentStyle = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+      const currentName = typeof state.customIconName === 'string' ? state.customIconName.trim() : '';
+      if (currentStyle !== style || currentName !== name) {
+        return;
+      }
+      state.customIconSvgData = result && result.dataUrl ? result.dataUrl : '';
+      updatePreview();
+      updateDownloadState();
+    })
+    .catch(error => {
+      if (customIconAssetRequestId !== requestId) {
+        return;
+      }
+      const currentStyle = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+      const currentName = typeof state.customIconName === 'string' ? state.customIconName.trim() : '';
+      if (currentStyle !== style || currentName !== name) {
+        return;
+      }
+      console.error('Unable to load Font Awesome icon SVG', error);
+      state.customIconSvgData = '';
+      updatePreview();
+      updateDownloadState();
+    });
+}
+
 function syncCustomIconPickerDisplay() {
   if (!customIconPickerButton) {
     return;
@@ -2838,6 +2883,9 @@ export function setCustomGraphicSource(source, options = {}) {
   updateCustomImageUi();
   if (normalized === 'icon' && previous !== 'icon') {
     refreshCustomIconOptions({ preserveSelection: true });
+    if (state.customIconName) {
+      refreshSelectedCustomIconAsset();
+    }
   }
   if (options.triggerUpdate !== false) {
     updateDownloadState();
@@ -2857,6 +2905,9 @@ export function setCustomIconStyle(style, { preserveSelection = true } = {}) {
     state.customIconName = '';
     state.customIconUnicode = '';
     state.customIconLabel = '';
+    resetCustomIconSvgData();
+  } else {
+    refreshSelectedCustomIconAsset();
   }
   refreshCustomIconOptions({ preserveSelection });
   applyCustomGraphicInfoDisplay();
@@ -2874,6 +2925,7 @@ export function setCustomIconSelection(icon = {}) {
   state.customIconName = name;
   state.customIconUnicode = unicode;
   state.customIconLabel = label;
+  refreshSelectedCustomIconAsset();
   applyCustomGraphicInfoDisplay();
   if (!state.customIconUnicode && state.customIconName) {
     findIcon(style, state.customIconName)
@@ -2899,6 +2951,20 @@ export function setCustomIconSelection(icon = {}) {
   updatePreview();
 }
 
+export function ensureCustomIconAsset() {
+  if (state.customGraphicSource !== 'icon') {
+    return;
+  }
+  if (!state.customIconName) {
+    resetCustomIconSvgData();
+    return;
+  }
+  if (state.customIconSvgData) {
+    return;
+  }
+  refreshSelectedCustomIconAsset();
+}
+
 export function updateCustomImageUi() {
   const source = normalizeCustomGraphicSource(state.customGraphicSource);
   state.customGraphicSource = source;
@@ -2917,7 +2983,8 @@ export function updateCustomImageUi() {
     customIconFields.classList.toggle('d-none', source !== 'icon');
   }
   const hasImage = source === 'image' && Boolean(state.customImageData);
-  const hasIcon = source === 'icon' && Boolean(state.customIconUnicode);
+  const hasIcon =
+    source === 'icon' && Boolean(state.customIconUnicode || state.customIconSvgData);
   if (customImageClearButton) {
     const label = source === 'icon' ? 'Remove icon' : 'Remove image';
     customImageClearButton.disabled = !(hasImage || hasIcon);
@@ -2960,6 +3027,7 @@ export function updateCustomImageUi() {
 export function clearCustomImage({ resetInput = true } = {}) {
   const source = normalizeCustomGraphicSource(state.customGraphicSource);
   if (source === 'icon') {
+    resetCustomIconSvgData();
     state.customIconName = '';
     state.customIconUnicode = '';
     state.customIconLabel = '';
@@ -2998,6 +3066,7 @@ export function handleCustomImageFile(file) {
     state.customIconName = '';
     state.customIconUnicode = '';
     state.customIconLabel = '';
+    resetCustomIconSvgData();
     state.customImageData = result;
     state.customImageName = file.name || 'Custom image';
     updateCustomImageUi();

--- a/js/render.js
+++ b/js/render.js
@@ -464,7 +464,21 @@ function layoutHardware(imageInfo, options) {
         });
       }
     } else if (imageInfo.type === 'custom-icon') {
-      if (imageInfo.hasIcon && imageInfo.iconUnicode) {
+      const iconLabel = imageInfo.iconLabel || imageInfo.iconName || 'Custom icon';
+      const svgHref = typeof imageInfo.iconSvgData === 'string' ? imageInfo.iconSvgData : '';
+      const hasSvg = svgHref.trim().length > 0;
+      const hasUnicode = Boolean(imageInfo.iconUnicode);
+      if (hasSvg) {
+        elements.push({
+          type: 'image',
+          href: svgHref,
+          x,
+          y: top,
+          width: targetWidth,
+          height,
+          title: iconLabel,
+        });
+      } else if (imageInfo.hasIcon && hasUnicode) {
         elements.push({
           type: 'icon',
           x,
@@ -473,7 +487,7 @@ function layoutHardware(imageInfo, options) {
           height,
           unicode: imageInfo.iconUnicode,
           style: imageInfo.iconStyle || 'solid',
-          label: imageInfo.iconLabel || 'Custom icon',
+          label: iconLabel,
         });
       } else {
         elements.push({
@@ -1316,7 +1330,9 @@ function resolveHardwareImageInfo() {
   if (state.hardwareType === 'Custom') {
     const source = state.customGraphicSource === 'icon' ? 'icon' : 'image';
     if (source === 'icon') {
-      const hasIcon = Boolean(state.customIconUnicode && state.customIconName);
+      const hasIcon = Boolean(
+        state.customIconName && (state.customIconSvgData || state.customIconUnicode),
+      );
       return {
         type: 'custom-icon',
         hasIcon,
@@ -1324,6 +1340,7 @@ function resolveHardwareImageInfo() {
         iconUnicode: state.customIconUnicode || '',
         iconStyle: state.customIconStyle || 'solid',
         iconLabel: state.customIconLabel || state.customIconName || 'Custom icon',
+        iconSvgData: state.customIconSvgData || '',
       };
     }
     const hasImage = Boolean(state.customImageData);

--- a/js/state.js
+++ b/js/state.js
@@ -35,6 +35,7 @@ export const state = {
   customIconName: '',
   customIconUnicode: '',
   customIconLabel: '',
+  customIconSvgData: '',
   customImageData: '',
   customImageName: '',
 };

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -473,6 +473,7 @@ function applyExpandedPayload(expanded) {
   if (typeof expanded.customIconLabel === 'string') {
     state.customIconLabel = sanitizeShortText(expanded.customIconLabel);
   }
+  state.customIconSvgData = '';
   if (typeof expanded.customImageData === 'string') {
     state.customImageData = expanded.customImageData;
   }


### PR DESCRIPTION
## Summary
- inline Font Awesome SVG assets for custom icons and cache the downloads
- add custom icon SVG state management so previews and exports render the icon graphic
- ensure initialization hydrates saved custom icon selections and loads the SVG asset

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dc937032888329a0b31741a704a0e3