### PR TITLE
Fix dark mode part type icon backgrounds

### DIFF
--- a/style.css
+++ b/style.css
@@ -1620,5 +1620,5 @@ body.part-type-picker-open {
 }
 
 :root[data-theme='dark'] .part-type-card__thumb {
-  background: rgba(30, 41, 59, 0.85);
+  background: transparent;
 }


### PR DESCRIPTION
## Summary
- remove the dark mode background fill behind part type picker thumbnails so icons float on the card

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf2e419488329bacf2510a71f3874