### PR TITLE
Center hardware picker modal close icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
                             data-part-type-picker-close
                             aria-label="Close part type picker"
                           >
-                            <span aria-hidden="true">&times;</span>
+                            <span class="part-type-picker__close-icon" aria-hidden="true"></span>
                           </button>
                         </header>
                         <div class="part-type-picker__search-row">

--- a/style.css
+++ b/style.css
@@ -1331,9 +1331,32 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.35rem;
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.part-type-picker__close-icon {
+  position: relative;
+  display: block;
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.part-type-picker__close-icon::before,
+.part-type-picker__close-icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 0.125rem;
+  background-color: currentColor;
+  border-radius: 999px;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.part-type-picker__close-icon::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
 }
 
 .part-type-picker__close:hover {


### PR DESCRIPTION
## Summary
- replace the text glyph in the part type picker close button with a CSS-based icon so it stays centered in its circle
- add styling for the new close icon to ensure consistent appearance across themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcf6479b8883298e0167dbf11f5485