### PR TITLE
Use Font Awesome icon for custom part type

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -151,6 +151,8 @@ const {
 const PLACEHOLDER_BLANK = '\u00a0';
 // Non-breaking space keeps custom pickers aligned without displaying placeholder copy.
 const HARDWARE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const CUSTOM_PART_TYPE_VALUE = 'Custom';
+const CUSTOM_PART_TYPE_ICON_CLASS = 'fa-pen-to-square';
 const HARDWARE_TYPE_ALL_FILTER = 'All';
 const HARDWARE_TYPE_DEFAULT_CATEGORY = 'Uncategorized';
 const HARDWARE_TYPE_RECENT_STORAGE_KEY = 'gridfinity.recentHardwareTypes';
@@ -276,13 +278,22 @@ function createPartTypeCard(record, { variant = 'grid' } = {}) {
   const thumb = document.createElement('span');
   thumb.className = 'part-type-card__thumb';
 
-  const image = document.createElement('img');
-  image.className = 'part-type-card__image';
-  image.alt = '';
-  image.decoding = 'async';
-  image.loading = 'lazy';
-  image.src = record.image;
-  thumb.appendChild(image);
+  if (record.image) {
+    const image = document.createElement('img');
+    image.className = 'part-type-card__image';
+    image.alt = '';
+    image.decoding = 'async';
+    image.loading = 'lazy';
+    image.src = record.image;
+    thumb.appendChild(image);
+  }
+
+  if (record.icon) {
+    const icon = document.createElement('i');
+    icon.className = `part-type-card__icon fa-solid ${record.icon}`;
+    icon.setAttribute('aria-hidden', 'true');
+    thumb.appendChild(icon);
+  }
 
   const label = document.createElement('span');
   label.className = 'part-type-card__label';
@@ -567,13 +578,16 @@ export function populateHardwareTypePicker() {
     const normalizedCategory = normalizeText(category);
     const rawImage = getOptionImage(option);
 
+    const isCustomOption = value === CUSTOM_PART_TYPE_VALUE;
+
     const record = {
       value,
       label,
       normalizedLabel: normalizeText(label),
       category,
       normalizedCategory,
-      image: rawImage || PART_TYPE_PLACEHOLDER_IMAGE,
+      image: rawImage || (isCustomOption ? '' : PART_TYPE_PLACEHOLDER_IMAGE),
+      icon: isCustomOption ? CUSTOM_PART_TYPE_ICON_CLASS : '',
       hasCustomImage: Boolean(rawImage),
       mainElement: null,
       recentElement: null,
@@ -1377,14 +1391,30 @@ export function syncHardwareTypePicker() {
     }
 
     if (fallback instanceof HTMLElement) {
+      const showIconFallback = resolvedValue === CUSTOM_PART_TYPE_VALUE;
+      fallback.classList.toggle('part-type-picker__chip-fallback--icon', showIconFallback);
+
       if (imageSrc) {
         fallback.hidden = true;
+        fallback.innerHTML = '';
+        fallback.style.backgroundImage = '';
+        fallback.style.backgroundSize = '';
+        fallback.style.backgroundPosition = '';
+        fallback.style.backgroundRepeat = '';
+      } else if (showIconFallback) {
+        fallback.hidden = false;
+        fallback.innerHTML = '';
+        const icon = document.createElement('i');
+        icon.className = `fa-solid ${CUSTOM_PART_TYPE_ICON_CLASS}`;
+        icon.setAttribute('aria-hidden', 'true');
+        fallback.appendChild(icon);
         fallback.style.backgroundImage = '';
         fallback.style.backgroundSize = '';
         fallback.style.backgroundPosition = '';
         fallback.style.backgroundRepeat = '';
       } else {
         fallback.hidden = false;
+        fallback.innerHTML = '';
         fallback.style.backgroundImage = `url("${PART_TYPE_PLACEHOLDER_IMAGE}")`;
         fallback.style.backgroundSize = 'cover';
         fallback.style.backgroundPosition = 'center';

--- a/style.css
+++ b/style.css
@@ -1264,6 +1264,16 @@ main {
   justify-content: center;
 }
 
+.part-type-picker__chip-fallback--icon {
+  background: transparent;
+}
+
+.part-type-picker__chip-fallback--icon i {
+  font-size: 1.125rem;
+  line-height: 1;
+  color: var(--bs-body-color, #0f172a);
+}
+
 .part-type-picker__chip-label {
   display: inline-flex;
   align-items: center;
@@ -1510,6 +1520,15 @@ main {
   max-height: 100%;
   object-fit: contain;
   filter: var(--form-icon-filter);
+}
+
+.part-type-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
+  line-height: 1;
+  color: var(--bs-body-color, #0f172a);
 }
 
 .part-type-card__label {


### PR DESCRIPTION
## Summary
- replace the hardware picker placeholder for the Custom option with the Font Awesome pen-to-square icon so the chip and modal cards render the icon
- adjust component logic to manage the icon-specific fallback state when no image asset is available for the Custom option
- style the custom picker icon so it appears centered without a background in both light and dark themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcf8f27c6083299a7817c131b2bdc7