### PR TITLE
Fix recent part type grid item sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1448,7 +1448,7 @@ main {
 .part-type-picker__recent-grid {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(108px, 1fr);
+  grid-auto-columns: minmax(112px, 112px);
   gap: 0.75rem;
   overflow-x: auto;
   padding-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- adjust the recently used part type grid to size each item to a single tile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfc982b488329b7a7c2c7c6e408fe