### PR TITLE
Add connector pickers with icon support

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,11 +452,44 @@
                   <label for="connector-category-select" class="form-label fw-semibold"
                     >Connector Category</label
                   >
-                  <select
-                    id="connector-category-select"
-                    class="form-select"
-                    aria-describedby="connector-category-message"
-                  ></select>
+                  <div class="bolt-drive-picker" id="connector-category-picker">
+                    <select
+                      id="connector-category-select"
+                      class="visually-hidden"
+                      aria-describedby="connector-category-message"
+                    ></select>
+                    <button
+                      type="button"
+                      class="bolt-drive-picker__button"
+                      id="connector-category-picker-button"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      aria-controls="connector-category-picker-list"
+                    >
+                      <span class="bolt-drive-picker__current">
+                        <span
+                          class="bolt-drive-picker__current-icon is-empty"
+                          aria-hidden="true"
+                        >
+                          <img
+                            class="bolt-drive-picker__current-icon-image"
+                            src=""
+                            alt=""
+                            hidden
+                          />
+                        </span>
+                        <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                      </span>
+                      <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                    </button>
+                    <ul
+                      class="bolt-drive-picker__list"
+                      id="connector-category-picker-list"
+                      role="listbox"
+                      aria-labelledby="connector-category-picker-button"
+                      hidden
+                    ></ul>
+                  </div>
                   <div id="connector-category-help" class="form-text d-none"></div>
                   <div
                     id="connector-category-message"
@@ -1028,6 +1061,43 @@
                     id="standard-field-label"
                     >Hardware Standard</label
                   >
+                  <div
+                    class="bolt-drive-picker d-none"
+                    id="connector-series-picker"
+                    aria-hidden="true"
+                  >
+                    <button
+                      type="button"
+                      class="bolt-drive-picker__button"
+                      id="connector-series-picker-button"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      aria-controls="connector-series-picker-list"
+                    >
+                      <span class="bolt-drive-picker__current">
+                        <span
+                          class="bolt-drive-picker__current-icon is-empty"
+                          aria-hidden="true"
+                        >
+                          <img
+                            class="bolt-drive-picker__current-icon-image"
+                            src=""
+                            alt=""
+                            hidden
+                          />
+                        </span>
+                        <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                      </span>
+                      <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                    </button>
+                    <ul
+                      class="bolt-drive-picker__list"
+                      id="connector-series-picker-list"
+                      role="listbox"
+                      aria-labelledby="connector-series-picker-button"
+                      hidden
+                    ></ul>
+                  </div>
                   <select id="standard-select" class="form-select"></select>
                   <div id="bolt-standard-group" class="row g-3 d-none" aria-hidden="true">
                     <div id="bolt-drive-field" class="col-12 col-sm-6 thread-length-field">

--- a/js/controls.js
+++ b/js/controls.js
@@ -23,10 +23,13 @@ import {
   setFuseTypeSelection,
   setThreadSizeSelection,
   setFuseValueSelection,
+  setConnectorCategorySelection,
+  setConnectorSeriesSelection,
   setComponentMountSelection,
   setResistorValueSelection,
   setCapacitorValueSelection,
   setDiodeValueSelection,
+  syncConnectorSeriesPicker,
   updateComponentValueUi,
 } from './forms.js';
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
@@ -51,7 +54,6 @@ function applyStateToControls() {
     widthRange,
     widthValueSpan,
     heightRadios,
-    connectorCategorySelect,
     nutTypeSelect,
     washerTypeSelect,
   } = elements;
@@ -73,9 +75,7 @@ function applyStateToControls() {
     glassFastBlowCheckbox.checked = state.glassSpeed.startsWith('Fast');
   }
 
-  if (connectorCategorySelect) {
-    connectorCategorySelect.value = state.connectorCategory || '';
-  }
+  setConnectorCategorySelection(state.connectorCategory || '', { triggerUpdate: false });
   setThreadSizeSelection(state.threadSize || '', { triggerUpdate: false });
   if (nutTypeSelect) {
     nutTypeSelect.value = state.nutType || '';
@@ -104,6 +104,11 @@ function applyStateToControls() {
   }
   if (standardSelect) {
     standardSelect.value = state.standardCode || '';
+  }
+  if (state.hardwareType === 'Connector') {
+    setConnectorSeriesSelection(state.standardCode || '', { triggerUpdate: false });
+  } else {
+    syncConnectorSeriesPicker({ isValid: true });
   }
   setBoltHeadSelection(state.boltHead || '', { triggerUpdate: false });
   setBoltDriveSelection(state.boltDrive || '', { triggerUpdate: false });

--- a/js/data.js
+++ b/js/data.js
@@ -403,6 +403,29 @@ export const hardwareTypeImageMap = {
   Diode: 'images/diodes/diode_through_hole.svg',
 };
 
+export const PRE_INSULATED_CRIMP_CATEGORY_ID = 'pre-insulated-crimp';
+
+export const connectorCategoryImageMap = {
+  [PRE_INSULATED_CRIMP_CATEGORY_ID]: 'images/connectors/ring_terminal.svg',
+  'bootlace-ferrule': 'images/connectors/bootlace_ferrule.svg',
+};
+
+export function getConnectorSeriesImage(categoryId, seriesCode) {
+  if (categoryId === PRE_INSULATED_CRIMP_CATEGORY_ID) {
+    const normalized = typeof seriesCode === 'string' ? seriesCode.toLowerCase() : '';
+    if (normalized.includes('ring terminal')) {
+      return 'images/connectors/ring_terminal.svg';
+    }
+    if (normalized.includes('fork terminal')) {
+      return 'images/connectors/fork_terminal.svg';
+    }
+    if (normalized.includes('butt')) {
+      return 'images/connectors/butt_connector.svg';
+    }
+  }
+  return '';
+}
+
 export const connectorCatalog = [
   {
     id: 'pre-insulated-crimp',

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -49,6 +49,9 @@ const notesInput = document.getElementById('notes-input');
 const measurementSystemContainer = document.getElementById('measurement-system-container');
 const connectorCategoryContainer = document.getElementById('connector-category-container');
 const connectorCategorySelect = document.getElementById('connector-category-select');
+const connectorCategoryPicker = document.getElementById('connector-category-picker');
+const connectorCategoryPickerButton = document.getElementById('connector-category-picker-button');
+const connectorCategoryPickerList = document.getElementById('connector-category-picker-list');
 const connectorCategoryHelp = document.getElementById('connector-category-help');
 const connectorNotesHint = document.getElementById('connector-notes-hint');
 const connectorCategoryMessage = document.getElementById('connector-category-message');
@@ -108,6 +111,9 @@ const notesField = document.getElementById('notes-field');
 const standardField = document.getElementById('standard-field');
 const standardFieldLabel = document.getElementById('standard-field-label');
 const boltStandardGroup = document.getElementById('bolt-standard-group');
+const connectorSeriesPicker = document.getElementById('connector-series-picker');
+const connectorSeriesPickerButton = document.getElementById('connector-series-picker-button');
+const connectorSeriesPickerList = document.getElementById('connector-series-picker-list');
 const boltHeadField = document.getElementById('bolt-head-field');
 const boltDriveField = document.getElementById('bolt-drive-field');
 const boltHeadLabel = document.querySelector('label[for="bolt-head-select"]');
@@ -226,6 +232,9 @@ export const elements = {
   measurementSystemContainer,
   connectorCategoryContainer,
   connectorCategorySelect,
+  connectorCategoryPicker,
+  connectorCategoryPickerButton,
+  connectorCategoryPickerList,
   connectorCategoryHelp,
   connectorNotesHint,
   connectorCategoryMessage,
@@ -283,6 +292,9 @@ export const elements = {
   standardField,
   standardFieldLabel,
   boltStandardGroup,
+  connectorSeriesPicker,
+  connectorSeriesPickerButton,
+  connectorSeriesPickerList,
   boltHeadField,
   boltDriveField,
   boltHeadLabel,

--- a/js/events.js
+++ b/js/events.js
@@ -3,8 +3,6 @@ import { elements } from './dom-elements.js';
 import {
   applyHardwareTypeSelection,
   populateThreadSizes,
-  populateStandards,
-  updateConnectorCategoryUi,
   handleCustomImageFile,
   clearCustomImage,
   setCustomGraphicSource,
@@ -23,6 +21,10 @@ import {
   syncNutTypePicker,
   setWasherTypeSelection,
   syncWasherTypePicker,
+  setConnectorCategorySelection,
+  syncConnectorCategoryPicker,
+  setConnectorSeriesSelection,
+  syncConnectorSeriesPicker,
   syncHardwareTypePicker,
   setHardwareTypeFilterCategory,
   setHardwareTypeSearchQuery,
@@ -54,6 +56,9 @@ const {
   hardwareTypePickerSearch,
   hardwareTypePickerFilters,
   connectorCategorySelect,
+  connectorCategoryPicker,
+  connectorCategoryPickerButton,
+  connectorCategoryPickerList,
   componentCategoryRadios,
   componentMountSelect,
   componentMountPicker,
@@ -120,6 +125,9 @@ const {
   washerTypePicker,
   washerTypePickerButton,
   washerTypePickerList,
+  connectorSeriesPicker,
+  connectorSeriesPickerButton,
+  connectorSeriesPickerList,
   standardSelect,
   standardToggle,
   imageToggle,
@@ -156,6 +164,8 @@ let capacitorValuePickerOpen = false;
 let diodeValuePickerOpen = false;
 let bearingTypePickerOpen = false;
 let customIconPickerOpen = false;
+let connectorCategoryPickerOpen = false;
+let connectorSeriesPickerOpen = false;
 
 const HARDWARE_TYPE_SEARCH_DELAY = 120;
 let hardwareTypePickerMode = 'dialog';
@@ -3293,6 +3303,454 @@ function handleWasherTypeListFocusOut() {
   }, 0);
 }
 
+function getConnectorCategoryOptionElements() {
+  if (!connectorCategoryPickerList) {
+    return [];
+  }
+  return Array.from(connectorCategoryPickerList.querySelectorAll('[role="option"]'));
+}
+
+function getVisibleConnectorCategoryOptions() {
+  return getConnectorCategoryOptionElements().filter(
+    option => !option.hidden && option.style.display !== 'none',
+  );
+}
+
+function focusConnectorCategoryOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getVisibleConnectorCategoryOptions();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openConnectorCategoryPicker() {
+  if (!connectorCategoryPicker || !connectorCategoryPickerButton || !connectorCategoryPickerList) {
+    return;
+  }
+  if (connectorCategoryPickerButton.disabled) {
+    return;
+  }
+  if (connectorCategoryPickerOpen) {
+    return;
+  }
+  connectorCategoryPickerOpen = true;
+  connectorCategoryPicker.classList.add('is-open');
+  connectorCategoryPickerList.hidden = false;
+  connectorCategoryPickerButton.setAttribute('aria-expanded', 'true');
+  syncConnectorCategoryPicker({ isValid: true });
+
+  const visibleOptions = getVisibleConnectorCategoryOptions();
+  if (visibleOptions.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+  const selectedOption = visibleOptions.find(option => option.dataset.value === currentValue);
+  focusConnectorCategoryOption(selectedOption || visibleOptions[0]);
+}
+
+function closeConnectorCategoryPicker({ focusButton = false } = {}) {
+  if (!connectorCategoryPicker || !connectorCategoryPickerButton || !connectorCategoryPickerList) {
+    return;
+  }
+  if (!connectorCategoryPickerOpen) {
+    if (focusButton && !connectorCategoryPickerButton.disabled) {
+      connectorCategoryPickerButton.focus();
+    }
+    return;
+  }
+  connectorCategoryPickerOpen = false;
+  connectorCategoryPicker.classList.remove('is-open');
+  connectorCategoryPickerList.hidden = true;
+  connectorCategoryPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !connectorCategoryPickerButton.disabled) {
+    connectorCategoryPickerButton.focus();
+  }
+}
+
+function toggleConnectorCategoryPicker() {
+  if (connectorCategoryPickerOpen) {
+    closeConnectorCategoryPicker({ focusButton: false });
+  } else {
+    openConnectorCategoryPicker();
+  }
+}
+
+function moveConnectorCategoryOption(delta) {
+  const options = getVisibleConnectorCategoryOptions();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeIndex = options.findIndex(option => option === active);
+  let nextIndex = activeIndex + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  }
+  if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  focusConnectorCategoryOption(options[nextIndex]);
+}
+
+function handleConnectorCategoryButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openConnectorCategoryPicker();
+    moveConnectorCategoryOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openConnectorCategoryPicker();
+    moveConnectorCategoryOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleConnectorCategoryPicker();
+    return;
+  }
+  if (key === 'Escape' && connectorCategoryPickerOpen) {
+    event.preventDefault();
+    closeConnectorCategoryPicker({ focusButton: true });
+  }
+}
+
+function handleConnectorCategoryListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveConnectorCategoryOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveConnectorCategoryOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getVisibleConnectorCategoryOptions();
+    if (options.length > 0) {
+      focusConnectorCategoryOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getVisibleConnectorCategoryOptions();
+    if (options.length > 0) {
+      focusConnectorCategoryOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setConnectorCategorySelection(option.dataset.value || '');
+        closeConnectorCategoryPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeConnectorCategoryPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeConnectorCategoryPicker();
+  }
+}
+
+function handleConnectorCategoryListClick(event) {
+  if (!connectorCategoryPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !connectorCategoryPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setConnectorCategorySelection(option.dataset.value || '');
+  closeConnectorCategoryPicker({ focusButton: true });
+}
+
+function handleConnectorCategoryListFocusOut() {
+  if (!connectorCategoryPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!connectorCategoryPickerOpen) {
+      return;
+    }
+    if (!connectorCategoryPicker) {
+      closeConnectorCategoryPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !connectorCategoryPicker.contains(active)) {
+      closeConnectorCategoryPicker();
+    }
+  }, 0);
+}
+
+function getConnectorSeriesOptionElements() {
+  if (!connectorSeriesPickerList) {
+    return [];
+  }
+  return Array.from(connectorSeriesPickerList.querySelectorAll('[role="option"]'));
+}
+
+function getVisibleConnectorSeriesOptions() {
+  return getConnectorSeriesOptionElements().filter(
+    option => !option.hidden && option.style.display !== 'none',
+  );
+}
+
+function focusConnectorSeriesOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getVisibleConnectorSeriesOptions();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openConnectorSeriesPicker() {
+  if (
+    !connectorSeriesPicker ||
+    !connectorSeriesPickerButton ||
+    !connectorSeriesPickerList ||
+    state.hardwareType !== 'Connector'
+  ) {
+    return;
+  }
+  if (connectorSeriesPickerButton.disabled) {
+    return;
+  }
+  if (connectorSeriesPickerOpen) {
+    return;
+  }
+  connectorSeriesPickerOpen = true;
+  connectorSeriesPicker.classList.add('is-open');
+  connectorSeriesPickerList.hidden = false;
+  connectorSeriesPickerButton.setAttribute('aria-expanded', 'true');
+  syncConnectorSeriesPicker({ isValid: true });
+
+  const visibleOptions = getVisibleConnectorSeriesOptions();
+  if (visibleOptions.length === 0) {
+    return;
+  }
+  const currentCode = typeof state.standardCode === 'string' ? state.standardCode : '';
+  const selectedOption = visibleOptions.find(option => option.dataset.value === currentCode);
+  focusConnectorSeriesOption(selectedOption || visibleOptions[0]);
+}
+
+function closeConnectorSeriesPicker({ focusButton = false } = {}) {
+  if (!connectorSeriesPicker || !connectorSeriesPickerButton || !connectorSeriesPickerList) {
+    return;
+  }
+  if (!connectorSeriesPickerOpen) {
+    if (focusButton && !connectorSeriesPickerButton.disabled) {
+      connectorSeriesPickerButton.focus();
+    }
+    return;
+  }
+  connectorSeriesPickerOpen = false;
+  connectorSeriesPicker.classList.remove('is-open');
+  connectorSeriesPickerList.hidden = true;
+  connectorSeriesPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !connectorSeriesPickerButton.disabled) {
+    connectorSeriesPickerButton.focus();
+  }
+}
+
+function toggleConnectorSeriesPicker() {
+  if (connectorSeriesPickerOpen) {
+    closeConnectorSeriesPicker({ focusButton: false });
+  } else {
+    openConnectorSeriesPicker();
+  }
+}
+
+function moveConnectorSeriesOption(delta) {
+  const options = getVisibleConnectorSeriesOptions();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeIndex = options.findIndex(option => option === active);
+  let nextIndex = activeIndex + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  }
+  if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  focusConnectorSeriesOption(options[nextIndex]);
+}
+
+function handleConnectorSeriesButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openConnectorSeriesPicker();
+    moveConnectorSeriesOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openConnectorSeriesPicker();
+    moveConnectorSeriesOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleConnectorSeriesPicker();
+    return;
+  }
+  if (key === 'Escape' && connectorSeriesPickerOpen) {
+    event.preventDefault();
+    closeConnectorSeriesPicker({ focusButton: true });
+    return;
+  }
+  if (
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    (key.length === 1 || key === 'Backspace' || key === 'Delete')
+  ) {
+    handleStandardSelectKeydown(event);
+    if (!connectorSeriesPickerOpen) {
+      openConnectorSeriesPicker();
+    }
+    const options = getVisibleConnectorSeriesOptions();
+    if (options.length > 0) {
+      focusConnectorSeriesOption(options[0]);
+    }
+  }
+}
+
+function handleConnectorSeriesListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveConnectorSeriesOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveConnectorSeriesOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getVisibleConnectorSeriesOptions();
+    if (options.length > 0) {
+      focusConnectorSeriesOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getVisibleConnectorSeriesOptions();
+    if (options.length > 0) {
+      focusConnectorSeriesOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setConnectorSeriesSelection(option.dataset.value || '');
+        closeConnectorSeriesPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeConnectorSeriesPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeConnectorSeriesPicker();
+    return;
+  }
+  if (
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    (key.length === 1 || key === 'Backspace' || key === 'Delete')
+  ) {
+    handleStandardSelectKeydown(event);
+    const options = getVisibleConnectorSeriesOptions();
+    if (options.length > 0) {
+      focusConnectorSeriesOption(options[0]);
+    }
+  }
+}
+
+function handleConnectorSeriesListClick(event) {
+  if (!connectorSeriesPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !connectorSeriesPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setConnectorSeriesSelection(option.dataset.value || '');
+  closeConnectorSeriesPicker({ focusButton: true });
+}
+
+function handleConnectorSeriesListFocusOut() {
+  if (!connectorSeriesPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!connectorSeriesPickerOpen) {
+      return;
+    }
+    if (!connectorSeriesPicker) {
+      closeConnectorSeriesPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !connectorSeriesPicker.contains(active)) {
+      closeConnectorSeriesPicker();
+    }
+  }, 0);
+}
+
 function handleDocumentPointer(event) {
   const target = event.target;
   if (fuseTypePickerOpen && fuseTypePicker) {
@@ -3353,6 +3811,16 @@ function handleDocumentPointer(event) {
   if (bearingTypePickerOpen && bearingTypePicker) {
     if (!(target instanceof Node) || !bearingTypePicker.contains(target)) {
       closeBearingTypePicker();
+    }
+  }
+  if (connectorCategoryPickerOpen && connectorCategoryPicker) {
+    if (!(target instanceof Node) || !connectorCategoryPicker.contains(target)) {
+      closeConnectorCategoryPicker();
+    }
+  }
+  if (connectorSeriesPickerOpen && connectorSeriesPicker) {
+    if (!(target instanceof Node) || !connectorSeriesPicker.contains(target)) {
+      closeConnectorSeriesPicker();
     }
   }
   if (customIconPickerOpen && customIconPicker) {
@@ -3417,6 +3885,16 @@ function handleDocumentFocusIn(event) {
   if (bearingTypePickerOpen && bearingTypePicker) {
     if (!(target instanceof Node) || !bearingTypePicker.contains(target)) {
       closeBearingTypePicker();
+    }
+  }
+  if (connectorCategoryPickerOpen && connectorCategoryPicker) {
+    if (!(target instanceof Node) || !connectorCategoryPicker.contains(target)) {
+      closeConnectorCategoryPicker();
+    }
+  }
+  if (connectorSeriesPickerOpen && connectorSeriesPicker) {
+    if (!(target instanceof Node) || !connectorSeriesPicker.contains(target)) {
+      closeConnectorSeriesPicker();
     }
   }
   if (customIconPickerOpen && customIconPicker) {
@@ -3513,11 +3991,7 @@ export function initEventHandlers() {
 
   if (connectorCategorySelect) {
     connectorCategorySelect.addEventListener('change', () => {
-      state.connectorCategory = connectorCategorySelect.value;
-      updateConnectorCategoryUi();
-      populateStandards();
-      updateDownloadState();
-      updatePreview();
+      setConnectorCategorySelection(connectorCategorySelect.value);
     });
   }
 
@@ -3785,6 +4259,10 @@ export function initEventHandlers() {
 
   if (standardSelect) {
     standardSelect.addEventListener('change', () => {
+      if (state.hardwareType === 'Connector') {
+        setConnectorSeriesSelection(standardSelect.value);
+        return;
+      }
       const selectedOption = standardSelect.selectedOptions[0];
       if (selectedOption && selectedOption.value) {
         const displayName = selectedOption.dataset.name || selectedOption.textContent;
@@ -3864,6 +4342,29 @@ export function initEventHandlers() {
     washerTypePickerList.addEventListener('keydown', handleWasherTypeListKeydown);
     washerTypePickerList.addEventListener('focusout', handleWasherTypeListFocusOut);
   }
+  if (connectorCategoryPickerButton && connectorCategoryPickerList) {
+    connectorCategoryPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleConnectorCategoryPicker();
+    });
+    connectorCategoryPickerButton.addEventListener(
+      'keydown',
+      handleConnectorCategoryButtonKeydown,
+    );
+    connectorCategoryPickerList.addEventListener('click', handleConnectorCategoryListClick);
+    connectorCategoryPickerList.addEventListener('keydown', handleConnectorCategoryListKeydown);
+    connectorCategoryPickerList.addEventListener('focusout', handleConnectorCategoryListFocusOut);
+  }
+  if (connectorSeriesPickerButton && connectorSeriesPickerList) {
+    connectorSeriesPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleConnectorSeriesPicker();
+    });
+    connectorSeriesPickerButton.addEventListener('keydown', handleConnectorSeriesButtonKeydown);
+    connectorSeriesPickerList.addEventListener('click', handleConnectorSeriesListClick);
+    connectorSeriesPickerList.addEventListener('keydown', handleConnectorSeriesListKeydown);
+    connectorSeriesPickerList.addEventListener('focusout', handleConnectorSeriesListFocusOut);
+  }
   if (customIconPickerButton && customIconPickerList) {
     customIconPickerButton.addEventListener('click', event => {
       event.preventDefault();
@@ -3888,6 +4389,8 @@ export function initEventHandlers() {
     capacitorValuePicker ||
     diodeValuePicker ||
     bearingTypePicker ||
+    connectorCategoryPicker ||
+    connectorSeriesPicker ||
     customIconPicker
   ) {
     document.addEventListener('pointerdown', handleDocumentPointer);

--- a/js/forms.js
+++ b/js/forms.js
@@ -21,6 +21,8 @@ import {
   resistorValueOptions,
   capacitorValueOptions,
   diodeValueOptions,
+  connectorCategoryImageMap,
+  getConnectorSeriesImage,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 import {
@@ -69,6 +71,9 @@ const {
   measurementSystemContainer,
   connectorCategoryContainer,
   connectorCategorySelect,
+  connectorCategoryPicker,
+  connectorCategoryPickerButton,
+  connectorCategoryPickerList,
   connectorCategoryHelp,
   connectorNotesHint,
   componentCategoryContainer,
@@ -115,6 +120,9 @@ const {
   notesField,
   standardField,
   boltStandardGroup,
+  connectorSeriesPicker,
+  connectorSeriesPickerButton,
+  connectorSeriesPickerList,
   boltHeadLabel,
   boltHeadPicker,
   boltHeadPickerButton,
@@ -209,6 +217,9 @@ const DIODE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validDiodeValues = new Set(diodeValueOptions.map(option => option.id));
 const BEARING_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validBearingCodes = new Set(bearingOptions.map(option => option.code));
+const CONNECTOR_CATEGORY_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const CONNECTOR_SERIES_PLACEHOLDER_TEXT = CONNECTOR_PLACEHOLDER_TEXT;
+const validConnectorCategoryIds = new Set(connectorCatalog.map(category => category.id));
 
 function getFastenerHeadOptions() {
   return state.hardwareType === 'Screw' ? screwTypeOptions : boltHeadOptions;
@@ -2072,24 +2083,283 @@ export function populateWasherTypeOptions() {
   syncWasherTypePicker({ isValid: true });
 }
 
+export function syncConnectorSeriesPicker({ isValid = true } = {}) {
+  if (state.hardwareType !== 'Connector') {
+    return;
+  }
+  const categoryId = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+  const category = findConnectorCategory(categoryId);
+  const series = category && Array.isArray(category.series) ? category.series : [];
+  const currentCode = typeof state.standardCode === 'string' ? state.standardCode : '';
+  const selectedEntry = series.find(entry => entry.code === currentCode) || null;
+  const sanitizedCode = selectedEntry ? selectedEntry.code : '';
+
+  if (sanitizedCode !== currentCode) {
+    state.standardCode = sanitizedCode;
+  }
+
+  const displayName = selectedEntry
+    ? selectedEntry.name && selectedEntry.name.trim()
+      ? `${selectedEntry.code} — ${selectedEntry.name}`
+      : selectedEntry.code
+    : '';
+  state.standard = displayName;
+
+  if (standardSelect) {
+    if (sanitizedCode) {
+      standardSelect.value = sanitizedCode;
+    } else {
+      standardSelect.value = '';
+      if (standardSelect.options.length > 0) {
+        standardSelect.selectedIndex = 0;
+      }
+    }
+  }
+
+  if (connectorSeriesPickerButton) {
+    const label = connectorSeriesPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = connectorSeriesPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = connectorSeriesPickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = displayName || CONNECTOR_SERIES_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      const iconSrc = selectedEntry ? getConnectorSeriesImage(categoryId, selectedEntry.code) : '';
+      if (iconSrc) {
+        iconImage.src = iconSrc;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      connectorSeriesPickerButton.classList.remove('is-invalid');
+      connectorSeriesPickerButton.removeAttribute('aria-invalid');
+    } else {
+      connectorSeriesPickerButton.classList.add('is-invalid');
+      connectorSeriesPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (connectorSeriesPicker) {
+    connectorSeriesPicker.classList.toggle('is-invalid', !isValid);
+    connectorSeriesPicker.classList.toggle('is-disabled', series.length === 0);
+  }
+
+  if (connectorSeriesPickerList) {
+    const optionElements = Array.from(
+      connectorSeriesPickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedCode;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setConnectorSeriesSelection(nextCode, { triggerUpdate = true } = {}) {
+  if (state.hardwareType !== 'Connector') {
+    return;
+  }
+  const desiredCode = typeof nextCode === 'string' ? nextCode.trim() : '';
+  const categoryId = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+  const category = findConnectorCategory(categoryId);
+  const series = category && Array.isArray(category.series) ? category.series : [];
+  const selectedEntry = series.find(entry => entry.code === desiredCode) || null;
+  const sanitizedCode = selectedEntry ? selectedEntry.code : '';
+  const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
+
+  state.standardCode = sanitizedCode;
+  if (selectedEntry) {
+    state.standard = selectedEntry.name && selectedEntry.name.trim()
+      ? `${selectedEntry.code} — ${selectedEntry.name}`
+      : selectedEntry.code;
+  } else {
+    state.standard = '';
+  }
+
+  syncConnectorSeriesPicker({ isValid: true });
+
+  if (triggerUpdate && previousCode !== sanitizedCode) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function syncConnectorCategoryPicker({ isValid = true } = {}) {
+  const currentValue = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+  const sanitizedValue = validConnectorCategoryIds.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.connectorCategory = sanitizedValue;
+  }
+
+  if (connectorCategorySelect) {
+    connectorCategorySelect.value = sanitizedValue || '';
+    if (!sanitizedValue && connectorCategorySelect.options.length > 0) {
+      connectorCategorySelect.selectedIndex = 0;
+    }
+  }
+
+  const category = sanitizedValue ? findConnectorCategory(sanitizedValue) : null;
+  const iconSrc = sanitizedValue ? connectorCategoryImageMap[sanitizedValue] || '' : '';
+
+  if (connectorCategoryPickerButton) {
+    const label = connectorCategoryPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = connectorCategoryPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = connectorCategoryPickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = category ? category.label : CONNECTOR_CATEGORY_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (iconSrc) {
+        iconImage.src = iconSrc;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      connectorCategoryPickerButton.classList.remove('is-invalid');
+      connectorCategoryPickerButton.removeAttribute('aria-invalid');
+    } else {
+      connectorCategoryPickerButton.classList.add('is-invalid');
+      connectorCategoryPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (connectorCategoryPicker) {
+    connectorCategoryPicker.classList.toggle('is-invalid', !isValid);
+    const isDisabled = connectorCatalog.length === 0;
+    connectorCategoryPicker.classList.toggle('is-disabled', isDisabled);
+  }
+
+  if (connectorCategoryPickerList) {
+    const optionElements = Array.from(
+      connectorCategoryPickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setConnectorCategorySelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validConnectorCategoryIds.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+
+  state.connectorCategory = sanitizedValue;
+  syncConnectorCategoryPicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateConnectorCategoryUi();
+    populateStandards();
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
 export function populateConnectorCategories() {
   if (!connectorCategorySelect) {
     return;
   }
+
+  const previousValue = typeof state.connectorCategory === 'string' ? state.connectorCategory : '';
+
   connectorCategorySelect.innerHTML = '';
+  if (connectorCategoryPickerList) {
+    connectorCategoryPickerList.innerHTML = '';
+  }
+
   const placeholder = document.createElement('option');
   placeholder.value = '';
   placeholder.textContent = PLACEHOLDER_BLANK;
   placeholder.disabled = true;
-  placeholder.selected = !state.connectorCategory;
+  placeholder.selected = !previousValue;
   connectorCategorySelect.appendChild(placeholder);
+
   connectorCatalog.forEach(category => {
     const opt = document.createElement('option');
     opt.value = category.id;
     opt.textContent = category.label;
     connectorCategorySelect.appendChild(opt);
+
+    if (connectorCategoryPickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = category.id;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      const categoryIcon = connectorCategoryImageMap[category.id] || '';
+      if (categoryIcon) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image is-rotated-90';
+        image.src = categoryIcon;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = category.label;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      connectorCategoryPickerList.appendChild(item);
+    }
   });
-  connectorCategorySelect.value = state.connectorCategory || '';
+
+  const sanitizedValue = validConnectorCategoryIds.has(previousValue) ? previousValue : '';
+  state.connectorCategory = sanitizedValue;
+  connectorCategorySelect.value = sanitizedValue;
+  if (!sanitizedValue) {
+    placeholder.selected = true;
+  }
+
+  connectorCategorySelect.disabled = false;
+  connectorCategorySelect.title = 'Select connector category';
+  connectorCategorySelect.setAttribute('aria-required', 'true');
+
+  if (connectorCategoryPickerButton) {
+    const isDisabled = connectorCatalog.length === 0;
+    connectorCategoryPickerButton.disabled = isDisabled;
+    connectorCategoryPickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (connectorCategoryPickerList) {
+    connectorCategoryPickerList.hidden = true;
+  }
+  if (connectorCategoryPicker) {
+    connectorCategoryPicker.classList.remove('is-open');
+    connectorCategoryPicker.classList.toggle('is-disabled', connectorCatalog.length === 0);
+  }
+
+  syncConnectorCategoryPicker({ isValid: true });
 }
 
 function findBearingOption(code) {
@@ -2267,6 +2537,7 @@ function ensureConnectorCategory() {
   if (connectorCategorySelect) {
     connectorCategorySelect.value = state.connectorCategory || '';
   }
+  syncConnectorCategoryPicker({ isValid: true });
 }
 
 export function updateConnectorCategoryUi() {
@@ -2278,6 +2549,7 @@ export function updateConnectorCategoryUi() {
       connectorCategoryHelp.textContent = '';
       connectorCategoryHelp.classList.add('d-none');
     }
+    syncConnectorCategoryPicker({ isValid: true });
     notesInput.placeholder = defaultNotesPlaceholder;
     return;
   }
@@ -2285,6 +2557,7 @@ export function updateConnectorCategoryUi() {
   if (connectorCategorySelect) {
     connectorCategorySelect.value = state.connectorCategory || '';
   }
+  syncConnectorCategoryPicker({ isValid: true });
   if (connectorCategoryHelp) {
     if (category && category.help) {
       connectorCategoryHelp.textContent = category.help;
@@ -2297,6 +2570,7 @@ export function updateConnectorCategoryUi() {
   const example =
     category && category.example ? category.example : 'e.g., 3-pin JST-PH plug, 26 AWG leads';
   notesInput.placeholder = example;
+  syncConnectorSeriesPicker({ isValid: true });
 }
 
 export { populateThreadSizes, syncThreadSizePicker, setThreadSizeSelection };
@@ -3249,6 +3523,23 @@ function populateBoltOptions() {
 export function populateStandards() {
   const previousCode = typeof state.standardCode === 'string' ? state.standardCode : '';
 
+  if (connectorSeriesPicker) {
+    connectorSeriesPicker.classList.add('d-none');
+    connectorSeriesPicker.classList.remove('is-open');
+    connectorSeriesPicker.setAttribute('aria-hidden', 'true');
+  }
+  if (connectorSeriesPickerButton) {
+    connectorSeriesPickerButton.disabled = true;
+    connectorSeriesPickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (connectorSeriesPickerList) {
+    connectorSeriesPickerList.hidden = true;
+    connectorSeriesPickerList.innerHTML = '';
+  }
+  if (standardSelect) {
+    standardSelect.classList.remove('d-none');
+  }
+
   if (state.hardwareType === 'Bolt' || state.hardwareType === 'Screw') {
     standardFilterState.query = '';
     if (standardSelect) {
@@ -3355,6 +3646,20 @@ export function populateStandards() {
     placeholderText = CONNECTOR_PLACEHOLDER_TEXT;
     noOptionsText = 'No connector series available';
     titleText = 'Type to filter connector series (Esc clears filter)';
+
+    if (connectorSeriesPicker) {
+      connectorSeriesPicker.classList.remove('d-none');
+      connectorSeriesPicker.setAttribute('aria-hidden', 'false');
+      connectorSeriesPicker.classList.toggle('is-disabled', standards.length === 0);
+    }
+    if (connectorSeriesPickerButton) {
+      connectorSeriesPickerButton.disabled = standards.length === 0;
+      connectorSeriesPickerButton.setAttribute('aria-expanded', 'false');
+      connectorSeriesPickerButton.setAttribute('aria-labelledby', 'standard-field-label');
+    }
+    if (standardSelect) {
+      standardSelect.classList.add('d-none');
+    }
   } else {
     const subset = hardwareCatalog[state.hardwareType];
     standards = Array.isArray(subset) ? subset : [];
@@ -3393,6 +3698,40 @@ export function populateStandards() {
       opt.dataset.name = entry.name;
     }
     standardSelect.appendChild(opt);
+
+    if (state.hardwareType === 'Connector' && connectorSeriesPickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = entry.code;
+      item.dataset.name = entry.name || entry.code;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      const resolvedIcon = getConnectorSeriesImage(state.connectorCategory, entry.code);
+      if (resolvedIcon) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image is-rotated-90';
+        image.src = resolvedIcon;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = entry.name ? `${entry.code} — ${entry.name}` : entry.code;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      connectorSeriesPickerList.appendChild(item);
+    }
   });
   standardSelect.disabled = false;
   standardSelect.title = titleText;
@@ -3414,6 +3753,9 @@ export function populateStandards() {
   }
 
   filterStandardOptions('');
+  if (state.hardwareType === 'Connector') {
+    syncConnectorSeriesPicker({ isValid: true });
+  }
   updatePreview();
 }
 
@@ -3424,6 +3766,10 @@ export function filterStandardOptions(query) {
   const normalized = (query || '').trim().toLowerCase();
   let selectionCleared = false;
   let matchesFound = false;
+  const isConnectorType = state.hardwareType === 'Connector';
+  const connectorListOptions = isConnectorType && connectorSeriesPickerList
+    ? Array.from(connectorSeriesPickerList.querySelectorAll('[role="option"]'))
+    : [];
   Array.from(standardSelect.options).forEach(option => {
     if (!option.value) {
       option.hidden = false;
@@ -3440,6 +3786,14 @@ export function filterStandardOptions(query) {
     } else if (option.selected) {
       selectionCleared = true;
     }
+
+    if (connectorListOptions.length > 0) {
+      const listOption = connectorListOptions.find(item => item.dataset.value === option.value);
+      if (listOption) {
+        listOption.hidden = !matches;
+        listOption.style.display = matches ? '' : 'none';
+      }
+    }
   });
 
   if (selectionCleared) {
@@ -3450,6 +3804,10 @@ export function filterStandardOptions(query) {
       updatePreview();
     }
     updateDownloadState();
+  }
+
+  if (isConnectorType) {
+    syncConnectorSeriesPicker({ isValid: true });
   }
 
   const placeholder = standardSelect.querySelector('option[value=""]');

--- a/js/render.js
+++ b/js/render.js
@@ -12,12 +12,17 @@ import {
   syncBearingTypePicker,
   syncWasherTypePicker,
   syncNutTypePicker,
+  syncConnectorCategoryPicker,
+  syncConnectorSeriesPicker,
 } from './forms.js';
 import {
   pxPerMm,
   hardwareImageFolders,
   hardwareImageExtensions,
   findConnectorCategory,
+  connectorCategoryImageMap,
+  getConnectorSeriesImage,
+  hardwareTypeImageMap,
   boltHeadMap,
   boltDriveMap,
   nutTypeMap,
@@ -1137,12 +1142,14 @@ function applyValidationFeedback() {
       messageElement: connectorCategoryMessage,
       valid: categoryValid,
     });
+    syncConnectorCategoryPicker({ isValid: categoryValid });
     updateInputFieldState({
       input: notesInput,
       container: notesField,
       messageElement: connectorNotesMessage,
       valid: true,
     });
+    syncConnectorSeriesPicker({ isValid: true });
   } else {
     updateInputFieldState({
       input: connectorCategorySelect,
@@ -1150,6 +1157,8 @@ function applyValidationFeedback() {
       messageElement: connectorCategoryMessage,
       valid: true,
     });
+    syncConnectorCategoryPicker({ isValid: true });
+    syncConnectorSeriesPicker({ isValid: true });
     updateInputFieldState({
       input: notesInput,
       container: notesField,
@@ -1392,6 +1401,51 @@ function resolveHardwareImageInfo() {
       type: 'photo',
       src: imageSrc,
       alt,
+    };
+  }
+  if (state.hardwareType === 'Connector') {
+    const categoryId = (state.connectorCategory || '').trim();
+    const category = findConnectorCategory(categoryId);
+    const seriesCode = (state.standardCode || '').trim();
+    let imageSrc = '';
+    let altParts = [];
+
+    if (seriesCode) {
+      imageSrc = getConnectorSeriesImage(categoryId, seriesCode) || '';
+      if (seriesCode) {
+        altParts.push(seriesCode);
+      }
+      if (category && Array.isArray(category.series)) {
+        const seriesEntry = category.series.find(entry => entry.code === seriesCode);
+        if (seriesEntry && seriesEntry.name) {
+          altParts.push(seriesEntry.name);
+        }
+      }
+    }
+
+    if (!imageSrc && category) {
+      imageSrc = connectorCategoryImageMap[category.id] || '';
+      if (category.label) {
+        altParts.push(category.label);
+      }
+    }
+
+    if (!imageSrc) {
+      imageSrc = hardwareTypeImageMap.Connector || '';
+    }
+
+    if (!imageSrc) {
+      return null;
+    }
+
+    if (altParts.length === 0) {
+      altParts.push('Connector');
+    }
+
+    return {
+      type: 'photo',
+      src: imageSrc,
+      alt: `${altParts.join(' — ')} illustration`,
     };
   }
   if (state.hardwareType === 'Bolt') {


### PR DESCRIPTION
## Summary
- convert the connector category and series selectors into bolt-drive pickers with icon placeholders
- add data helpers to supply category art and per-series icons for pre-insulated crimps while rotating menu thumbnails
- update form syncing, events, and rendering to populate the new pickers and use the resolved connector imagery in the preview

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd15a07d20832981595cc21debd8d4