### PR TITLE
Update header branding with Poppins typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,11 +51,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Tagesschrift&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Barlow:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <script>
@@ -108,7 +104,14 @@
         </button>
       </div>
       <header class="title-section text-center mb-4">
-        <h1 class="display-5 fw-semibold">Gridfinity Label Maker</h1>
+        <div class="title-brand d-flex align-items-center justify-content-center gap-3 mb-2">
+          <img
+            src="images/icons/logo.svg"
+            class="title-logo"
+            alt="Gridfinity Label Maker logo"
+          />
+          <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
+        </div>
         <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
       </header>
       <div class="alert alert-warning d-flex align-items-center justify-content-center gap-2 mb-4" role="alert">

--- a/style.css
+++ b/style.css
@@ -94,6 +94,7 @@ body {
   text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 }
 
 main {
@@ -124,14 +125,25 @@ main {
   background-color: rgba(148, 163, 184, 0.2);
 }
 
-.title-section h1 {
-  font-family: 'Tagesschrift', sans-serif;
-  font-size: clamp(1.35rem, 6vw, 4.5rem);
-  line-height: 1.05;
+
+.title-brand {
+  flex-wrap: wrap;
+}
+
+.title-logo {
+  width: clamp(3rem, 10vw, 4.5rem);
+  height: auto;
+}
+
+.title-heading {
+  font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  font-size: clamp(1.75rem, 6vw, 3.25rem);
+  line-height: 1.1;
+  font-weight: 600;
 }
 
 .section-heading {
-  font-family: 'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   font-size: clamp(1.5rem, 2.5vw, 1.9rem);
 }
 


### PR DESCRIPTION
## Summary
- replace the old heading fonts with the Google-hosted Poppins family and apply it as the site default
- add the project logo beside the Gridfinity Label Maker title in the header
- style the new brand row so the logo and text align responsively across screen sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1b67757c8329a7c1805763e8f578