### PR TITLE
Hide unused bolt standard select and refresh headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
             <div class="card-body">
               <h2 class="h5 mb-3 section-heading">
                 <i class="fa-solid fa-puzzle-piece me-2" aria-hidden="true"></i>
-                Part Details
+                <span>Part Details</span>
               </h2>
               <div class="vstack gap-3">
                 <div>
@@ -1381,7 +1381,10 @@
       </div>
       <section class="preview-section card shadow-sm mt-4">
         <div class="card-body">
-          <h2 class="h5 mb-3 section-heading">Label Preview</h2>
+          <h2 class="h5 mb-3 section-heading">
+            <i class="fa-solid fa-eye me-2" aria-hidden="true"></i>
+            <span>Label Preview</span>
+          </h2>
           <div class="size-info text-muted small mb-3">
             <span
               id="preview-status-text"

--- a/js/forms.js
+++ b/js/forms.js
@@ -4175,16 +4175,22 @@ export function onHardwareTypeChange() {
     } else {
       standardLabel.textContent = defaultStandardLabel;
     }
-    standardLabel.setAttribute('for', showFastenerFields ? 'bolt-head-select' : 'standard-select');
+    const hideStandardLabel = showFastenerFields || showFuseFields || showNutFields;
+    standardLabel.classList.toggle('d-none', hideStandardLabel);
+    standardLabel.setAttribute('for', hideStandardLabel ? 'bolt-head-select' : 'standard-select');
   }
   if (standardSelect) {
     const hideStandardSelect = showFastenerFields || showFuseFields || showNutFields;
     standardSelect.classList.toggle('d-none', hideStandardSelect);
+    standardSelect.hidden = hideStandardSelect;
     if (hideStandardSelect) {
       standardSelect.disabled = true;
       standardSelect.setAttribute('aria-hidden', 'true');
       standardSelect.setAttribute('aria-required', 'false');
     } else {
+      standardSelect.disabled = false;
+      standardSelect.hidden = false;
+      standardSelect.removeAttribute('hidden');
       standardSelect.setAttribute('aria-hidden', 'false');
       standardSelect.removeAttribute('aria-required');
     }

--- a/style.css
+++ b/style.css
@@ -145,6 +145,12 @@ main {
 .section-heading {
   font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   font-size: clamp(1.5rem, 2.5vw, 1.9rem);
+  font-weight: 600;
+}
+
+.section-heading span {
+  font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: inherit;
 }
 
 .field-help {


### PR DESCRIPTION
## Summary
- hide the unused hardware standard dropdown whenever fastener-specific controls are shown
- restyle the section headings with consistent Poppins typography and add an eye icon to the label preview header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dd200264d483298d7e63440d14a6ec