### PR TITLE
Keep fastener drive controls while hiding unused standard select

### DIFF
--- a/index.html
+++ b/index.html
@@ -1057,7 +1057,7 @@
                     </div>
                   </div>
                 </div>
-                <div id="standard-field">
+                <div id="standard-field" class="d-none">
                   <label
                     for="standard-select"
                     class="form-label fw-semibold visually-hidden"

--- a/js/forms.js
+++ b/js/forms.js
@@ -4166,7 +4166,11 @@ export function onHardwareTypeChange() {
   if (standardField) {
     standardField.classList.toggle(
       'd-none',
-      showCustomFields || showBearingFields || showComponentFields || showFuseFields || showNutFields,
+      showCustomFields ||
+        showBearingFields ||
+        showComponentFields ||
+        showFuseFields ||
+        showNutFields,
     );
   }
   if (standardLabel) {


### PR DESCRIPTION
## Summary
- keep the hardware standard field container visible for fasteners so drive/head controls remain available
- continue to hide the unused hardware standard select when fastener-specific fields are active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd22f4efcc83298bcf88b410a85a4f