### PR TITLE
Adjust header logo for dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@
                           role="group"
                           aria-label="Filter part types by category"
                         ></div>
+                        <!--
                         <section
                           class="part-type-picker__recent"
                           id="hardware-type-picker-recent-section"
@@ -281,6 +282,7 @@
                             aria-label="Recently used part types"
                           ></div>
                         </section>
+                        -->
                         <p class="part-type-picker__empty" id="hardware-type-picker-empty" hidden>
                           No part types match your filters.
                         </p>

--- a/style.css
+++ b/style.css
@@ -135,6 +135,10 @@ main {
   height: auto;
 }
 
+:root[data-theme='dark'] .title-logo {
+  filter: brightness(0) invert(1);
+}
+
 .title-heading {
   font-family: 'Poppins', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   font-size: clamp(1.75rem, 6vw, 3.25rem);


### PR DESCRIPTION
## Summary
- update the header logo styling so it inverts for better contrast in dark mode
- comment out the recently used section in the part type picker modal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2a2404cc8329b9dd70ec8264fb0c