### PR TITLE
Add collapsible cards with persistent toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,13 +120,31 @@
       </div>
       <div class="row g-4">
         <section class="form-section col-lg-7">
-          <div class="card shadow-sm h-100">
+          <div
+            class="card shadow-sm h-100"
+            data-collapsible="part-details"
+            data-collapsible-label="Part Details"
+          >
             <div class="card-body">
-              <h2 class="h5 mb-3 section-heading">
-                <i class="fa-solid fa-puzzle-piece me-2" aria-hidden="true"></i>
-                <span>Part Details</span>
-              </h2>
-              <div class="vstack gap-3">
+              <div class="collapsible-section-header d-flex align-items-center justify-content-between gap-2 mb-3">
+                <h2 class="h5 mb-0 section-heading d-flex align-items-center">
+                  <i class="fa-solid fa-puzzle-piece me-2" aria-hidden="true"></i>
+                  <span>Part Details</span>
+                </h2>
+                <button
+                  type="button"
+                  class="section-toggle-button"
+                  data-collapsible-toggle
+                  aria-expanded="true"
+                  aria-controls="part-details-content"
+                  aria-label="Collapse Part Details"
+                  title="Collapse Part Details"
+                >
+                  <i class="fa-solid fa-chevron-up section-toggle-icon" aria-hidden="true"></i>
+                </button>
+              </div>
+              <div class="collapsible-content" id="part-details-content" data-collapsible-content>
+                <div class="vstack gap-3">
                 <div>
                   <label
                     class="form-label fw-semibold"
@@ -1209,13 +1227,35 @@
           </div>
         </section>
         <section class="settings-section col-lg-5">
-          <div class="card shadow-sm h-100">
+          <div
+            class="card shadow-sm h-100"
+            data-collapsible="label-settings"
+            data-collapsible-label="Label Settings"
+          >
             <div class="card-body">
-              <h2 class="h5 mb-3 section-heading">
-                <i class="fa-solid fa-gear me-2" aria-hidden="true"></i>
-                <span>Label Settings</span>
-              </h2>
-              <div class="vstack gap-3">
+              <div class="collapsible-section-header d-flex align-items-center justify-content-between gap-2 mb-3">
+                <h2 class="h5 mb-0 section-heading d-flex align-items-center">
+                  <i class="fa-solid fa-gear me-2" aria-hidden="true"></i>
+                  <span>Label Settings</span>
+                </h2>
+                <button
+                  type="button"
+                  class="section-toggle-button"
+                  data-collapsible-toggle
+                  aria-expanded="true"
+                  aria-controls="label-settings-content"
+                  aria-label="Collapse Label Settings"
+                  title="Collapse Label Settings"
+                >
+                  <i class="fa-solid fa-chevron-up section-toggle-icon" aria-hidden="true"></i>
+                </button>
+              </div>
+              <div
+                class="collapsible-content"
+                id="label-settings-content"
+                data-collapsible-content
+              >
+                <div class="vstack gap-3">
                 <div
                   class="d-flex align-items-center justify-content-between p-3 rounded-4 border bg-body-secondary"
                 >
@@ -1381,36 +1421,55 @@
           </div>
         </section>
       </div>
-      <section class="preview-section card shadow-sm mt-4">
+      <section
+        class="preview-section card shadow-sm mt-4"
+        data-collapsible="label-preview"
+        data-collapsible-label="Label Preview"
+      >
         <div class="card-body">
-          <h2 class="h5 mb-3 section-heading">
-            <i class="fa-solid fa-eye me-2" aria-hidden="true"></i>
-            <span>Label Preview</span>
-          </h2>
-          <div class="size-info text-muted small mb-3">
-            <span
-              id="preview-status-text"
-              class="visually-hidden"
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
-            ></span>
-            <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
-            <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+          <div class="collapsible-section-header d-flex align-items-center justify-content-between gap-2 mb-3">
+            <h2 class="h5 mb-0 section-heading d-flex align-items-center">
+              <i class="fa-solid fa-eye me-2" aria-hidden="true"></i>
+              <span>Label Preview</span>
+            </h2>
+            <button
+              type="button"
+              class="section-toggle-button"
+              data-collapsible-toggle
+              aria-expanded="true"
+              aria-controls="label-preview-content"
+              aria-label="Collapse Label Preview"
+              title="Collapse Label Preview"
+            >
+              <i class="fa-solid fa-chevron-up section-toggle-icon" aria-hidden="true"></i>
+            </button>
           </div>
-          <div class="label-preview-viewport">
-            <div id="preview-container" class="label-preview">
-              <div id="preview-placeholder" class="preview-placeholder">
-                <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
-                <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
+          <div class="collapsible-content" id="label-preview-content" data-collapsible-content>
+            <div class="size-info text-muted small mb-3">
+              <span
+                id="preview-status-text"
+                class="visually-hidden"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              ></span>
+              <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
+              <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+            </div>
+            <div class="label-preview-viewport">
+              <div id="preview-container" class="label-preview">
+                <div id="preview-placeholder" class="preview-placeholder">
+                  <i class="fa-solid fa-clipboard-list placeholder-icon" aria-hidden="true"></i>
+                  <p class="placeholder-text mb-0">Fill out the form to generate a label</p>
+                </div>
+                <img
+                  id="label-preview-image"
+                  class="label-preview-image"
+                  alt="Gridfinity label preview"
+                  decoding="async"
+                  aria-hidden="true"
+                />
               </div>
-              <img
-                id="label-preview-image"
-                class="label-preview-image"
-                alt="Gridfinity label preview"
-                decoding="async"
-                aria-hidden="true"
-              />
             </div>
           </div>
         </div>

--- a/js/collapsible-sections.js
+++ b/js/collapsible-sections.js
@@ -1,0 +1,222 @@
+const STORAGE_KEY = 'gridfinity-collapsible-sections';
+const MOBILE_BREAKPOINT_QUERY = '(max-width: 768px)';
+const sections = new Map();
+const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+let storedStates = {};
+
+function loadStoredStates() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    // Ignore storage access errors and fall back to defaults.
+  }
+  return {};
+}
+
+function persistStates() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storedStates));
+  } catch {
+    // Ignore storage write errors to avoid breaking the UI when storage is unavailable.
+  }
+}
+
+function saveState(id, expanded) {
+  storedStates[id] = expanded;
+  persistStates();
+}
+
+function cancelOngoingAnimation(content) {
+  if (typeof content._collapsibleCleanup === 'function') {
+    content._collapsibleCleanup();
+  }
+}
+
+function animateSection(content, expand) {
+  cancelOngoingAnimation(content);
+
+  if (reduceMotionQuery.matches) {
+    content.hidden = !expand;
+    content.style.maxHeight = '';
+    content.style.opacity = '';
+    content.style.overflow = '';
+    content._collapsibleCleanup = undefined;
+    return;
+  }
+
+  content.style.overflow = 'hidden';
+
+  if (expand) {
+    content.hidden = false;
+    content.style.opacity = '0';
+    content.style.maxHeight = '0px';
+    const fullHeight = content.scrollHeight;
+    requestAnimationFrame(() => {
+      content.style.maxHeight = `${fullHeight}px`;
+      content.style.opacity = '1';
+    });
+  } else {
+    const fullHeight = content.scrollHeight;
+    content.style.maxHeight = `${fullHeight}px`;
+    content.style.opacity = '1';
+    requestAnimationFrame(() => {
+      content.style.maxHeight = '0px';
+      content.style.opacity = '0';
+    });
+  }
+
+  const onTransitionEnd = event => {
+    if (event.target !== content || event.propertyName !== 'max-height') {
+      return;
+    }
+    content.removeEventListener('transitionend', onTransitionEnd);
+    if (!expand) {
+      content.hidden = true;
+    }
+    content.style.maxHeight = '';
+    content.style.opacity = '';
+    content.style.overflow = '';
+    content._collapsibleCleanup = undefined;
+  };
+
+  content._collapsibleCleanup = () => {
+    content.removeEventListener('transitionend', onTransitionEnd);
+    if (!expand) {
+      content.hidden = true;
+    }
+    content.style.maxHeight = '';
+    content.style.opacity = '';
+    content.style.overflow = '';
+    content._collapsibleCleanup = undefined;
+  };
+
+  content.addEventListener('transitionend', onTransitionEnd);
+}
+
+function updateToggleLabel(toggle, label, expanded) {
+  const action = expanded ? 'Collapse' : 'Expand';
+  const message = `${action} ${label}`;
+  toggle.setAttribute('aria-label', message);
+  toggle.setAttribute('title', message);
+}
+
+function applySectionState(sectionData, expanded, options = {}) {
+  const { animate = true, save = true } = options;
+  const { id, section, toggle, content, label } = sectionData;
+  const currentlyExpanded = toggle.getAttribute('aria-expanded') === 'true';
+
+  toggle.setAttribute('aria-expanded', String(expanded));
+  content.setAttribute('aria-hidden', String(!expanded));
+  section.classList.toggle('is-collapsed', !expanded);
+  updateToggleLabel(toggle, label, expanded);
+
+  if (currentlyExpanded === expanded) {
+    cancelOngoingAnimation(content);
+    content.hidden = !expanded;
+    content.style.maxHeight = '';
+    content.style.opacity = '';
+    content.style.overflow = '';
+    if (save) {
+      saveState(id, expanded);
+    }
+    return;
+  }
+
+  if (animate) {
+    animateSection(content, expanded);
+  } else {
+    cancelOngoingAnimation(content);
+    content.hidden = !expanded;
+    content.style.maxHeight = '';
+    content.style.opacity = '';
+    content.style.overflow = '';
+  }
+
+  if (save) {
+    saveState(id, expanded);
+  }
+}
+
+function deriveLabel(section, fallback) {
+  const primary = section.querySelector('.section-heading span');
+  if (primary && primary.textContent) {
+    const text = primary.textContent.trim();
+    if (text) {
+      return text;
+    }
+  }
+  const heading = section.querySelector('.section-heading');
+  if (heading && heading.textContent) {
+    const text = heading.textContent.trim();
+    if (text) {
+      return text;
+    }
+  }
+  return fallback;
+}
+
+function registerSection(section, defaultExpanded) {
+  const id = section.getAttribute('data-collapsible');
+  const toggle = section.querySelector('[data-collapsible-toggle]');
+  const content = section.querySelector('[data-collapsible-content]');
+
+  if (!id || !toggle || !content) {
+    return;
+  }
+
+  if (!content.id) {
+    content.id = `${id}-content`;
+  }
+
+  toggle.setAttribute('aria-controls', content.id);
+
+  const label = section.getAttribute('data-collapsible-label')
+    || toggle.getAttribute('data-collapsible-label')
+    || deriveLabel(section, id);
+
+  const sectionData = { id, section, toggle, content, label };
+  sections.set(id, sectionData);
+
+  const hasStoredState = Object.prototype.hasOwnProperty.call(storedStates, id);
+  const initialExpanded = hasStoredState ? Boolean(storedStates[id]) : defaultExpanded;
+
+  applySectionState(sectionData, initialExpanded, { animate: false, save: hasStoredState });
+
+  toggle.addEventListener('click', event => {
+    event.preventDefault();
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    applySectionState(sectionData, !expanded);
+  });
+}
+
+function initCollapsibleSections() {
+  storedStates = loadStoredStates();
+  const defaultExpanded = !window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches;
+  const sectionElements = document.querySelectorAll('[data-collapsible]');
+  sectionElements.forEach(section => registerSection(section, defaultExpanded));
+}
+
+function expandAllCollapsibleSections({ animate = true } = {}) {
+  sections.forEach(sectionData => {
+    applySectionState(sectionData, true, { animate, save: true });
+  });
+}
+
+function collapseAllCollapsibleSections({ animate = true } = {}) {
+  sections.forEach(sectionData => {
+    applySectionState(sectionData, false, { animate, save: true });
+  });
+}
+
+export {
+  initCollapsibleSections,
+  expandAllCollapsibleSections,
+  collapseAllCollapsibleSections,
+};

--- a/js/controls.js
+++ b/js/controls.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { elements } from './dom-elements.js';
 import { initTheme } from './theme.js';
+import { initCollapsibleSections } from './collapsible-sections.js';
 import {
   populateFuseValues,
   populateFuseTypePicker,
@@ -35,6 +36,7 @@ import {
 import { updateDownloadState, updateQrContentVisibility, updatePreview } from './render.js';
 import { initEventHandlers } from './events.js';
 import { hydrateStateFromUrl } from './url-state.js';
+export { expandAllCollapsibleSections, collapseAllCollapsibleSections } from './collapsible-sections.js';
 
 function applyStateToControls() {
   const {
@@ -141,6 +143,7 @@ function applyStateToControls() {
 
 function init() {
   initTheme();
+  initCollapsibleSections();
   hydrateStateFromUrl();
   populateFuseValues();
   populateFuseTypePicker();

--- a/style.css
+++ b/style.css
@@ -157,6 +157,70 @@ main {
   font-weight: inherit;
 }
 
+.collapsible-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.is-collapsed .collapsible-section-header {
+  margin-bottom: 0;
+}
+
+.section-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--theme-toggle-border);
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.section-toggle-button:hover {
+  background-color: var(--theme-toggle-bg-hover);
+}
+
+.section-toggle-button:focus-visible {
+  outline: var(--focus-outline-width) solid var(--focus-ring-border);
+  outline-offset: var(--focus-outline-offset);
+  box-shadow: 0 0 0 0.2rem var(--theme-toggle-focus-ring);
+}
+
+.section-toggle-icon {
+  transition: transform 0.2s ease;
+}
+
+.section-toggle-button[aria-expanded='false'] .section-toggle-icon {
+  transform: rotate(180deg);
+}
+
+[data-collapsible-content] {
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
+  will-change: max-height;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-collapsible-content] {
+    transition: none;
+  }
+
+  .section-toggle-icon {
+    transition: none;
+  }
+}
+
 .field-help {
   border-radius: 0.9rem;
   border: 1px solid var(--field-help-border);


### PR DESCRIPTION
## Summary
- add accessible toggle controls to the Part Details, Label Settings, and Label Preview cards with mobile-first defaults
- persist each section's state in localStorage and expose helpers to expand or collapse all cards at once
- style the collapsible headers and animate transitions without disturbing existing card layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd30176ce083298f1fe28663fb8581