### PR TITLE
Fix clipped validation outline in collapsible sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -206,7 +206,13 @@ main {
 }
 
 [data-collapsible-content] {
-  overflow: hidden;
+  /*
+   * Allow validation outlines and other visual affordances to render fully
+   * when sections are expanded. The JavaScript animation logic toggles
+   * `overflow: hidden` inline during transitions, so the default can safely be
+   * visible without affecting the collapse behavior.
+   */
+  overflow: visible;
   transition: max-height 0.25s ease, opacity 0.2s ease;
   will-change: max-height;
 }


### PR DESCRIPTION
## Summary
- default collapsible section content to `overflow: visible` so validation rings are not clipped
- document why the new default does not interfere with the existing open/close animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd3559adbc8329a2295373593bb31b