### PR TITLE
Fix bearing icons across bearing workflow

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -399,6 +399,7 @@ export const hardwareTypeImageMap = {
   Connector: 'images/connectors/connector.svg',
   Resistor: 'images/resistors/resistor_through_hole.svg',
   Capacitor: 'images/capacitors/capacitor_through_hole.svg',
+  Bearing: 'images/bearings/bearing.svg',
   Washer: 'images/washers/plain_washer.svg',
   Diode: 'images/diodes/diode_through_hole.svg',
 };

--- a/js/forms.js
+++ b/js/forms.js
@@ -2486,22 +2486,10 @@ export function populateBearingOptions() {
       item.setAttribute('role', 'option');
       item.tabIndex = -1;
 
-      const icon = document.createElement('span');
-      icon.className = 'bolt-drive-picker__option-icon';
-
-      const image = document.createElement('img');
-      image.className = 'bolt-drive-picker__option-icon-image';
-      image.src = 'images/bearings/bearing.svg';
-      image.alt = '';
-      image.loading = 'lazy';
-      image.decoding = 'async';
-      icon.appendChild(image);
-
       const label = document.createElement('span');
       label.className = 'bolt-drive-picker__option-label';
       label.textContent = `${option.code} — ${option.description}`;
 
-      item.appendChild(icon);
       item.appendChild(label);
 
       bearingTypePickerList.appendChild(item);

--- a/js/render.js
+++ b/js/render.js
@@ -1527,6 +1527,26 @@ function resolveHardwareImageInfo() {
       alt: 'Threaded heat insert reference illustration',
     };
   }
+  if (state.hardwareType === 'Bearing') {
+    const bearingCode = (state.bearingType || '').trim();
+    const bearingDescription = (state.bearingDetails || '').trim();
+    const altParts = [];
+    if (bearingCode) {
+      altParts.push(bearingCode);
+    }
+    if (bearingDescription && bearingDescription.toLowerCase() !== bearingCode.toLowerCase()) {
+      altParts.push(bearingDescription);
+    }
+    const altText =
+      altParts.length > 0
+        ? `${altParts.join(' — ')} bearing illustration`
+        : 'Bearing reference illustration';
+    return {
+      type: 'photo',
+      src: 'images/bearings/bearing.svg',
+      alt: altText,
+    };
+  }
   if (state.hardwareType === 'Washer') {
     const typeId = (state.washerType || '').trim();
     const typeEntry = washerTypeMap.get(typeId);


### PR DESCRIPTION
## Summary
- add bearing imagery to the part type picker and label rendering pipeline
- remove redundant bearing icons from each entry in the bearing type dropdown
- ensure bearing metadata informs the preview image alt text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd3893bd908329ac98c22fb4d86884