### PR TITLE
Improve owner-focused usage analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ include:
 - Download-and-print flows that use a shared SVG renderer to keep the preview
   and exported artwork in sync.
 - Shareable label URLs with Web Share API support and clipboard fallback.
+- Local usage analytics that surface your most frequently generated labels for
+  the current day, week, month, and year.
 
 The repository is structured as a traditional GitHub Pages site, making it easy
 to host the tool directly from the `main` branch.
@@ -81,6 +83,15 @@ native share sheets on mobile and desktop. Browsers without Web Share support
 fall back to copying the link to the clipboard and display a confirmation
 message. Opening a shared URL pre-populates the form and preview so the label is
 ready to review, print, or export without additional input.
+
+## Usage Stats
+
+Visit [`stats.html`](stats.html) or use the **Open usage dashboard (local only)**
+link in the app header to review activity summaries. The owner-facing dashboard
+counts every label you download or print, aggregates them by design, surfaces
+custom-label wording, and highlights the most popular entries for the current
+day, week, month, and year. All usage data stays in your browser—no information
+leaves your device.
 
 ## Development Workflow and Version Control Safeguards
 

--- a/index.html
+++ b/index.html
@@ -113,6 +113,12 @@
           <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
         </div>
         <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
+        <div class="mt-3">
+          <a class="btn btn-outline-primary btn-sm" href="stats.html">
+            <i class="fa-solid fa-chart-line me-1" aria-hidden="true"></i>
+            Open usage dashboard (local only)
+          </a>
+        </div>
       </header>
       <div class="alert alert-warning d-flex align-items-center justify-content-center gap-3 mb-4" role="alert">
         <i class="fa-solid fa-person-digging fa-2xl" aria-hidden="true"></i>

--- a/js/actions.js
+++ b/js/actions.js
@@ -2,6 +2,15 @@ import { state } from './state.js';
 import { findConnectorCategory, boltHeadMap, boltDriveMap, screwTypeMap } from './data.js';
 import { renderLabelPng } from './render.js';
 import { buildShareUrl } from './url-state.js';
+import { recordLabelUsage } from './usage-stats.js';
+
+function captureStateSnapshot() {
+  try {
+    return structuredClone(state);
+  } catch {
+    return JSON.parse(JSON.stringify(state));
+  }
+}
 
 async function copyLinkToClipboard(link) {
   if (
@@ -61,8 +70,9 @@ function formatTimestamp(date) {
 }
 
 export function downloadLabel() {
+  const labelSnapshot = captureStateSnapshot();
   renderLabelPng()
-    .then(({ blob }) => {
+    .then(({ blob, svgMarkup }) => {
       const link = document.createElement('a');
       const objectUrl = URL.createObjectURL(blob);
       link.href = objectUrl;
@@ -164,6 +174,7 @@ export function downloadLabel() {
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(objectUrl);
+      recordLabelUsage('download', { snapshot: labelSnapshot, svgMarkup });
     })
     .catch(err => {
       console.error('Label download failed', err);
@@ -172,6 +183,7 @@ export function downloadLabel() {
 }
 
 export function printLabel() {
+  const labelSnapshot = captureStateSnapshot();
   const printWindow = window.open('', '_blank', 'width=800,height=600');
   if (!printWindow) {
     alert('Please allow pop-ups to print the label.');
@@ -216,7 +228,7 @@ export function printLabel() {
     img.style.imageRendering = 'pixelated';
   }
   renderLabelPng()
-    .then(({ blob, widthPx, heightPx }) => {
+    .then(({ blob, widthPx, heightPx, svgMarkup }) => {
       if (!(img instanceof HTMLImageElement)) {
         throw new Error('Print image element was not created.');
       }
@@ -244,6 +256,7 @@ export function printLabel() {
         { once: true },
       );
       img.src = objectUrl;
+      recordLabelUsage('print', { snapshot: labelSnapshot, svgMarkup });
     })
     .catch(err => {
       console.error('Print preview generation failed', err);

--- a/js/stats-page.js
+++ b/js/stats-page.js
@@ -1,0 +1,695 @@
+import { initTheme } from './theme.js';
+import { getUsageEntries, computeTopLabels } from './usage-stats.js';
+
+const PERIOD_DEFINITIONS = [
+  {
+    id: 'today',
+    title: 'Today',
+    description: 'Labels generated since midnight.',
+    start: startOfToday,
+  },
+  {
+    id: 'week',
+    title: 'This Week',
+    description: 'Activity since the start of this week.',
+    start: startOfWeek,
+  },
+  {
+    id: 'month',
+    title: 'This Month',
+    description: 'Downloads or prints during the current month.',
+    start: startOfMonth,
+  },
+  {
+    id: 'year',
+    title: 'This Year',
+    description: 'Your most popular labels of the year.',
+    start: startOfYear,
+  },
+];
+
+const TOP_LABEL_LIMIT = 5;
+const MAX_CUSTOM_GROUPS = 20;
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+
+  const entries = getUsageEntries();
+  const summaryContainer = document.getElementById('stats-summary-cards');
+  const emptyMessage = document.getElementById('stats-empty-message');
+  const periodsContainer = document.getElementById('stats-periods');
+  const hardwareSection = document.getElementById('stats-hardware-section');
+  const hardwareTableBody = document.getElementById('stats-hardware-tbody');
+  const customSection = document.getElementById('stats-custom-section');
+  const customGrid = document.getElementById('stats-custom-grid');
+  const customEmptyMessage = document.getElementById('stats-custom-empty');
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    if (summaryContainer) {
+      summaryContainer.innerHTML = '';
+    }
+    if (emptyMessage) {
+      emptyMessage.textContent =
+        'No download or print activity recorded yet. Stats will populate after you export a label from this browser.';
+    }
+    return;
+  }
+
+  const summary = computeSummary(entries);
+
+  if (summaryContainer) {
+    renderSummary(summary, summaryContainer);
+  }
+
+  if (emptyMessage) {
+    const lastActivity = summary.latestTimestamp
+      ? ` Last recorded activity: ${formatTimestamp(summary.latestTimestamp)}.`
+      : '';
+    emptyMessage.textContent =
+      'Stats are stored locally in this browser. Downloading or printing new labels updates the dashboard automatically.' +
+      lastActivity;
+  }
+
+  if (hardwareSection && hardwareTableBody) {
+    renderHardwareBreakdown(entries, hardwareSection, hardwareTableBody);
+  }
+
+  if (customSection && customGrid && customEmptyMessage) {
+    renderCustomLabelGroups(entries, customSection, customGrid, customEmptyMessage);
+  }
+
+  if (periodsContainer) {
+    periodsContainer.hidden = false;
+    renderPeriods(entries, periodsContainer);
+  }
+});
+
+function computeSummary(entries) {
+  const uniqueKeys = new Set();
+  let total = 0;
+  let downloadCount = 0;
+  let printCount = 0;
+  let latestTimestamp = 0;
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    total += 1;
+    if (entry.key) {
+      uniqueKeys.add(entry.key);
+    }
+    if (entry.eventType === 'print') {
+      printCount += 1;
+    } else {
+      downloadCount += 1;
+    }
+    if (Number.isFinite(entry.timestamp) && entry.timestamp > latestTimestamp) {
+      latestTimestamp = entry.timestamp;
+    }
+  }
+
+  return {
+    total,
+    downloadCount,
+    printCount,
+    uniqueLabelCount: uniqueKeys.size,
+    latestTimestamp,
+  };
+}
+
+function renderSummary(summary, container) {
+  container.innerHTML = '';
+  const cards = [
+    {
+      label: 'Total uses',
+      value: formatNumber(summary.total),
+      hint: 'Download and print events combined.',
+    },
+    {
+      label: 'Downloads',
+      value: formatNumber(summary.downloadCount),
+    },
+    {
+      label: 'Prints',
+      value: formatNumber(summary.printCount),
+    },
+    {
+      label: 'Unique designs',
+      value: formatNumber(summary.uniqueLabelCount),
+    },
+  ];
+
+  for (const cardData of cards) {
+    const col = document.createElement('div');
+    col.className = 'col-12 col-sm-6 col-lg-3';
+
+    const card = document.createElement('article');
+    card.className = 'stats-summary-card card shadow-sm h-100';
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+
+    const labelEl = document.createElement('p');
+    labelEl.className = 'stats-summary-label text-muted text-uppercase fw-semibold small mb-1';
+    labelEl.textContent = cardData.label;
+    body.append(labelEl);
+
+    const valueEl = document.createElement('p');
+    valueEl.className = 'stats-summary-value fs-2 fw-semibold mb-0';
+    valueEl.textContent = cardData.value;
+    body.append(valueEl);
+
+    if (cardData.hint) {
+      const hintEl = document.createElement('p');
+      hintEl.className = 'text-muted small mb-0';
+      hintEl.textContent = cardData.hint;
+      body.append(hintEl);
+    }
+
+    card.append(body);
+    col.append(card);
+    container.append(col);
+  }
+}
+
+function renderHardwareBreakdown(entries, section, tableBody) {
+  const breakdown = aggregateByHardwareType(entries);
+  if (breakdown.length === 0) {
+    section.hidden = true;
+    tableBody.innerHTML = '';
+    return;
+  }
+
+  section.hidden = false;
+  tableBody.innerHTML = '';
+
+  for (const item of breakdown) {
+    const row = document.createElement('tr');
+
+    const typeCell = document.createElement('th');
+    typeCell.scope = 'row';
+    typeCell.textContent = item.label;
+    row.append(typeCell);
+
+    const totalCell = document.createElement('td');
+    totalCell.className = 'text-end';
+    totalCell.textContent = formatNumber(item.count);
+    row.append(totalCell);
+
+    const downloadCell = document.createElement('td');
+    downloadCell.className = 'text-end';
+    downloadCell.textContent = formatNumber(item.downloadCount);
+    row.append(downloadCell);
+
+    const printCell = document.createElement('td');
+    printCell.className = 'text-end';
+    printCell.textContent = formatNumber(item.printCount);
+    row.append(printCell);
+
+    const lastCell = document.createElement('td');
+    lastCell.className = 'text-muted';
+    lastCell.textContent = item.latestTimestamp ? formatTimestamp(item.latestTimestamp) : '—';
+    row.append(lastCell);
+
+    tableBody.append(row);
+  }
+}
+
+function aggregateByHardwareType(entries) {
+  const aggregated = new Map();
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const snapshot = entry.snapshot || {};
+    const hardwareTypeRaw = typeof snapshot.hardwareType === 'string' ? snapshot.hardwareType.trim() : '';
+    const hardwareType = hardwareTypeRaw || 'Unspecified';
+    const key = hardwareType.toLowerCase();
+    const group =
+      aggregated.get(key) || {
+        key,
+        label: hardwareType,
+        count: 0,
+        downloadCount: 0,
+        printCount: 0,
+        latestTimestamp: 0,
+      };
+
+    group.count += 1;
+    if (entry.eventType === 'print') {
+      group.printCount += 1;
+    } else {
+      group.downloadCount += 1;
+    }
+    if (Number.isFinite(entry.timestamp) && entry.timestamp > group.latestTimestamp) {
+      group.latestTimestamp = entry.timestamp;
+    }
+
+    aggregated.set(key, group);
+  }
+
+  const results = Array.from(aggregated.values());
+  results.sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    return b.latestTimestamp - a.latestTimestamp;
+  });
+
+  return results;
+}
+
+function renderCustomLabelGroups(entries, section, grid, emptyMessage) {
+  const groups = collectCustomLabelGroups(entries);
+  grid.innerHTML = '';
+  const existingNotice = section.querySelector('.stats-custom-overflow');
+  if (existingNotice) {
+    existingNotice.remove();
+  }
+
+  if (groups.length === 0) {
+    section.hidden = false;
+    emptyMessage.hidden = false;
+    return;
+  }
+
+  section.hidden = false;
+  emptyMessage.hidden = true;
+
+  for (const group of groups.slice(0, MAX_CUSTOM_GROUPS)) {
+    grid.append(buildCustomLabelCard(group));
+  }
+
+  if (groups.length > MAX_CUSTOM_GROUPS) {
+    const overflowNotice = document.createElement('p');
+    overflowNotice.className = 'text-muted small mt-3 mb-0 stats-custom-overflow';
+    overflowNotice.textContent = `Showing the ${MAX_CUSTOM_GROUPS} most-used custom designs.`;
+    section.append(overflowNotice);
+  }
+}
+
+function collectCustomLabelGroups(entries) {
+  const groups = new Map();
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const snapshot = entry.snapshot || {};
+    const hardwareType = typeof snapshot.hardwareType === 'string' ? snapshot.hardwareType.trim() : '';
+    if (hardwareType.toLowerCase() !== 'custom') {
+      continue;
+    }
+    const line1 = normalizeLine(snapshot.customLine1);
+    const line2 = normalizeLine(snapshot.customLine2);
+    const key = `${line1}|||${line2}`;
+    const group =
+      groups.get(key) || {
+        line1,
+        line2,
+        count: 0,
+        downloadCount: 0,
+        printCount: 0,
+        latestTimestamp: 0,
+        svgMarkup: '',
+        eventTypes: new Set(),
+        notes: new Set(),
+        sizes: new Set(),
+        snapshot: null,
+      };
+
+    group.count += 1;
+    if (entry.eventType === 'print') {
+      group.printCount += 1;
+    } else {
+      group.downloadCount += 1;
+    }
+    group.eventTypes.add(entry.eventType === 'print' ? 'print' : 'download');
+
+    const timestamp = Number.isFinite(entry.timestamp) ? entry.timestamp : 0;
+    if (timestamp > group.latestTimestamp) {
+      group.latestTimestamp = timestamp;
+      group.svgMarkup = typeof entry.svgMarkup === 'string' ? entry.svgMarkup : group.svgMarkup;
+      group.snapshot = entry.snapshot || group.snapshot;
+    }
+
+    const sizeLabel = formatDimensions(snapshot.widthMm, snapshot.heightMm);
+    if (sizeLabel) {
+      group.sizes.add(sizeLabel);
+    }
+
+    const note = normalizeLine(snapshot.notes);
+    if (note) {
+      group.notes.add(note);
+    }
+
+    groups.set(key, group);
+  }
+
+  const results = Array.from(groups.values());
+  results.sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    return b.latestTimestamp - a.latestTimestamp;
+  });
+
+  return results;
+}
+
+function buildCustomLabelCard(group) {
+  const card = document.createElement('article');
+  card.className = 'stats-label-card card shadow-sm stats-custom-card';
+
+  const previewWrapper = document.createElement('div');
+  previewWrapper.className = 'stats-label-preview card-img-top stats-custom-preview';
+  if (typeof group.svgMarkup === 'string' && group.svgMarkup.trim().length > 0) {
+    previewWrapper.innerHTML = group.svgMarkup;
+  } else {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'stats-label-placeholder text-muted';
+    placeholder.textContent = 'Preview unavailable';
+    previewWrapper.append(placeholder);
+  }
+  card.append(previewWrapper);
+
+  const body = document.createElement('div');
+  body.className = 'card-body d-flex flex-column gap-2';
+
+  const titleEl = document.createElement('h3');
+  titleEl.className = 'h5 mb-0';
+  titleEl.textContent = group.line1 || 'Untitled custom label';
+  body.append(titleEl);
+
+  if (group.line2) {
+    const subtitleEl = document.createElement('p');
+    subtitleEl.className = 'text-muted mb-2';
+    subtitleEl.textContent = group.line2;
+    body.append(subtitleEl);
+  }
+
+  const usageEl = document.createElement('p');
+  usageEl.className = 'fw-semibold mb-0';
+  usageEl.textContent = formatCount(group.count);
+  body.append(usageEl);
+
+  const eventTypeEl = document.createElement('p');
+  eventTypeEl.className = 'text-muted small mb-2';
+  const eventTypeLabel = formatEventTypes(Array.from(group.eventTypes));
+  const eventBreakdown = formatEventBreakdown(group.downloadCount, group.printCount);
+  eventTypeEl.textContent = eventBreakdown ? `${eventTypeLabel} · ${eventBreakdown}` : eventTypeLabel;
+  body.append(eventTypeEl);
+
+  const detailsList = document.createElement('dl');
+  detailsList.className = 'stats-detail-list mb-0';
+
+  const sizeList = Array.from(group.sizes);
+  if (sizeList.length > 0) {
+    appendDetail(detailsList, 'Sizes used', formatList(sizeList));
+  }
+
+  if (group.latestTimestamp) {
+    appendDetail(detailsList, 'Last activity', formatTimestamp(group.latestTimestamp));
+  }
+
+  const notes = Array.from(group.notes).slice(0, 4);
+  if (notes.length > 0) {
+    appendDetail(detailsList, 'Notes', notes.join(' · '));
+  }
+
+  if (detailsList.childElementCount > 0) {
+    body.append(detailsList);
+  }
+
+  const snapshotSummary = buildSnapshotSummary(group.snapshot);
+  if (snapshotSummary) {
+    const details = document.createElement('details');
+    details.className = 'stats-snapshot-details';
+
+    const summary = document.createElement('summary');
+    summary.className = 'stats-snapshot-summary';
+    summary.textContent = 'View captured state';
+    details.append(summary);
+
+    const pre = document.createElement('pre');
+    pre.className = 'stats-snapshot-json';
+    pre.textContent = JSON.stringify(snapshotSummary, null, 2);
+    details.append(pre);
+
+    body.append(details);
+  }
+
+  card.append(body);
+  return card;
+}
+
+function appendDetail(list, term, value) {
+  if (!term || !value) {
+    return;
+  }
+  const dt = document.createElement('dt');
+  dt.className = 'stats-detail-term';
+  dt.textContent = term;
+  list.append(dt);
+
+  const dd = document.createElement('dd');
+  dd.className = 'stats-detail-description';
+  dd.textContent = value;
+  list.append(dd);
+}
+
+function buildSnapshotSummary(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') {
+    return null;
+  }
+  const summary = {};
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (key === 'customImageData' || key === 'customIconSvgData') {
+      if (typeof value === 'string' && value.length > 0) {
+        summary[key] = `[${value.length} characters omitted]`;
+      }
+      continue;
+    }
+    summary[key] = value;
+  }
+  return summary;
+}
+
+function normalizeLine(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function formatDimensions(width, height) {
+  const widthNumber = Number(width);
+  const heightNumber = Number(height);
+  if (Number.isFinite(widthNumber) && Number.isFinite(heightNumber)) {
+    return `${widthNumber} × ${heightNumber} mm`;
+  }
+  if (Number.isFinite(widthNumber)) {
+    return `${widthNumber} mm wide`;
+  }
+  if (Number.isFinite(heightNumber)) {
+    return `${heightNumber} mm tall`;
+  }
+  return '';
+}
+
+function formatList(items) {
+  const filtered = items.map(item => item && item.trim()).filter(Boolean);
+  if (filtered.length === 0) {
+    return '';
+  }
+  if (typeof Intl !== 'undefined' && typeof Intl.ListFormat === 'function') {
+    try {
+      const formatter = new Intl.ListFormat(undefined, { style: 'short', type: 'conjunction' });
+      return formatter.format(filtered);
+    } catch {
+      // Fallback to join below.
+    }
+  }
+  return filtered.join(', ');
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
+    try {
+      return new Intl.NumberFormat().format(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function formatEventBreakdown(downloadCount, printCount) {
+  const parts = [];
+  if (Number.isFinite(downloadCount) && downloadCount > 0) {
+    const label = downloadCount === 1 ? 'download' : 'downloads';
+    parts.push(`${formatNumber(downloadCount)} ${label}`);
+  }
+  if (Number.isFinite(printCount) && printCount > 0) {
+    const label = printCount === 1 ? 'print' : 'prints';
+    parts.push(`${formatNumber(printCount)} ${label}`);
+  }
+  return parts.join(' · ');
+}
+
+function renderPeriods(entries, container) {
+  container.innerHTML = '';
+  const now = new Date();
+  for (const definition of PERIOD_DEFINITIONS) {
+    const section = buildPeriodSection(entries, definition, now);
+    container.append(section);
+  }
+}
+
+function buildPeriodSection(entries, definition, referenceDate) {
+  const section = document.createElement('section');
+  section.className = 'stats-period-section mb-5';
+  section.setAttribute('data-period', definition.id);
+
+  const header = document.createElement('div');
+  header.className = 'd-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3';
+
+  const headingWrapper = document.createElement('div');
+  const titleEl = document.createElement('h2');
+  titleEl.className = 'h4 mb-1';
+  titleEl.textContent = definition.title;
+  headingWrapper.append(titleEl);
+
+  if (definition.description) {
+    const descriptionEl = document.createElement('p');
+    descriptionEl.className = 'text-muted small mb-0';
+    descriptionEl.textContent = definition.description;
+    headingWrapper.append(descriptionEl);
+  }
+
+  header.append(headingWrapper);
+  section.append(header);
+
+  const startTimestamp = definition.start(referenceDate);
+  const topLabels = computeTopLabels(entries, startTimestamp, TOP_LABEL_LIMIT);
+
+  if (!topLabels || topLabels.length === 0) {
+    const emptyState = document.createElement('p');
+    emptyState.className = 'text-muted fst-italic';
+    emptyState.textContent = 'No labels generated in this period yet.';
+    section.append(emptyState);
+    return section;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'stats-label-grid';
+
+  for (const label of topLabels) {
+    grid.append(buildLabelCard(label));
+  }
+
+  section.append(grid);
+  return section;
+}
+
+function buildLabelCard(label) {
+  const card = document.createElement('article');
+  card.className = 'stats-label-card card shadow-sm';
+
+  const previewWrapper = document.createElement('div');
+  previewWrapper.className = 'stats-label-preview card-img-top';
+  if (typeof label.svgMarkup === 'string' && label.svgMarkup.trim().length > 0) {
+    previewWrapper.innerHTML = label.svgMarkup;
+  } else {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'stats-label-placeholder text-muted';
+    placeholder.textContent = 'Preview unavailable';
+    previewWrapper.append(placeholder);
+  }
+  card.append(previewWrapper);
+
+  const body = document.createElement('div');
+  body.className = 'card-body';
+
+  const countEl = document.createElement('p');
+  countEl.className = 'fw-semibold mb-1';
+  countEl.textContent = formatCount(label.count);
+  body.append(countEl);
+
+  const typeEl = document.createElement('p');
+  typeEl.className = 'text-muted mb-1';
+  typeEl.textContent = formatEventTypes(label.eventTypes);
+  body.append(typeEl);
+
+  if (Number.isFinite(label.latestTimestamp)) {
+    const lastUsed = document.createElement('p');
+    lastUsed.className = 'text-muted small mb-0';
+    lastUsed.textContent = `Last activity: ${formatTimestamp(label.latestTimestamp)}`;
+    body.append(lastUsed);
+  }
+
+  card.append(body);
+  return card;
+}
+
+function formatCount(count) {
+  if (!Number.isFinite(count) || count <= 0) {
+    return '0 uses';
+  }
+  return count === 1 ? '1 use' : `${count} uses`;
+}
+
+function formatEventTypes(types) {
+  const normalized = Array.isArray(types) ? types : [];
+  const hasDownload = normalized.includes('download');
+  const hasPrint = normalized.includes('print');
+  if (hasDownload && hasPrint) {
+    return 'Downloads & Prints';
+  }
+  if (hasDownload) {
+    return 'Downloads';
+  }
+  if (hasPrint) {
+    return 'Prints';
+  }
+  return 'Activity';
+}
+
+function formatTimestamp(timestamp) {
+  try {
+    return new Date(timestamp).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function startOfToday(referenceDate) {
+  const date = new Date(referenceDate);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function startOfWeek(referenceDate) {
+  const date = new Date(referenceDate);
+  date.setHours(0, 0, 0, 0);
+  const day = date.getDay();
+  const diff = (day + 6) % 7; // Monday as the first day of the week
+  date.setDate(date.getDate() - diff);
+  return date.getTime();
+}
+
+function startOfMonth(referenceDate) {
+  const date = new Date(referenceDate);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(1);
+  return date.getTime();
+}
+
+function startOfYear(referenceDate) {
+  const date = new Date(referenceDate);
+  date.setHours(0, 0, 0, 0);
+  date.setMonth(0, 1);
+  return date.getTime();
+}

--- a/js/usage-stats.js
+++ b/js/usage-stats.js
@@ -1,0 +1,164 @@
+const STORAGE_KEY = 'gridfinity-label-usage-v1';
+const MAX_ENTRIES = 400;
+
+function supportsLocalStorage() {
+  try {
+    return typeof window !== 'undefined' && 'localStorage' in window && window.localStorage !== null;
+  } catch (error) {
+    console.warn('Local storage unavailable for usage stats', error);
+    return false;
+  }
+}
+
+function safeParse(json) {
+  if (!json) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Unable to parse stored label usage stats', error);
+    return [];
+  }
+}
+
+function loadEntries() {
+  if (!supportsLocalStorage()) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const entries = safeParse(raw);
+    return entries.filter(entry => entry && typeof entry.timestamp === 'number' && entry.key);
+  } catch (error) {
+    console.warn('Unable to load label usage stats', error);
+    return [];
+  }
+}
+
+function saveEntries(entries) {
+  if (!supportsLocalStorage()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    console.warn('Unable to persist label usage stats', error);
+  }
+}
+
+function normalizeSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') {
+    return {};
+  }
+  const normalized = {};
+  const keys = Object.keys(snapshot);
+  keys.sort();
+  for (const key of keys) {
+    normalized[key] = snapshot[key];
+  }
+  return normalized;
+}
+
+function createLabelKey(snapshot) {
+  const normalized = normalizeSnapshot(snapshot);
+  return JSON.stringify(normalized);
+}
+
+function sanitizeEventType(eventType) {
+  return eventType === 'print' ? 'print' : 'download';
+}
+
+function cloneSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') {
+    return {};
+  }
+  try {
+    return structuredClone(snapshot);
+  } catch {
+    return JSON.parse(JSON.stringify(snapshot));
+  }
+}
+
+export function recordLabelUsage(eventType, details) {
+  if (!details || typeof details !== 'object') {
+    return;
+  }
+  const { snapshot, svgMarkup } = details;
+  if (!snapshot || typeof svgMarkup !== 'string' || svgMarkup.length === 0) {
+    return;
+  }
+  const entrySnapshot = cloneSnapshot(snapshot);
+  const key = createLabelKey(entrySnapshot);
+  const timestamp = Number.isFinite(details.timestamp) ? details.timestamp : Date.now();
+  const entry = {
+    key,
+    snapshot: entrySnapshot,
+    svgMarkup,
+    timestamp,
+    eventType: sanitizeEventType(eventType),
+  };
+  const entries = loadEntries();
+  entries.push(entry);
+  if (entries.length > MAX_ENTRIES) {
+    entries.splice(0, entries.length - MAX_ENTRIES);
+  }
+  saveEntries(entries);
+}
+
+export function getUsageEntries() {
+  return loadEntries();
+}
+
+export function computeTopLabels(entries, periodStartMs, limit = 5) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+  const start = Number.isFinite(periodStartMs) ? Number(periodStartMs) : 0;
+  const aggregated = new Map();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const { timestamp, key } = entry;
+    if (!Number.isFinite(timestamp) || timestamp < start || !key) {
+      continue;
+    }
+    const group = aggregated.get(key) || {
+      key,
+      count: 0,
+      latestTimestamp: 0,
+      snapshot: null,
+      svgMarkup: '',
+      eventTypes: new Set(),
+    };
+    group.count += 1;
+    if (timestamp > group.latestTimestamp) {
+      group.latestTimestamp = timestamp;
+      group.snapshot = entry.snapshot || group.snapshot;
+      group.svgMarkup = typeof entry.svgMarkup === 'string' && entry.svgMarkup.length > 0
+        ? entry.svgMarkup
+        : group.svgMarkup;
+    }
+    if (entry.eventType) {
+      group.eventTypes.add(entry.eventType);
+    }
+    aggregated.set(key, group);
+  }
+  const results = Array.from(aggregated.values());
+  results.sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    return b.latestTimestamp - a.latestTimestamp;
+  });
+  return results.slice(0, Math.max(0, limit)).map(item => ({
+    key: item.key,
+    count: item.count,
+    latestTimestamp: item.latestTimestamp,
+    snapshot: item.snapshot,
+    svgMarkup: item.svgMarkup,
+    eventTypes: Array.from(item.eventTypes),
+  }));
+}

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en" data-bs-theme="light" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Label Usage Stats – Gridfinity Label Maker</title>
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="Gridfinity Label Maker" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      id="apple-mobile-web-app-status-bar-style"
+    />
+    <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
+    <meta
+      name="description"
+      content="Owner-facing label analytics for reviewing popular downloads, print activity, and custom designs."
+    />
+    <link rel="manifest" href="manifest.json" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="icon" type="image/x-icon" href="images/icons/favicon.ico" />
+    <link rel="apple-touch-icon" href="images/icons/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="57x57" href="images/icons/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="images/icons/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="images/icons/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="images/icons/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="images/icons/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="images/icons/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="images/icons/apple-touch-icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon-180x180.png" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <script>
+      (function () {
+        const storageKey = 'gridfinity-theme-preference';
+        const themeColors = { light: '#f8fafc', dark: '#0f172a' };
+        const statusBarStyles = { light: 'default', dark: 'black-translucent' };
+        let theme = 'light';
+        try {
+          const storedTheme = localStorage.getItem(storageKey);
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+          if (storedTheme === 'light' || storedTheme === 'dark') {
+            theme = storedTheme;
+          } else if (prefersDark.matches) {
+            theme = 'dark';
+          }
+        } catch (error) {
+          theme = 'light';
+        }
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        const themeColorMeta = document.getElementById('theme-color-meta');
+        if (themeColorMeta) {
+          themeColorMeta.setAttribute('content', themeColors[theme] || themeColors.light);
+        }
+        const statusBarMeta = document.getElementById('apple-mobile-web-app-status-bar-style');
+        if (statusBarMeta) {
+          statusBarMeta.setAttribute('content', statusBarStyles[theme] || statusBarStyles.light);
+        }
+      })();
+    </script>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style-print.css" media="print" />
+    <link rel="stylesheet" href="print.css" />
+    <script type="module" defer src="js/stats-page.js"></script>
+  </head>
+  <body class="stats-page-body">
+    <main class="container py-4 stats-page" id="stats-root">
+      <div class="theme-toggle-wrapper mb-3">
+        <button
+          type="button"
+          class="theme-toggle-button"
+          id="theme-toggle"
+          aria-pressed="false"
+          aria-label="Switch to dark mode"
+          title="Switch to dark mode"
+        >
+          <i class="fa-solid fa-moon theme-toggle-icon" aria-hidden="true"></i>
+          <span class="theme-toggle-text">Dark mode</span>
+        </button>
+      </div>
+      <header class="title-section text-center mb-4">
+        <div class="title-brand d-flex align-items-center justify-content-center gap-3 mb-2">
+          <img
+            src="images/icons/logo.svg"
+            class="title-logo"
+            alt="Gridfinity Label Maker logo"
+          />
+          <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
+        </div>
+        <p class="text-muted mb-0">Local analytics for monitoring label activity and trends.</p>
+        <div class="mt-3 d-flex justify-content-center gap-2 flex-wrap">
+          <a class="btn btn-outline-secondary btn-sm" href="./">
+            <i class="fa-solid fa-arrow-left" aria-hidden="true"></i>
+            <span class="ms-2">Back to label maker</span>
+          </a>
+        </div>
+      </header>
+      <section class="stats-summary mb-5" aria-live="polite">
+        <div class="row g-3" id="stats-summary-cards"></div>
+        <p class="text-muted small mb-0 mt-3" id="stats-empty-message"></p>
+      </section>
+      <section class="stats-hardware mb-5" id="stats-hardware-section" hidden>
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-end gap-2 mb-3">
+          <div>
+            <h2 class="h4 mb-1">Hardware type breakdown</h2>
+            <p class="text-muted small mb-0">Counts from downloads and prints combined.</p>
+          </div>
+        </div>
+        <div class="table-responsive stats-table-wrapper">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th scope="col">Hardware type</th>
+                <th scope="col" class="text-end">Total uses</th>
+                <th scope="col" class="text-end">Downloads</th>
+                <th scope="col" class="text-end">Prints</th>
+                <th scope="col">Last activity</th>
+              </tr>
+            </thead>
+            <tbody id="stats-hardware-tbody"></tbody>
+          </table>
+        </div>
+      </section>
+      <section class="stats-custom mb-5" id="stats-custom-section" hidden>
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-end gap-2 mb-3">
+          <div>
+            <h2 class="h4 mb-1">Custom label designs</h2>
+            <p class="text-muted small mb-0">
+              Review freeform labels to spot emerging part categories or naming patterns.
+            </p>
+          </div>
+        </div>
+        <div id="stats-custom-grid" class="stats-custom-grid"></div>
+        <p class="text-muted fst-italic" id="stats-custom-empty" hidden>No custom labels recorded yet.</p>
+      </section>
+      <section class="stats-periods" id="stats-periods" hidden></section>
+    </main>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1762,3 +1762,140 @@ body.part-type-picker-open {
 :root[data-theme='dark'] .part-type-card__thumb {
   background: transparent;
 }
+
+.stats-page-body {
+  background-color: var(--bs-body-bg);
+}
+
+.stats-page {
+  max-width: 960px;
+}
+
+.stats-summary-card .card-body {
+  padding: 1.5rem;
+}
+
+.stats-summary-label {
+  letter-spacing: 0.08em;
+}
+
+.stats-summary-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-table-wrapper {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.stats-table-wrapper table {
+  margin-bottom: 0;
+}
+
+.stats-period-section + .stats-period-section {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: 2.5rem;
+}
+
+.stats-custom-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.stats-custom-card .card-body {
+  padding: 1.25rem 1.5rem 1.5rem;
+}
+
+.stats-detail-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.stats-detail-term {
+  font-weight: 600;
+  color: var(--bs-body-color);
+}
+
+.stats-detail-description {
+  margin-bottom: 0.25rem;
+  color: var(--bs-secondary-color);
+}
+
+.stats-snapshot-details {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: rgba(15, 23, 42, 0.04);
+}
+
+.stats-snapshot-summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--bs-primary);
+}
+
+.stats-snapshot-json {
+  margin: 0.75rem 0 0;
+  max-height: 240px;
+  overflow: auto;
+  font-size: 0.75rem;
+  background-color: rgba(15, 23, 42, 0.05);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+}
+
+.stats-label-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stats-label-card {
+  overflow: hidden;
+}
+
+.stats-label-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bs-body-bg);
+  padding: 1.25rem;
+  min-height: 140px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.stats-label-preview svg {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.stats-label-placeholder {
+  font-size: 0.875rem;
+}
+
+:root[data-theme='dark'] .stats-period-section + .stats-period-section {
+  border-top-color: rgba(148, 163, 184, 0.2);
+}
+
+:root[data-theme='dark'] .stats-table-wrapper {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+:root[data-theme='dark'] .stats-snapshot-details {
+  border-color: rgba(148, 163, 184, 0.35);
+  background-color: rgba(15, 23, 42, 0.55);
+}
+
+:root[data-theme='dark'] .stats-snapshot-json {
+  background-color: rgba(30, 41, 59, 0.7);
+}
+
+:root[data-theme='dark'] .stats-label-preview {
+  background-color: rgba(15, 23, 42, 0.45);
+  border-bottom-color: rgba(148, 163, 184, 0.2);
+}


### PR DESCRIPTION
## Summary
- align the stats dashboard with the main site chrome and theme toggling while reframing the copy for an owner-only workflow
- add local summary metrics, hardware breakdowns, and custom label cards (with captured state) so new part-type requests are easy to spot
- extend styles and documentation, and update the home link text to highlight that the dashboard is a local-only admin view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddccd37e4c83299c66d4fa7be02377