### PR TITLE
Move stats dashboard link to footer CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,12 +113,6 @@
           <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
         </div>
         <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>
-        <div class="mt-3">
-          <a class="btn btn-outline-primary btn-sm" href="stats.html">
-            <i class="fa-solid fa-chart-line me-1" aria-hidden="true"></i>
-            Open usage dashboard (local only)
-          </a>
-        </div>
       </header>
       <div class="alert alert-warning d-flex align-items-center justify-content-center gap-3 mb-4" role="alert">
         <i class="fa-solid fa-person-digging fa-2xl" aria-hidden="true"></i>
@@ -1515,6 +1509,17 @@
           <span>Share</span>
         </button>
       </div>
+      <section class="stats-cta text-center mt-5">
+        <h2 class="h5 mb-2">See what's trending</h2>
+        <p class="text-muted mb-3">
+          Explore aggregated label activity from the entire Gridfinity Label Maker community to spot
+          emerging part types.
+        </p>
+        <a class="btn btn-outline-primary btn-lg d-inline-flex align-items-center gap-2" href="stats.html">
+          <i class="fa-solid fa-chart-line" aria-hidden="true"></i>
+          <span>Open community usage dashboard</span>
+        </a>
+      </section>
     </main>
   </body>
 </html>

--- a/stats.html
+++ b/stats.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#f8fafc" id="theme-color-meta" />
     <meta
       name="description"
-      content="Owner-facing label analytics for reviewing popular downloads, print activity, and custom designs."
+      content="Owner-facing community analytics for reviewing popular downloads, print activity, and custom designs across all users."
     />
     <link rel="manifest" href="manifest.json" />
     <link
@@ -103,7 +103,10 @@
           />
           <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
         </div>
-        <p class="text-muted mb-0">Local analytics for monitoring label activity and trends.</p>
+        <p class="text-muted mb-0">
+          Community-wide analytics for monitoring label activity and trends across every Gridfinity
+          Label Maker user.
+        </p>
         <div class="mt-3 d-flex justify-content-center gap-2 flex-wrap">
           <a class="btn btn-outline-secondary btn-sm" href="./">
             <i class="fa-solid fa-arrow-left" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- relocate the stats dashboard call-to-action to the bottom of the label maker so it appears after primary actions
- refresh the button copy to highlight community-wide trend insights instead of local-only data
- clarify the stats page hero text and metadata to explain that analytics aggregate activity across all users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde51a609483298382c65dda6f7fb2