### PR TITLE
Improve mobile layout for stats page

### DIFF
--- a/style.css
+++ b/style.css
@@ -1899,3 +1899,60 @@ body.part-type-picker-open {
   background-color: rgba(15, 23, 42, 0.45);
   border-bottom-color: rgba(148, 163, 184, 0.2);
 }
+
+@media (max-width: 575.98px) {
+  .stats-page {
+    padding-inline: 0.75rem;
+  }
+
+  .stats-summary-card .card-body {
+    padding: 1.125rem 1.25rem;
+  }
+
+  .stats-summary-label {
+    letter-spacing: 0.05em;
+  }
+
+  .stats-summary-value {
+    font-size: clamp(1.75rem, 8vw, 2.25rem);
+  }
+
+  .stats-table-wrapper {
+    border-radius: 0.5rem;
+  }
+
+  .stats-table-wrapper table {
+    font-size: 0.875rem;
+  }
+
+  .stats-table-wrapper th,
+  .stats-table-wrapper td {
+    padding: 0.75rem 0.5rem;
+    white-space: nowrap;
+  }
+
+  .stats-table-wrapper th:first-child,
+  .stats-table-wrapper td:first-child {
+    white-space: normal;
+  }
+
+  .stats-custom-grid,
+  .stats-label-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.25rem;
+  }
+
+  .stats-custom-card .card-body {
+    padding: 1rem 1.125rem 1.25rem;
+  }
+
+  .stats-detail-list {
+    font-size: 0.8125rem;
+    gap: 0.25rem 0.5rem;
+  }
+
+  .stats-label-preview {
+    padding: 1rem;
+    min-height: 120px;
+  }
+}


### PR DESCRIPTION
## Summary
- tune stats summary card spacing and typography for handheld screens
- adjust stats tables and grids to use mobile-friendly padding and single-column layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf854e4648329b54256c0ae3466b2