### PR TITLE
Display stats summary cards in a responsive grid

### DIFF
--- a/js/stats-page.js
+++ b/js/stats-page.js
@@ -120,6 +120,8 @@ function computeSummary(entries) {
 
 function renderSummary(summary, container) {
   container.innerHTML = '';
+  container.classList.remove('row', 'g-3');
+  container.classList.add('stats-summary-grid');
   const cards = [
     {
       label: 'Total uses',
@@ -141,9 +143,6 @@ function renderSummary(summary, container) {
   ];
 
   for (const cardData of cards) {
-    const col = document.createElement('div');
-    col.className = 'col-12 col-sm-6 col-lg-3';
-
     const card = document.createElement('article');
     card.className = 'stats-summary-card card shadow-sm h-100';
 
@@ -168,8 +167,7 @@ function renderSummary(summary, container) {
     }
 
     card.append(body);
-    col.append(card);
-    container.append(col);
+    container.append(card);
   }
 }
 

--- a/stats.html
+++ b/stats.html
@@ -115,7 +115,7 @@
         </div>
       </header>
       <section class="stats-summary mb-5" aria-live="polite">
-        <div class="row g-3" id="stats-summary-cards"></div>
+        <div class="stats-summary-grid" id="stats-summary-cards"></div>
         <p class="text-muted small mb-0 mt-3" id="stats-empty-message"></p>
       </section>
       <section class="stats-hardware mb-5" id="stats-hardware-section" hidden>

--- a/style.css
+++ b/style.css
@@ -1771,6 +1771,12 @@ body.part-type-picker-open {
   max-width: 960px;
 }
 
+.stats-summary-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
 .stats-summary-card .card-body {
   padding: 1.5rem;
 }
@@ -1903,6 +1909,11 @@ body.part-type-picker-open {
 @media (max-width: 575.98px) {
   .stats-page {
     padding-inline: 0.75rem;
+  }
+
+  .stats-summary-grid {
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .stats-summary-card .card-body {


### PR DESCRIPTION
## Summary
- render the stats summary cards inside a dedicated grid container
- remove bootstrap column wrappers in the stats script to work with the new grid layout
- add responsive CSS so the summary cards compact into a tighter grid on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddfb2e8fdc8329b33043e307e361b7