### PR TITLE
Ensure stats summary cards form grid on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1913,7 +1913,7 @@ body.part-type-picker-open {
 
   .stats-summary-grid {
     gap: 1rem;
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .stats-summary-card .card-body {


### PR DESCRIPTION
## Summary
- adjust the mobile breakpoint styles so the stats summary cards render in a two-column grid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de0c7c9d0c8329b2487e33a623286f