### PR TITLE
Refine stats dashboard messaging for community trends

### DIFF
--- a/js/stats-page.js
+++ b/js/stats-page.js
@@ -31,10 +31,22 @@ const PERIOD_DEFINITIONS = [
 const TOP_LABEL_LIMIT = 5;
 const MAX_CUSTOM_GROUPS = 20;
 
-document.addEventListener('DOMContentLoaded', () => {
+function showLoadingState(summaryContainer, emptyMessage) {
+  if (summaryContainer) {
+    summaryContainer.innerHTML = '';
+    const loadingMessage = document.createElement('p');
+    loadingMessage.className = 'text-muted text-center w-100 my-4';
+    loadingMessage.textContent = 'Loading community activity…';
+    summaryContainer.append(loadingMessage);
+  }
+  if (emptyMessage) {
+    emptyMessage.textContent = 'Loading community activity…';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
   initTheme();
 
-  const entries = getUsageEntries();
   const summaryContainer = document.getElementById('stats-summary-cards');
   const emptyMessage = document.getElementById('stats-empty-message');
   const periodsContainer = document.getElementById('stats-periods');
@@ -44,13 +56,57 @@ document.addEventListener('DOMContentLoaded', () => {
   const customGrid = document.getElementById('stats-custom-grid');
   const customEmptyMessage = document.getElementById('stats-custom-empty');
 
+  showLoadingState(summaryContainer, emptyMessage);
+
+  let usageResult;
+  try {
+    usageResult = await getUsageEntries();
+  } catch (error) {
+    console.error('Unexpected error while resolving usage entries', error);
+    usageResult = { entries: [], source: 'remote', error };
+  }
+
+  const { entries, source, error } = usageResult;
+
+  if (source !== 'remote') {
+    if (error) {
+      console.warn('Community analytics unavailable; ignoring local fallback data.', error);
+    }
+    if (summaryContainer) {
+      summaryContainer.innerHTML = '';
+    }
+    if (emptyMessage) {
+      emptyMessage.textContent =
+        'Unable to load community-wide stats right now. Trending ideas will return once the analytics service is back online.';
+    }
+    if (periodsContainer) {
+      periodsContainer.hidden = true;
+    }
+    if (hardwareSection) {
+      hardwareSection.hidden = true;
+    }
+    if (customSection) {
+      customSection.hidden = true;
+    }
+    return;
+  }
+
   if (!Array.isArray(entries) || entries.length === 0) {
     if (summaryContainer) {
       summaryContainer.innerHTML = '';
     }
     if (emptyMessage) {
       emptyMessage.textContent =
-        'No download or print activity recorded yet. Stats will populate after you export a label from this browser.';
+        'No community activity recorded yet. As makers generate labels, trending hardware and custom ideas will appear here.';
+    }
+    if (periodsContainer) {
+      periodsContainer.hidden = true;
+    }
+    if (hardwareSection) {
+      hardwareSection.hidden = true;
+    }
+    if (customSection) {
+      customSection.hidden = true;
     }
     return;
   }
@@ -66,8 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ? ` Last recorded activity: ${formatTimestamp(summary.latestTimestamp)}.`
       : '';
     emptyMessage.textContent =
-      'Stats are stored locally in this browser. Downloading or printing new labels updates the dashboard automatically.' +
-      lastActivity;
+      'Trending Gridfinity label activity from across the community.' + lastActivity;
   }
 
   if (hardwareSection && hardwareTableBody) {

--- a/js/usage-stats.js
+++ b/js/usage-stats.js
@@ -23,6 +23,23 @@ function safeParse(json) {
   }
 }
 
+function parseSnapshotString(value) {
+  if (typeof value !== 'string') {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Unable to parse snapshot from analytics payload', error);
+    return {};
+  }
+}
+
+const SHARED_ANALYTICS_ENDPOINT =
+  (typeof window !== 'undefined' && window.GRIDFINITY_ANALYTICS_ENDPOINT) ||
+  'https://analytics.gridfinitylabels.com/usage.json';
+
 function loadEntries() {
   if (!supportsLocalStorage()) {
     return [];
@@ -107,8 +124,99 @@ export function recordLabelUsage(eventType, details) {
   saveEntries(entries);
 }
 
-export function getUsageEntries() {
-  return loadEntries();
+function extractRemoteEntries(payload) {
+  if (!payload) {
+    return null;
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (typeof payload === 'object') {
+    if (Array.isArray(payload.entries)) {
+      return payload.entries;
+    }
+    if (Array.isArray(payload.data)) {
+      return payload.data;
+    }
+  }
+  return null;
+}
+
+function normalizeRemoteEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const key = typeof entry.key === 'string'
+    ? entry.key
+    : typeof entry.labelKey === 'string'
+      ? entry.labelKey
+      : null;
+
+  if (!key) {
+    return null;
+  }
+
+  const timestampValue =
+    entry.timestamp ?? entry.latestTimestamp ?? entry.updatedAt ?? entry.lastSeen ?? entry.lastTimestamp;
+  const timestamp = Number(timestampValue);
+  if (!Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  const snapshot = entry.snapshot && typeof entry.snapshot === 'object'
+    ? cloneSnapshot(entry.snapshot)
+    : typeof entry.snapshot === 'string'
+      ? cloneSnapshot(parseSnapshotString(entry.snapshot))
+      : entry.data && typeof entry.data === 'object'
+        ? cloneSnapshot(entry.data)
+        : {};
+
+  const svgMarkup = typeof entry.svgMarkup === 'string'
+    ? entry.svgMarkup
+    : typeof entry.svg === 'string'
+      ? entry.svg
+      : '';
+
+  const eventType = sanitizeEventType(entry.eventType || entry.lastEventType || entry.type);
+
+  return { key, snapshot, svgMarkup, timestamp, eventType };
+}
+
+export async function getUsageEntries() {
+  let remoteError = null;
+
+  try {
+    const response = await fetch(SHARED_ANALYTICS_ENDPOINT, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-cache',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Analytics request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const rawEntries = extractRemoteEntries(payload);
+    if (!Array.isArray(rawEntries)) {
+      throw new Error('Analytics payload did not contain an entries array');
+    }
+
+    const normalizedEntries = rawEntries.map(normalizeRemoteEntry).filter(Boolean);
+
+    if (normalizedEntries.length === 0 && rawEntries.length > 0) {
+      throw new Error('Analytics payload did not include valid entries');
+    }
+
+    return { entries: normalizedEntries, source: 'remote', error: null };
+  } catch (error) {
+    remoteError = error instanceof Error ? error : new Error('Unknown analytics error');
+    console.error('Unable to load global usage stats', remoteError);
+  }
+
+  const fallbackEntries = loadEntries();
+  return { entries: fallbackEntries, source: 'local', error: remoteError };
 }
 
 export function computeTopLabels(entries, periodStartMs, limit = 5) {

--- a/stats.html
+++ b/stats.html
@@ -150,7 +150,9 @@
           </div>
         </div>
         <div id="stats-custom-grid" class="stats-custom-grid"></div>
-        <p class="text-muted fst-italic" id="stats-custom-empty" hidden>No custom labels recorded yet.</p>
+        <p class="text-muted fst-italic" id="stats-custom-empty" hidden>
+          No trending custom labels recorded yet. Check back soon for new part ideas from the community.
+        </p>
       </section>
       <section class="stats-periods" id="stats-periods" hidden></section>
     </main>


### PR DESCRIPTION
## Summary
- update the stats dashboard to ignore local fallbacks and surface community analytics messaging
- refresh loading and empty copy so the page emphasizes trending ideas from the shared dataset
- tweak the custom label empty state to highlight community-sourced part ideas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de3755c0fc8329bf9a596d8e34f73f