### PR TITLE
Add switch hardware type

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,13 @@
                           Connector
                         </option>
                         <option
+                          value="Switch"
+                          data-img="images/switches/microswitch_roller.svg"
+                          data-cat="Electrical"
+                        >
+                          Switch
+                        </option>
+                        <option
                           value="Resistor"
                           data-img="images/resistors/resistor_through_hole.svg"
                           data-cat="Electrical"

--- a/js/data.js
+++ b/js/data.js
@@ -371,6 +371,7 @@ export const hardwareCatalog = {
     { code: 'General Purpose', name: 'Rectifier Diode' },
     { code: 'Signal', name: 'Small Signal Diode' },
   ],
+  Switch: [],
   Fuse: [
     { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
     { code: 'IEC 60127-3', name: 'Fast-Acting Cartridge Fuse' },
@@ -397,6 +398,7 @@ export const hardwareTypeImageMap = {
   Nut: 'images/nuts/hex_nut.svg',
   Fuse: 'images/fuses/glass_fuse.svg',
   Connector: 'images/connectors/connector.svg',
+  Switch: 'images/switches/microswitch_roller.svg',
   Resistor: 'images/resistors/resistor_through_hole.svg',
   Capacitor: 'images/capacitors/capacitor_through_hole.svg',
   Bearing: 'images/bearings/bearing.svg',

--- a/js/forms.js
+++ b/js/forms.js
@@ -3899,6 +3899,7 @@ export function onHardwareTypeChange() {
   const requiresThreadDetails = type === 'Bolt' || type === 'Screw';
   const showFuseFields = type === 'Fuse';
   const showConnectorFields = type === 'Connector';
+  const showSwitchFields = type === 'Switch';
   const showComponentFields = ELECTRICAL_COMPONENT_TYPES.has(type);
   const showCustomFields = type === 'Custom';
   const showBearingFields = type === 'Bearing';
@@ -4023,6 +4024,7 @@ export function onHardwareTypeChange() {
     const hideMeasurementSystem =
       showFuseFields ||
       showConnectorFields ||
+      showSwitchFields ||
       showCustomFields ||
       showBearingFields ||
       showComponentFields;
@@ -4036,6 +4038,7 @@ export function onHardwareTypeChange() {
     radio.disabled =
       showFuseFields ||
       showConnectorFields ||
+      showSwitchFields ||
       showCustomFields ||
       showBearingFields ||
       showComponentFields;
@@ -4053,6 +4056,7 @@ export function onHardwareTypeChange() {
       !requiresThreadDetails &&
         !showFuseFields &&
         !showConnectorFields &&
+        !showSwitchFields &&
         !showCustomFields &&
         !showBearingFields &&
         !showComponentFields &&
@@ -4065,6 +4069,7 @@ export function onHardwareTypeChange() {
     threadSizeContainer.style.display =
       showFuseFields ||
       showConnectorFields ||
+      showSwitchFields ||
       showCustomFields ||
       showBearingFields ||
       showComponentFields
@@ -4158,6 +4163,7 @@ export function onHardwareTypeChange() {
         showBearingFields ||
         showComponentFields ||
         showFuseFields ||
+        showSwitchFields ||
         showNutFields,
     );
   }
@@ -4167,12 +4173,14 @@ export function onHardwareTypeChange() {
     } else {
       standardLabel.textContent = defaultStandardLabel;
     }
-    const hideStandardLabel = showFastenerFields || showFuseFields || showNutFields;
+    const hideStandardLabel =
+      showFastenerFields || showFuseFields || showSwitchFields || showNutFields;
     standardLabel.classList.toggle('d-none', hideStandardLabel);
     standardLabel.setAttribute('for', hideStandardLabel ? 'bolt-head-select' : 'standard-select');
   }
   if (standardSelect) {
-    const hideStandardSelect = showFastenerFields || showFuseFields || showNutFields;
+    const hideStandardSelect =
+      showFastenerFields || showFuseFields || showSwitchFields || showNutFields;
     standardSelect.classList.toggle('d-none', hideStandardSelect);
     standardSelect.hidden = hideStandardSelect;
     if (hideStandardSelect) {

--- a/js/render.js
+++ b/js/render.js
@@ -972,6 +972,9 @@ export function isLabelReady() {
   if (state.hardwareType === 'Threaded Heat Insert') {
     return Boolean(state.threadSize && state.length);
   }
+  if (state.hardwareType === 'Switch') {
+    return true;
+  }
   return Boolean(state.threadSize);
 }
 


### PR DESCRIPTION
## Summary
- add a Switch option to the electrical part picker with the microswitch roller icon
- wire the new Switch type through the data and render layers so it skips threaded UI and label requirements

## Testing
- npm run lint *(fails: existing no-unused-vars errors in js/actions.js)*

------
https://chatgpt.com/codex/tasks/task_e_68de6ad499c4832992677d6fa0635b42