### PR TITLE
Hide thread length row when switch fields are shown

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -42,6 +42,7 @@ const {
   threadSizeContainer,
   threadLengthRow,
   lengthContainer,
+  lengthInput,
   fuseSelectionRow,
   fuseTypeContainer,
   fuseTypeSelect,
@@ -4048,6 +4049,7 @@ export function onHardwareTypeChange() {
     const hideThreadLength =
       showFuseFields ||
       showConnectorFields ||
+      showSwitchFields ||
       showCustomFields ||
       showBearingFields ||
       showComponentFields;
@@ -4064,6 +4066,12 @@ export function onHardwareTypeChange() {
         !showWasherFields,
     );
     threadLengthRow.style.display = hideThreadLength ? 'none' : '';
+    if (hideThreadLength) {
+      state.length = '';
+      if (lengthInput) {
+        lengthInput.value = '';
+      }
+    }
   }
   if (threadSizeContainer) {
     threadSizeContainer.style.display =


### PR DESCRIPTION
## Summary
- hide the thread length row when switch-related fields are displayed
- clear the saved length value whenever the row is hidden to avoid stale state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de75baff2083299b8d9503e836d0a3