### PR TITLE
Add switch type picker and wiring

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,6 +958,55 @@
                     ></div>
                   </div>
                 </div>
+                <div id="switch-selection-row" class="row g-3 d-none">
+                  <div class="col-12 col-sm-6" id="switch-type-container">
+                    <label for="switch-type-select" class="form-label fw-semibold"
+                      >Switch Type</label
+                    >
+                    <div class="bolt-drive-picker" id="switch-type-picker">
+                      <select
+                        id="switch-type-select"
+                        class="visually-hidden"
+                        aria-describedby="switch-type-message"
+                      ></select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="switch-type-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="switch-type-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span
+                            class="bolt-drive-picker__current-icon is-empty"
+                            aria-hidden="true"
+                          >
+                            <img
+                              class="bolt-drive-picker__current-icon-image"
+                              src=""
+                              alt=""
+                              hidden
+                            />
+                          </span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                        </span>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="switch-type-picker-list"
+                        role="listbox"
+                        aria-labelledby="switch-type-picker-button"
+                        hidden
+                      ></ul>
+                    </div>
+                    <div
+                      id="switch-type-message"
+                      class="validation-message text-danger small mt-2 d-none"
+                    ></div>
+                  </div>
+                </div>
                 <div id="fuse-selection-row" class="row g-3 d-none">
                   <div class="col-6" id="fuse-type-container">
                     <label

--- a/js/actions.js
+++ b/js/actions.js
@@ -69,9 +69,9 @@ function formatTimestamp(date) {
 }
 
 export function downloadLabel() {
-  const labelSnapshot = captureStateSnapshot();
+  captureStateSnapshot();
   renderLabelPng()
-    .then(({ blob, svgMarkup }) => {
+    .then(({ blob }) => {
       const link = document.createElement('a');
       const objectUrl = URL.createObjectURL(blob);
       link.href = objectUrl;
@@ -181,7 +181,7 @@ export function downloadLabel() {
 }
 
 export function printLabel() {
-  const labelSnapshot = captureStateSnapshot();
+  captureStateSnapshot();
   const printWindow = window.open('', '_blank', 'width=800,height=600');
   if (!printWindow) {
     alert('Please allow pop-ups to print the label.');
@@ -226,7 +226,7 @@ export function printLabel() {
     img.style.imageRendering = 'pixelated';
   }
   renderLabelPng()
-    .then(({ blob, widthPx, heightPx, svgMarkup }) => {
+    .then(({ blob, widthPx, heightPx }) => {
       if (!(img instanceof HTMLImageElement)) {
         throw new Error('Print image element was not created.');
       }

--- a/js/controls.js
+++ b/js/controls.js
@@ -8,6 +8,7 @@ import {
   populateConnectorCategories,
   populateBearingOptions,
   populateHardwareTypePicker,
+  populateSwitchTypePicker,
   populateComponentMountPicker,
   populateResistorValues,
   populateCapacitorValues,
@@ -20,6 +21,7 @@ import {
   setBoltHeadSelection,
   setNutTypeSelection,
   setWasherTypeSelection,
+  setSwitchTypeSelection,
   setBearingTypeSelection,
   setFuseTypeSelection,
   setThreadSizeSelection,
@@ -116,6 +118,7 @@ function applyStateToControls() {
   setBoltDriveSelection(state.boltDrive || '', { triggerUpdate: false });
   setNutTypeSelection(state.nutType || '', { triggerUpdate: false });
   setWasherTypeSelection(state.washerType || '', { triggerUpdate: false });
+  setSwitchTypeSelection(state.switchType || '', { triggerUpdate: false });
   if (standardToggle) {
     standardToggle.checked = state.showStandard;
   }
@@ -155,6 +158,7 @@ function init() {
   populateCapacitorValues();
   populateDiodeValues();
   populateWasherTypeOptions();
+  populateSwitchTypePicker();
   updateCustomImageUi();
   ensureCustomIconAsset();
   onHardwareTypeChange();

--- a/js/data.js
+++ b/js/data.js
@@ -80,6 +80,23 @@ export const fuseTypeOptions = [
   { id: 'Blade', label: 'Blade Fuse', image: 'images/fuses/blade_fuse.svg' },
 ];
 
+export const switchTypeOptions = [
+  {
+    id: 'Microswitch (Roller)',
+    label: 'Microswitch (Roller)',
+    image: 'images/switches/microswitch_roller.svg',
+  },
+  {
+    id: 'Tactile Switch',
+    label: 'Tactile Switch',
+    image: 'images/switches/tactile_switch.svg',
+  },
+];
+
+export const switchTypeImageMap = new Map(
+  switchTypeOptions.map(option => [option.id, option.image]),
+);
+
 export const electricalComponentTypes = ['Resistor', 'Capacitor', 'Diode'];
 
 export const componentImageMap = {

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -28,6 +28,13 @@ const washerTypePickerButton = document.getElementById('washer-type-picker-butto
 const washerTypePickerList = document.getElementById('washer-type-picker-list');
 const washerTypeSelect = document.getElementById('washer-type-select');
 const washerTypeMessage = document.getElementById('washer-type-message');
+const switchSelectionRow = document.getElementById('switch-selection-row');
+const switchTypeContainer = document.getElementById('switch-type-container');
+const switchTypePicker = document.getElementById('switch-type-picker');
+const switchTypePickerButton = document.getElementById('switch-type-picker-button');
+const switchTypePickerList = document.getElementById('switch-type-picker-list');
+const switchTypeSelect = document.getElementById('switch-type-select');
+const switchTypeMessage = document.getElementById('switch-type-message');
 const fuseSelectionRow = document.getElementById('fuse-selection-row');
 const fuseTypeContainer = document.getElementById('fuse-type-container');
 const fuseTypeSelect = document.getElementById('fuse-type-select');
@@ -211,6 +218,13 @@ export const elements = {
   washerTypePickerList,
   washerTypeSelect,
   washerTypeMessage,
+  switchSelectionRow,
+  switchTypeContainer,
+  switchTypePicker,
+  switchTypePickerButton,
+  switchTypePickerList,
+  switchTypeSelect,
+  switchTypeMessage,
   fuseSelectionRow,
   fuseTypeContainer,
   fuseTypeSelect,

--- a/js/events.js
+++ b/js/events.js
@@ -21,6 +21,8 @@ import {
   syncNutTypePicker,
   setWasherTypeSelection,
   syncWasherTypePicker,
+  setSwitchTypeSelection,
+  syncSwitchTypePicker,
   setConnectorCategorySelection,
   syncConnectorCategoryPicker,
   setConnectorSeriesSelection,
@@ -125,6 +127,10 @@ const {
   washerTypePicker,
   washerTypePickerButton,
   washerTypePickerList,
+  switchTypeSelect,
+  switchTypePicker,
+  switchTypePickerButton,
+  switchTypePickerList,
   connectorSeriesPicker,
   connectorSeriesPickerButton,
   connectorSeriesPickerList,
@@ -157,6 +163,7 @@ let boltDrivePickerOpen = false;
 let boltHeadPickerOpen = false;
 let nutTypePickerOpen = false;
 let washerTypePickerOpen = false;
+let switchTypePickerOpen = false;
 let fuseValuePickerOpen = false;
 let componentMountPickerOpen = false;
 let resistorValuePickerOpen = false;
@@ -3114,6 +3121,213 @@ function handleNutTypeListFocusOut() {
   }, 0);
 }
 
+function getSwitchTypeOptionElements() {
+  if (!switchTypePickerList) {
+    return [];
+  }
+  return Array.from(switchTypePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusSwitchTypeOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getSwitchTypeOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openSwitchTypePicker() {
+  if (!switchTypePicker || !switchTypePickerButton || !switchTypePickerList) {
+    return;
+  }
+  if (switchTypePickerButton.disabled || switchTypePickerOpen) {
+    return;
+  }
+  switchTypePickerOpen = true;
+  switchTypePicker.classList.add('is-open');
+  switchTypePickerList.hidden = false;
+  switchTypePickerButton.setAttribute('aria-expanded', 'true');
+  syncSwitchTypePicker({ isValid: true });
+
+  const options = getSwitchTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.switchType === 'string' ? state.switchType : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusSwitchTypeOption(selectedOption || options[0]);
+}
+
+function closeSwitchTypePicker({ focusButton = false } = {}) {
+  if (!switchTypePicker || !switchTypePickerButton || !switchTypePickerList) {
+    return;
+  }
+  if (!switchTypePickerOpen) {
+    if (focusButton && !switchTypePickerButton.disabled) {
+      switchTypePickerButton.focus();
+    }
+    return;
+  }
+  switchTypePickerOpen = false;
+  switchTypePicker.classList.remove('is-open');
+  switchTypePickerList.hidden = true;
+  switchTypePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !switchTypePickerButton.disabled) {
+    switchTypePickerButton.focus();
+  }
+}
+
+function toggleSwitchTypePicker() {
+  if (switchTypePickerOpen) {
+    closeSwitchTypePicker({ focusButton: false });
+  } else {
+    openSwitchTypePicker();
+  }
+}
+
+function moveSwitchTypeOption(delta) {
+  const options = getSwitchTypeOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeIndex = options.findIndex(option => option === active);
+  let nextIndex = activeIndex + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  }
+  if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  focusSwitchTypeOption(options[nextIndex]);
+}
+
+function handleSwitchTypeButtonKeydown(event) {
+  if (!switchTypePickerList) {
+    return;
+  }
+  const key = event.key;
+  if (key === 'ArrowDown' || key === 'Down') {
+    event.preventDefault();
+    openSwitchTypePicker();
+    const options = getSwitchTypeOptionElements();
+    if (options.length > 0) {
+      focusSwitchTypeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'ArrowUp' || key === 'Up') {
+    event.preventDefault();
+    openSwitchTypePicker();
+    const options = getSwitchTypeOptionElements();
+    if (options.length > 0) {
+      focusSwitchTypeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleSwitchTypePicker();
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeSwitchTypePicker({ focusButton: true });
+  }
+}
+
+function handleSwitchTypeListKeydown(event) {
+  const key = event.key;
+  if (key === 'ArrowDown' || key === 'Down') {
+    event.preventDefault();
+    moveSwitchTypeOption(1);
+    return;
+  }
+  if (key === 'ArrowUp' || key === 'Up') {
+    event.preventDefault();
+    moveSwitchTypeOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getSwitchTypeOptionElements();
+    if (options.length > 0) {
+      focusSwitchTypeOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getSwitchTypeOptionElements();
+    if (options.length > 0) {
+      focusSwitchTypeOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setSwitchTypeSelection(option.dataset.value || '');
+        closeSwitchTypePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeSwitchTypePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeSwitchTypePicker();
+  }
+}
+
+function handleSwitchTypeListClick(event) {
+  if (!switchTypePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !switchTypePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setSwitchTypeSelection(option.dataset.value || '');
+  closeSwitchTypePicker({ focusButton: true });
+}
+
+function handleSwitchTypeListFocusOut() {
+  if (!switchTypePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!switchTypePickerOpen) {
+      return;
+    }
+    if (!switchTypePicker) {
+      closeSwitchTypePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !switchTypePicker.contains(active)) {
+      closeSwitchTypePicker();
+    }
+  }, 0);
+}
+
 function getWasherTypeOptionElements() {
   if (!washerTypePickerList) {
     return [];
@@ -3783,6 +3997,11 @@ function handleDocumentPointer(event) {
       closeWasherTypePicker();
     }
   }
+  if (switchTypePickerOpen && switchTypePicker) {
+    if (!(target instanceof Node) || !switchTypePicker.contains(target)) {
+      closeSwitchTypePicker();
+    }
+  }
   if (fuseValuePickerOpen && fuseValuePicker) {
     if (!(target instanceof Node) || !fuseValuePicker.contains(target)) {
       closeFuseValuePicker();
@@ -3855,6 +4074,11 @@ function handleDocumentFocusIn(event) {
   if (nutTypePickerOpen && nutTypePicker) {
     if (!(target instanceof Node) || !nutTypePicker.contains(target)) {
       closeNutTypePicker();
+    }
+  }
+  if (switchTypePickerOpen && switchTypePicker) {
+    if (!(target instanceof Node) || !switchTypePicker.contains(target)) {
+      closeSwitchTypePicker();
     }
   }
   if (fuseValuePickerOpen && fuseValuePicker) {
@@ -4289,6 +4513,11 @@ export function initEventHandlers() {
       setWasherTypeSelection(washerTypeSelect.value);
     });
   }
+  if (switchTypeSelect) {
+    switchTypeSelect.addEventListener('change', () => {
+      setSwitchTypeSelection(switchTypeSelect.value);
+    });
+  }
 
   if (boltHeadSelect) {
     boltHeadSelect.addEventListener('change', () => {
@@ -4342,6 +4571,16 @@ export function initEventHandlers() {
     washerTypePickerList.addEventListener('keydown', handleWasherTypeListKeydown);
     washerTypePickerList.addEventListener('focusout', handleWasherTypeListFocusOut);
   }
+  if (switchTypePickerButton && switchTypePickerList) {
+    switchTypePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleSwitchTypePicker();
+    });
+    switchTypePickerButton.addEventListener('keydown', handleSwitchTypeButtonKeydown);
+    switchTypePickerList.addEventListener('click', handleSwitchTypeListClick);
+    switchTypePickerList.addEventListener('keydown', handleSwitchTypeListKeydown);
+    switchTypePickerList.addEventListener('focusout', handleSwitchTypeListFocusOut);
+  }
   if (connectorCategoryPickerButton && connectorCategoryPickerList) {
     connectorCategoryPickerButton.addEventListener('click', event => {
       event.preventDefault();
@@ -4383,6 +4622,7 @@ export function initEventHandlers() {
     boltHeadPicker ||
     nutTypePicker ||
     washerTypePicker ||
+    switchTypePicker ||
     fuseValuePicker ||
     componentMountPicker ||
     resistorValuePicker ||
@@ -4400,6 +4640,10 @@ export function initEventHandlers() {
   document.addEventListener('gridfinity:fuse-picker-close', () => {
     closeFuseTypePicker();
     closeFuseValuePicker();
+  });
+
+  document.addEventListener('gridfinity:switch-picker-close', () => {
+    closeSwitchTypePicker();
   });
 
   document.addEventListener('gridfinity:component-picker-close', () => {

--- a/js/forms.js
+++ b/js/forms.js
@@ -3,6 +3,7 @@ import { elements } from './dom-elements.js';
 import {
   fuseValues,
   fuseTypeOptions,
+  switchTypeOptions,
   bearingOptions,
   boltHeadOptions,
   boltDriveOptions,
@@ -69,6 +70,12 @@ const {
   washerTypePickerButton,
   washerTypePickerList,
   washerTypeSelect,
+  switchSelectionRow,
+  switchTypeContainer,
+  switchTypePicker,
+  switchTypePickerButton,
+  switchTypePickerList,
+  switchTypeSelect,
   measurementSystemContainer,
   connectorCategoryContainer,
   connectorCategorySelect,
@@ -201,6 +208,9 @@ let customIconRequestId = 0;
 let lastIconCollection = { style: '', total: 0 };
 const WASHER_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validWasherTypeIds = new Set(washerTypeOptions.map(option => option.id));
+const SWITCH_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validSwitchTypeIds = new Set(switchTypeOptions.map(option => option.id));
+const switchTypeMap = new Map(switchTypeOptions.map(option => [option.id, option]));
 const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const DEFAULT_FUSE_TYPE = 'Glass';
 const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
@@ -1924,6 +1934,170 @@ export function populateNutTypeOptions() {
   syncNutTypePicker({ isValid: true });
 }
 
+export function syncSwitchTypePicker({ isValid = true } = {}) {
+  if (!switchTypeSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.switchType === 'string' ? state.switchType : '';
+  const sanitizedValue = validSwitchTypeIds.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.switchType = sanitizedValue;
+  }
+
+  switchTypeSelect.value = sanitizedValue;
+  if (!sanitizedValue && switchTypeSelect.options.length > 0) {
+    switchTypeSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = sanitizedValue ? switchTypeMap.get(sanitizedValue) || null : null;
+
+  if (switchTypePickerButton) {
+    const label = switchTypePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = switchTypePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = switchTypePickerButton.querySelector(
+      '.bolt-drive-picker__current-icon-image',
+    );
+
+    if (label) {
+      label.textContent = selectedOption
+        ? selectedOption.label
+        : SWITCH_TYPE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption && selectedOption.image) {
+        iconImage.src = selectedOption.image;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      switchTypePickerButton.classList.remove('is-invalid');
+      switchTypePickerButton.removeAttribute('aria-invalid');
+    } else {
+      switchTypePickerButton.classList.add('is-invalid');
+      switchTypePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (switchTypePicker) {
+    switchTypePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (switchTypePickerList) {
+    const optionElements = Array.from(
+      switchTypePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setSwitchTypeSelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validSwitchTypeIds.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.switchType === 'string' ? state.switchType : '';
+
+  state.switchType = sanitizedValue;
+  syncSwitchTypePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updatePreview();
+    updateDownloadState();
+  }
+}
+
+export function populateSwitchTypePicker() {
+  if (!switchTypeSelect) {
+    state.switchType = '';
+    return;
+  }
+
+  const previousType = typeof state.switchType === 'string' ? state.switchType : '';
+
+  switchTypeSelect.innerHTML = '';
+  if (switchTypePickerList) {
+    switchTypePickerList.innerHTML = '';
+  }
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = SWITCH_TYPE_PLACEHOLDER_TEXT;
+  placeholder.disabled = true;
+  placeholder.selected = !previousType;
+  switchTypeSelect.appendChild(placeholder);
+
+  switchTypeOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    switchTypeSelect.appendChild(opt);
+
+    if (switchTypePickerList) {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+
+      if (option.image) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = option.image;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+
+      item.appendChild(icon);
+      item.appendChild(label);
+
+      switchTypePickerList.appendChild(item);
+    }
+  });
+
+  const sanitizedValue = validSwitchTypeIds.has(previousType) ? previousType : '';
+  state.switchType = sanitizedValue;
+  switchTypeSelect.value = sanitizedValue;
+  if (!sanitizedValue) {
+    placeholder.selected = true;
+  }
+
+  switchTypeSelect.disabled = false;
+  switchTypeSelect.title = 'Select switch type';
+  switchTypeSelect.setAttribute('aria-required', 'true');
+
+  if (switchTypePickerButton) {
+    switchTypePickerButton.disabled = false;
+    switchTypePickerButton.setAttribute('aria-expanded', 'false');
+  }
+  if (switchTypePickerList) {
+    switchTypePickerList.hidden = true;
+  }
+
+  syncSwitchTypePicker({ isValid: true });
+}
+
 export function syncWasherTypePicker({ isValid = true } = {}) {
   if (!washerTypeSelect) {
     return;
@@ -3625,6 +3799,21 @@ export function populateStandards() {
     return;
   }
 
+  if (state.hardwareType === 'Switch') {
+    placeholder.textContent = 'Not used for switch labels';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.dataset.defaultText = placeholder.textContent;
+    standardSelect.appendChild(placeholder);
+    standardSelect.disabled = true;
+    standardSelect.title = '';
+    state.standard = '';
+    state.standardCode = '';
+    standardSelect.value = '';
+    updatePreview();
+    return;
+  }
+
   let standards = [];
   let placeholderText = STANDARD_PLACEHOLDER_TEXT;
   let noOptionsText = 'No standards available';
@@ -3914,6 +4103,51 @@ export function onHardwareTypeChange() {
     lengthContainer.style.display = requiresThreadDetails ? '' : 'none';
   }
 
+  if (switchSelectionRow) {
+    switchSelectionRow.classList.toggle('d-none', !showSwitchFields);
+  }
+  if (switchTypeContainer) {
+    switchTypeContainer.classList.toggle('d-none', !showSwitchFields);
+    switchTypeContainer.setAttribute('aria-hidden', !showSwitchFields ? 'true' : 'false');
+  }
+  if (switchTypeSelect) {
+    if (showSwitchFields) {
+      const sanitizedSwitchType = validSwitchTypeIds.has(state.switchType)
+        ? state.switchType
+        : '';
+      switchTypeSelect.value = sanitizedSwitchType;
+      switchTypeSelect.disabled = false;
+      switchTypeSelect.setAttribute('aria-required', 'true');
+      switchTypeSelect.title = 'Select switch type';
+    } else {
+      switchTypeSelect.disabled = true;
+      switchTypeSelect.setAttribute('aria-required', 'false');
+      switchTypeSelect.title = '';
+    }
+  }
+  if (switchTypePickerButton) {
+    switchTypePickerButton.disabled = !showSwitchFields;
+    if (!showSwitchFields) {
+      switchTypePickerButton.setAttribute('aria-expanded', 'false');
+    } else {
+      const isOpen = Boolean(
+        switchTypePicker && switchTypePicker.classList.contains('is-open'),
+      );
+      switchTypePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    }
+  }
+  if (switchTypePickerList) {
+    const shouldHideSwitchList =
+      !showSwitchFields ||
+      !switchTypePicker ||
+      !switchTypePicker.classList.contains('is-open');
+    switchTypePickerList.hidden = shouldHideSwitchList;
+  }
+  if (!showSwitchFields && switchTypePicker) {
+    switchTypePicker.classList.remove('is-open');
+    document.dispatchEvent(new CustomEvent('gridfinity:switch-picker-close'));
+  }
+
   if (bearingOptionsContainer) {
     const hidden = !showBearingFields;
     bearingOptionsContainer.classList.toggle('d-none', hidden);
@@ -4149,6 +4383,7 @@ export function onHardwareTypeChange() {
     syncFuseTypePicker();
     syncFuseValuePicker({ isValid: true });
   }
+  syncSwitchTypePicker({ isValid: true });
   if (connectorNotesHint) {
     connectorNotesHint.classList.toggle('d-none', !showConnectorFields);
   }

--- a/js/render.js
+++ b/js/render.js
@@ -6,6 +6,7 @@ import {
   syncThreadSizePicker,
   syncFuseTypePicker,
   syncFuseValuePicker,
+  syncSwitchTypePicker,
   syncComponentMountPicker,
   syncResistorValuePicker,
   syncCapacitorValuePicker,
@@ -23,6 +24,7 @@ import {
   connectorCategoryImageMap,
   getConnectorSeriesImage,
   hardwareTypeImageMap,
+  switchTypeImageMap,
   boltHeadMap,
   boltDriveMap,
   nutTypeMap,
@@ -57,6 +59,9 @@ const {
   washerTypeSelect,
   washerTypeContainer,
   washerTypeMessage,
+  switchTypeSelect,
+  switchTypeContainer,
+  switchTypeMessage,
   fuseTypeSelect,
   fuseTypeContainer,
   fuseTypeMessage,
@@ -973,7 +978,7 @@ export function isLabelReady() {
     return Boolean(state.threadSize && state.length);
   }
   if (state.hardwareType === 'Switch') {
-    return true;
+    return Boolean(state.switchType);
   }
   return Boolean(state.threadSize);
 }
@@ -1044,6 +1049,14 @@ function applyValidationFeedback() {
       valid: valueValid,
     });
     syncFuseValuePicker({ isValid: valueValid });
+    updateInputFieldState({
+      input: switchTypeSelect,
+      container: switchTypeContainer,
+      messageElement: switchTypeMessage,
+      valid: true,
+      message: '',
+    });
+    syncSwitchTypePicker({ isValid: true });
   } else {
     updateInputFieldState({
       input: fuseTypeSelect,
@@ -1060,6 +1073,26 @@ function applyValidationFeedback() {
       valid: true,
     });
     syncFuseValuePicker({ isValid: true });
+    if (hardwareType === 'Switch') {
+      const switchValid = Boolean(state.switchType);
+      updateInputFieldState({
+        input: switchTypeSelect,
+        container: switchTypeContainer,
+        messageElement: switchTypeMessage,
+        valid: switchValid,
+        message: switchValid ? '' : 'Select a switch type',
+      });
+      syncSwitchTypePicker({ isValid: switchValid });
+    } else {
+      updateInputFieldState({
+        input: switchTypeSelect,
+        container: switchTypeContainer,
+        messageElement: switchTypeMessage,
+        valid: true,
+        message: '',
+      });
+      syncSwitchTypePicker({ isValid: true });
+    }
   }
 
   if (
@@ -1406,6 +1439,19 @@ function resolveHardwareImageInfo() {
       alt,
     };
   }
+  if (state.hardwareType === 'Switch') {
+    const switchId = (state.switchType || '').trim();
+    const imageSrc = switchTypeImageMap.get(switchId) || hardwareTypeImageMap.Switch || '';
+    if (!imageSrc) {
+      return null;
+    }
+    const altLabel = switchId || 'Switch';
+    return {
+      type: 'photo',
+      src: imageSrc,
+      alt: `${altLabel} illustration`,
+    };
+  }
   if (state.hardwareType === 'Connector') {
     const categoryId = (state.connectorCategory || '').trim();
     const category = findConnectorCategory(categoryId);
@@ -1692,6 +1738,12 @@ function buildTextLines() {
     const line2 = state.showStandard && state.bearingDetails ? state.bearingDetails : '';
     const line3 = state.notes || '';
     return { line1, line2, line3 };
+  }
+
+  if (state.hardwareType === 'Switch') {
+    const line1 = state.switchType || 'Switch';
+    const line2 = state.notes || '';
+    return { line1, line2, line3: '' };
   }
 
   if (ELECTRICAL_COMPONENT_TYPES.has(state.hardwareType)) {

--- a/js/state.js
+++ b/js/state.js
@@ -2,6 +2,7 @@ export const state = {
   hardwareType: 'Bolt',
   systemType: 'Metric',
   fuseType: 'Glass',
+  switchType: '',
   threadSize: '',
   length: '',
   fuseValue: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -9,6 +9,7 @@ import {
   boltHeadOptions,
   boltDriveOptions,
   screwTypeOptions,
+  switchTypeOptions,
   electricalComponentTypes,
   componentMountOptions as componentMountOptionList,
   resistorValueOptions,
@@ -22,6 +23,7 @@ const FIELD_MAP = {
   hardwareType: 'ht',
   systemType: 'ms',
   fuseType: 'ft',
+  switchType: 'sw',
   threadSize: 'ts',
   length: 'ln',
   fuseValue: 'fv',
@@ -68,6 +70,7 @@ const fuseTypeOptions = new Set(
     ? Array.from(elements.fuseTypeSelect.options, option => option.value).filter(Boolean)
     : [],
 );
+const switchTypeOptionSet = new Set(switchTypeOptions.map(option => option.id));
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
 const DEFAULT_COMPONENT_TYPE = electricalComponentTypes[0] || 'Resistor';
 const componentCategoryOptions = new Set(electricalComponentTypes);
@@ -405,6 +408,17 @@ function applyExpandedPayload(expanded) {
     state.fuseValue = '';
     state.glassSpeed = '';
     state.glassSize = '';
+  }
+
+  if (state.hardwareType === 'Switch') {
+    if (typeof expanded.switchType === 'string') {
+      const trimmedSwitch = expanded.switchType.trim();
+      state.switchType = switchTypeOptionSet.has(trimmedSwitch) ? trimmedSwitch : '';
+    } else {
+      state.switchType = '';
+    }
+  } else {
+    state.switchType = '';
   }
 
   if (typeof expanded.notes === 'string') {


### PR DESCRIPTION
## Summary
- add a Switch Type picker with microswitch and tactile options and surface the selection in state
- update form population, events, rendering, and URL state so switch labels require and display the chosen type and image
- wire the picker into initialization flows and tidy unused action variables triggered by linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7a962d508329b7ff53ff5e922197