### PR TITLE
Fix switch chip image visibility

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1381,7 +1381,9 @@ export function syncHardwareTypePicker() {
     const label = hardwareTypePickerButton.querySelector('.part-type-picker__chip-label');
     const iconImage = hardwareTypePickerButton.querySelector('.part-type-picker__chip-image');
     const fallback = hardwareTypePickerButton.querySelector('.part-type-picker__chip-fallback');
-    const imageSrc = resolvedValue ? hardwareTypeImageMap[resolvedValue] : '';
+    const imageSrc = resolvedValue
+      ? hardwareTypeImageMap[resolvedValue] ?? hardwareTypeImageMap.get?.(resolvedValue) ?? ''
+      : '';
 
     let optionLabel = HARDWARE_TYPE_PLACEHOLDER_TEXT;
     if (resolvedValue && hardwareTypeSelect) {
@@ -1403,11 +1405,13 @@ export function syncHardwareTypePicker() {
       if (imageSrc) {
         iconImage.src = imageSrc;
         iconImage.hidden = false;
+        iconImage.removeAttribute('hidden');
         if (resolvedValue === 'Bolt' || resolvedValue === 'Screw') {
           iconImage.classList.add('is-rotated-90');
         }
       } else {
         iconImage.hidden = true;
+        iconImage.setAttribute('hidden', '');
         iconImage.removeAttribute('src');
       }
     }


### PR DESCRIPTION
## Summary
- ensure the hardware type picker resolves artwork for the Switch option even when values are trimmed
- remove the hidden attribute when an image is available so the chip renders its artwork

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7e6bf8a48329a4b615890c226cc2