### PR TITLE
Add arcade button option to switch picker

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -87,6 +87,11 @@ export const switchTypeOptions = [
     image: 'images/switches/microswitch_roller.svg',
   },
   {
+    id: 'Arcade Button',
+    label: 'Arcade Button',
+    image: 'images/switches/arcade_button.svg',
+  },
+  {
     id: 'Tactile Switch',
     label: 'Tactile Switch',
     image: 'images/switches/tactile_switch.svg',


### PR DESCRIPTION
## Summary
- add the Arcade Button option to the switch type picker so the existing artwork can be selected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8583de188329a6d2c8c46e22cb6d