### PR TITLE
Improve label rendering with shared SVG pipeline

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1,0 +1,945 @@
+import { loadQrCodeLibrary } from '../lazy-loaders.js';
+
+const SVG_XMLNS = 'http://www.w3.org/2000/svg';
+const LABEL_BACKGROUND_COLOR = '#ffffff';
+const LABEL_TEXT_COLOR = '#000000';
+const FRAME_STROKE_COLOR = 'rgba(100, 116, 139, 0.6)';
+const LABEL_FONT_FAMILY = "'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif";
+
+const MIN_FONT_SIZE_PT = 8.25;
+const LINE_HEIGHT_RATIO = 1.12;
+const LETTER_SPACING_STEPS = [0, -0.15, -0.3, -0.45, -0.6];
+const MAX_FIT_ITERATIONS = 14;
+
+const inlineImageCache = new Map();
+
+const textMeasurementCanvas =
+  typeof document !== 'undefined' ? document.createElement('canvas') : null;
+const textMeasurementContext = textMeasurementCanvas
+  ? textMeasurementCanvas.getContext('2d')
+  : null;
+
+const qrCanvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
+
+export function mmToPx(mm, pxPerMm) {
+  if (!Number.isFinite(mm) || !Number.isFinite(pxPerMm)) {
+    return 0;
+  }
+  return mm * pxPerMm;
+}
+
+export function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  const rounded = Math.round(value * 1000) / 1000;
+  if (Math.abs(rounded - Math.round(rounded)) < 0.0001) {
+    return String(Math.round(rounded));
+  }
+  return rounded.toString();
+}
+
+export function escapeXml(str) {
+  return (str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function toFontPx(pt, pxPerMm) {
+  const pointsPerInch = 72;
+  const mmPerInch = 25.4;
+  const dpi = pxPerMm * mmPerInch;
+  return (pt / pointsPerInch) * dpi;
+}
+
+function measureTextWidth(text, fontSizePx, fontWeight, fontFamily, letterSpacingPx) {
+  if (!text) {
+    return 0;
+  }
+  let width = 0;
+  if (textMeasurementContext) {
+    textMeasurementContext.font = `${fontWeight} ${fontSizePx}px ${fontFamily}`;
+    const metrics = textMeasurementContext.measureText(text);
+    width = metrics.width || 0;
+  } else {
+    width = text.length * fontSizePx * 0.6;
+  }
+  if (letterSpacingPx) {
+    const normalized = text.replace(/\s+$/g, '');
+    width += Math.max(0, normalized.length - 1) * letterSpacingPx;
+  }
+  return width;
+}
+
+function applyEllipsis(line, fontSizePx, fontWeight, fontFamily, letterSpacingPx, maxWidth) {
+  if (!line) {
+    return '…';
+  }
+  const ellipsis = '…';
+  let trimmed = line.trimEnd();
+  while (trimmed.length > 0) {
+    const candidate = `${trimmed}${ellipsis}`;
+    const width = measureTextWidth(candidate, fontSizePx, fontWeight, fontFamily, letterSpacingPx);
+    if (width <= maxWidth + 0.25) {
+      return candidate;
+    }
+    trimmed = trimmed.slice(0, -1).trimEnd();
+  }
+  return ellipsis;
+}
+
+function wrapSegment({
+  segment,
+  fontSizePx,
+  fontWeight,
+  fontFamily,
+  letterSpacingPx,
+  maxWidth,
+}) {
+  const words = segment.split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return [''];
+  }
+  const lines = [];
+  let current = words[0];
+  for (let i = 1; i < words.length; i += 1) {
+    const candidate = `${current} ${words[i]}`;
+    const width = measureTextWidth(candidate, fontSizePx, fontWeight, fontFamily, letterSpacingPx);
+    if (width <= maxWidth + 0.25) {
+      current = candidate;
+    } else if (measureTextWidth(words[i], fontSizePx, fontWeight, fontFamily, letterSpacingPx) <= maxWidth + 0.25) {
+      lines.push(current);
+      current = words[i];
+    } else {
+      // Fallback to character wrapping
+      const chars = words[i].split('');
+      let chunk = '';
+      chars.forEach(char => {
+        const candidateChunk = chunk ? `${chunk}${char}` : char;
+        const chunkWidth = measureTextWidth(
+          candidateChunk,
+          fontSizePx,
+          fontWeight,
+          fontFamily,
+          letterSpacingPx,
+        );
+        if (chunkWidth <= maxWidth + 0.25) {
+          chunk = candidateChunk;
+        } else {
+          if (chunk) {
+            lines.push(chunk);
+          }
+          chunk = char;
+        }
+      });
+      if (chunk) {
+        if (measureTextWidth(chunk, fontSizePx, fontWeight, fontFamily, letterSpacingPx) > maxWidth + 0.25) {
+          // Force tiny segments if nothing fits
+          const forcedChars = chunk.split('');
+          forcedChars.forEach(singleChar => {
+            lines.push(singleChar);
+          });
+          chunk = '';
+        }
+        if (chunk) {
+          lines.push(chunk);
+        }
+      }
+      current = '';
+    }
+  }
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function layoutText({
+  text,
+  fontSizePx,
+  fontWeight,
+  fontFamily,
+  letterSpacingPx,
+  boxWidthPx,
+  boxHeightPx,
+  lineClamp,
+}) {
+  const normalized = (text || '').replace(/[\r\t]+/g, ' ').replace(/\s+\n/g, '\n').trim();
+  if (!normalized) {
+    return { lines: [], lineWidths: [], totalHeightPx: 0, ellipsisApplied: false };
+  }
+  const segments = normalized.split(/\n/);
+  const lines = [];
+  segments.forEach(segment => {
+    const trimmed = segment.trim();
+    if (!trimmed) {
+      lines.push('');
+      return;
+    }
+    if (measureTextWidth(trimmed, fontSizePx, fontWeight, fontFamily, letterSpacingPx) <= boxWidthPx + 0.25) {
+      lines.push(trimmed);
+      return;
+    }
+    wrapSegment({
+      segment: trimmed,
+      fontSizePx,
+      fontWeight,
+      fontFamily,
+      letterSpacingPx,
+      maxWidth: boxWidthPx,
+    }).forEach(line => {
+      lines.push(line.trimEnd());
+    });
+  });
+
+  let ellipsisApplied = false;
+  const clamp = Number.isFinite(lineClamp) && lineClamp > 0 ? Math.floor(lineClamp) : null;
+  if (clamp && lines.length > clamp) {
+    const retained = lines.slice(0, clamp);
+    const lastIndex = retained.length - 1;
+    retained[lastIndex] = applyEllipsis(
+      retained[lastIndex],
+      fontSizePx,
+      fontWeight,
+      fontFamily,
+      letterSpacingPx,
+      boxWidthPx,
+    );
+    ellipsisApplied = true;
+    const widths = retained.map(line =>
+      measureTextWidth(line, fontSizePx, fontWeight, fontFamily, letterSpacingPx),
+    );
+    return {
+      lines: retained,
+      lineWidths: widths,
+      totalHeightPx: retained.length * fontSizePx * LINE_HEIGHT_RATIO,
+      ellipsisApplied,
+    };
+  }
+
+  const lineHeightPx = fontSizePx * LINE_HEIGHT_RATIO;
+  const totalHeightPx = lines.length * lineHeightPx;
+  const fitsHeight = totalHeightPx <= boxHeightPx + 0.25;
+  const lineWidths = lines.map(line =>
+    measureTextWidth(line, fontSizePx, fontWeight, fontFamily, letterSpacingPx),
+  );
+  return {
+    lines,
+    lineWidths,
+    totalHeightPx,
+    ellipsisApplied,
+    fits: fitsHeight,
+  };
+}
+
+export function fitTextToBox({
+  text,
+  fontFamily = LABEL_FONT_FAMILY,
+  fontWeight = 400,
+  maxFontSizePx,
+  minFontSizePx,
+  boxWidthPx,
+  boxHeightPx,
+  lineClamp,
+}) {
+  const safeWidth = Math.max(0, boxWidthPx || 0);
+  const safeHeight = Math.max(0, boxHeightPx || 0);
+  const minSize = Math.max(minFontSizePx || 0, 1);
+  const sizeUpperBound = Math.max(minSize, maxFontSizePx || minSize);
+  const candidates = [];
+
+  LETTER_SPACING_STEPS.forEach(letterSpacingPx => {
+    let low = minSize;
+    let high = sizeUpperBound;
+    let best = null;
+    for (let i = 0; i < MAX_FIT_ITERATIONS && high - low > 0.2; i += 1) {
+      const mid = (low + high) / 2;
+      const layout = layoutText({
+        text,
+        fontSizePx: mid,
+        fontWeight,
+        fontFamily,
+        letterSpacingPx,
+        boxWidthPx: safeWidth,
+        boxHeightPx: safeHeight,
+        lineClamp,
+      });
+      const fitsWidth = layout.lines.every(line =>
+        measureTextWidth(line, mid, fontWeight, fontFamily, letterSpacingPx) <= safeWidth + 0.25,
+      );
+      if (layout.lines.length === 0) {
+        best = {
+          fontSizePx: minSize,
+          lines: [],
+          lineWidths: [],
+          letterSpacingPx,
+          ellipsisApplied: false,
+          totalHeightPx: 0,
+        };
+        break;
+      }
+      if (fitsWidth && layout.fits !== false && layout.totalHeightPx <= safeHeight + 0.25) {
+        best = {
+          fontSizePx: mid,
+          lines: layout.lines,
+          lineWidths: layout.lineWidths,
+          letterSpacingPx,
+          ellipsisApplied: layout.ellipsisApplied || false,
+          totalHeightPx: layout.totalHeightPx,
+        };
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+    if (!best) {
+      const fallbackLayout = layoutText({
+        text,
+        fontSizePx: minSize,
+        fontWeight,
+        fontFamily,
+        letterSpacingPx,
+        boxWidthPx: safeWidth,
+        boxHeightPx: safeHeight,
+        lineClamp,
+      });
+      best = {
+        fontSizePx: minSize,
+        lines: fallbackLayout.lines,
+        lineWidths: fallbackLayout.lineWidths,
+        letterSpacingPx,
+        ellipsisApplied: fallbackLayout.ellipsisApplied || false,
+        totalHeightPx: fallbackLayout.totalHeightPx,
+      };
+    }
+    candidates.push(best);
+  });
+
+  candidates.sort((a, b) => {
+    if (a.lines.length === 0 && b.lines.length > 0) {
+      return 1;
+    }
+    if (b.lines.length === 0 && a.lines.length > 0) {
+      return -1;
+    }
+    if (Math.abs(b.fontSizePx - a.fontSizePx) > 0.25) {
+      return b.fontSizePx - a.fontSizePx;
+    }
+    if (a.ellipsisApplied !== b.ellipsisApplied) {
+      return a.ellipsisApplied ? 1 : -1;
+    }
+    return a.totalHeightPx - b.totalHeightPx;
+  });
+
+  const chosen = candidates[0] || {
+    fontSizePx: minSize,
+    lines: [],
+    lineWidths: [],
+    letterSpacingPx: 0,
+    ellipsisApplied: false,
+    totalHeightPx: 0,
+  };
+  const lineHeightPx = chosen.fontSizePx * LINE_HEIGHT_RATIO;
+  return {
+    fontSizePx: chosen.fontSizePx,
+    lines: chosen.lines,
+    lineWidths: chosen.lineWidths,
+    letterSpacingPx: chosen.letterSpacingPx,
+    ellipsisApplied: chosen.ellipsisApplied,
+    totalHeightPx: chosen.totalHeightPx,
+    lineHeightPx,
+  };
+}
+
+async function resolveSvgImageHref(href) {
+  if (!href) {
+    return '';
+  }
+  const normalized = href.trim();
+  if (!normalized) {
+    return '';
+  }
+  if (/^(data:|blob:)/i.test(normalized)) {
+    return normalized;
+  }
+  if (inlineImageCache.has(normalized)) {
+    return inlineImageCache.get(normalized);
+  }
+  if (typeof fetch !== 'function') {
+    inlineImageCache.set(normalized, normalized);
+    return normalized;
+  }
+  try {
+    const response = await fetch(normalized, { cache: 'force-cache' });
+    if (!response.ok) {
+      throw new Error(`Unexpected response status ${response.status}`);
+    }
+    const blob = await response.blob();
+    const reader = new FileReader();
+    const dataUrlPromise = new Promise((resolve, reject) => {
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Unable to convert image.'));
+    });
+    reader.readAsDataURL(blob);
+    const dataUrl = await dataUrlPromise;
+    inlineImageCache.set(normalized, dataUrl);
+    return dataUrl;
+  } catch (error) {
+    console.warn('Unable to inline SVG image asset, using absolute URL instead.', error);
+    inlineImageCache.set(normalized, normalized);
+    return normalized;
+  }
+}
+
+async function generateQrImage(content, sizePx) {
+  if (!qrCanvas || !(sizePx > 0) || !content) {
+    return null;
+  }
+  const size = Math.max(1, Math.round(sizePx));
+  qrCanvas.width = size;
+  qrCanvas.height = size;
+  const qrLib = await loadQrCodeLibrary();
+  const renderFn = qrLib && typeof qrLib.toCanvas === 'function' ? qrLib.toCanvas : null;
+  if (!renderFn) {
+    throw new Error('QR code renderer unavailable');
+  }
+  await renderFn.call(qrLib, qrCanvas, content, {
+    width: size,
+    margin: 1,
+    color: {
+      dark: '#000000',
+      light: '#00000000',
+    },
+  });
+  return { dataUrl: qrCanvas.toDataURL('image/png'), sizePx: size };
+}
+
+function computeMediaZoneWidth({
+  printableWidthPx,
+  printableHeightPx,
+  printableWidthMm,
+  contentWidthPx,
+  minTextWidthPx,
+  hasMedia,
+  stackIcons,
+}) {
+  if (!hasMedia) {
+    return 0;
+  }
+  if (!(contentWidthPx > 0) || contentWidthPx <= minTextWidthPx) {
+    return 0;
+  }
+  const aspect = printableHeightPx > 0 ? printableHeightPx / Math.max(printableWidthPx, 1) : 0;
+  const basePercent = 0.28 + aspect * 0.12;
+  const clampedPercent = Math.min(0.36, Math.max(0.24, basePercent));
+  let zoneWidth = contentWidthPx * clampedPercent;
+  if (stackIcons) {
+    zoneWidth = Math.max(zoneWidth, contentWidthPx * 0.32);
+  }
+  if (stackIcons && Number.isFinite(printableWidthMm) && printableWidthMm > 0 && printableWidthMm < 45) {
+    zoneWidth = Math.max(zoneWidth, contentWidthPx * 0.34);
+  }
+  const maxAllowed = contentWidthPx - minTextWidthPx;
+  if (maxAllowed <= 0) {
+    return 0;
+  }
+  return Math.min(zoneWidth, maxAllowed);
+}
+
+function layoutMediaZone({
+  hardwareInfo,
+  rect,
+  stackIcons,
+  paddingPx,
+  gapPx,
+}) {
+  if (!hardwareInfo || rect.width <= 0 || rect.height <= 0) {
+    return { width: 0, elements: [] };
+  }
+  const elements = [];
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+  const paddedWidth = Math.max(0, rect.width - paddingPx * 2);
+  const paddedHeight = Math.max(0, rect.height - paddingPx * 2);
+
+  if (hardwareInfo.type === 'custom-image') {
+    if (hardwareInfo.hasImage && hardwareInfo.src) {
+      elements.push({
+        type: 'image',
+        href: hardwareInfo.src,
+        x: rect.x + paddingPx,
+        y: rect.y + paddingPx,
+        width: paddedWidth,
+        height: paddedHeight,
+        title: hardwareInfo.alt || 'Custom image',
+      });
+      return { width: rect.width, elements };
+    }
+    elements.push({
+      type: 'placeholder',
+      x: rect.x + paddingPx / 2,
+      y: rect.y + paddingPx / 2,
+      width: Math.max(0, rect.width - paddingPx),
+      height: Math.max(0, rect.height - paddingPx),
+      label: 'Add image',
+    });
+    return { width: rect.width, elements };
+  }
+
+  if (hardwareInfo.type === 'custom-icon') {
+    const iconLabel = hardwareInfo.iconLabel || hardwareInfo.iconName || 'Custom icon';
+    const hasSvg = typeof hardwareInfo.iconSvgData === 'string' && hardwareInfo.iconSvgData.trim().length > 0;
+    if (hasSvg) {
+      elements.push({
+        type: 'image',
+        href: hardwareInfo.iconSvgData,
+        x: rect.x + paddingPx,
+        y: rect.y + paddingPx,
+        width: paddedWidth,
+        height: paddedHeight,
+        title: iconLabel,
+      });
+      return { width: rect.width, elements };
+    }
+    if (hardwareInfo.hasIcon && hardwareInfo.iconUnicode) {
+      const iconSize = Math.min(paddedWidth, paddedHeight);
+      elements.push({
+        type: 'icon',
+        unicode: hardwareInfo.iconUnicode,
+        style: hardwareInfo.iconStyle || 'solid',
+        label: iconLabel,
+        x: centerX,
+        y: centerY,
+        size: iconSize,
+      });
+      return { width: rect.width, elements };
+    }
+    elements.push({
+      type: 'placeholder',
+      x: rect.x + paddingPx / 2,
+      y: rect.y + paddingPx / 2,
+      width: Math.max(0, rect.width - paddingPx),
+      height: Math.max(0, rect.height - paddingPx),
+      label: 'Choose icon',
+    });
+    return { width: rect.width, elements };
+  }
+
+  const stackedCandidates = new Set(['bolt', 'screw']);
+  if (stackedCandidates.has(hardwareInfo.type)) {
+    const images = Array.isArray(hardwareInfo.images)
+      ? hardwareInfo.images.filter(image => image && image.src)
+      : [];
+    if (images.length === 0) {
+      return { width: 0, elements: [] };
+    }
+    if (stackIcons && images.length >= 2) {
+      const slotHeight = (rect.height - gapPx * (images.length - 1)) / images.length;
+      const iconSize = Math.min(slotHeight - paddingPx * 2, rect.width - paddingPx * 2);
+      let cursorY = rect.y;
+      images.forEach(image => {
+        const size = Math.max(1, iconSize);
+        const offsetX = centerX - size / 2;
+        const offsetY = cursorY + (slotHeight - size) / 2;
+        elements.push({
+          type: 'image',
+          href: image.src,
+          x: offsetX,
+          y: offsetY,
+          width: size,
+          height: size,
+          title: image.alt || 'Hardware reference',
+        });
+        cursorY += slotHeight + gapPx;
+      });
+      return { width: rect.width, elements };
+    }
+    const slotWidth = (rect.width - gapPx * (images.length - 1)) / images.length;
+    const iconSize = Math.min(slotWidth - paddingPx * 2, rect.height - paddingPx * 2);
+    let cursorX = rect.x;
+    images.forEach(image => {
+      const size = Math.max(1, iconSize);
+      const offsetX = cursorX + (slotWidth - size) / 2;
+      const offsetY = centerY - size / 2;
+      elements.push({
+        type: 'image',
+        href: image.src,
+        x: offsetX,
+        y: offsetY,
+        width: size,
+        height: size,
+        title: image.alt || 'Hardware reference',
+      });
+      cursorX += slotWidth + gapPx;
+    });
+    return { width: rect.width, elements };
+  }
+
+  if (hardwareInfo.type === 'photo' || hardwareInfo.type === 'fuse-illustration') {
+    if (!hardwareInfo.src) {
+      return { width: 0, elements: [] };
+    }
+    const width = rect.width - paddingPx * 2;
+    const height = rect.height - paddingPx * 2;
+    const size = Math.max(1, Math.min(width, height));
+    elements.push({
+      type: 'image',
+      href: hardwareInfo.src,
+      x: centerX - size / 2,
+      y: centerY - size / 2,
+      width: size,
+      height: size,
+      title: hardwareInfo.alt || 'Hardware illustration',
+    });
+    return { width: rect.width, elements };
+  }
+
+  return { width: 0, elements: [] };
+}
+
+function layoutTextBlocks({
+  textLines,
+  textRect,
+  pxPerMm,
+  minFontSizePx,
+}) {
+  const mainLine = (textLines.line1 || '').trim();
+  const subtitleLines = [textLines.line2, textLines.line3].filter(line => (line || '').trim().length > 0);
+  if (!mainLine && subtitleLines.length === 0) {
+    return { blocks: [], main: null, subtitles: [] };
+  }
+  const minMainShare = 0.44;
+  const maxMainShare = 0.68;
+  let mainShare = subtitleLines.length > 0 ? 0.58 : 0.7;
+  let chosenLayout = null;
+
+  const maxFontSizeEstimate = Math.max(textRect.height, textRect.width);
+
+  for (let iteration = 0; iteration < 6; iteration += 1) {
+    const mainHeight = textRect.height * mainShare;
+    const subtitleHeight = Math.max(0, textRect.height - mainHeight);
+
+    const mainFit = fitTextToBox({
+      text: mainLine,
+      fontWeight: 800,
+      maxFontSizePx: Math.max(12, Math.min(mainHeight, maxFontSizeEstimate)),
+      minFontSizePx: minFontSizePx,
+      boxWidthPx: textRect.width,
+      boxHeightPx: Math.max(mainHeight, minFontSizePx * LINE_HEIGHT_RATIO),
+      lineClamp: 2,
+    });
+
+    const subtitleFits = [];
+    let remainingHeight = subtitleHeight;
+    let overflow = false;
+    if (subtitleLines.length > 0) {
+      subtitleLines.forEach((line, index) => {
+        const linesRemaining = subtitleLines.length - index;
+        const allocation = linesRemaining > 0 ? remainingHeight / linesRemaining : remainingHeight;
+        const fit = fitTextToBox({
+          text: line,
+          fontWeight: 600,
+          maxFontSizePx: Math.min(allocation, textRect.width),
+          minFontSizePx: Math.max(minFontSizePx * 0.85, 10),
+          boxWidthPx: textRect.width,
+          boxHeightPx: Math.max(allocation, minFontSizePx * LINE_HEIGHT_RATIO),
+          lineClamp: 2,
+        });
+        subtitleFits.push(fit);
+        remainingHeight -= fit.totalHeightPx;
+        if (index < subtitleLines.length - 1) {
+          const gap = Math.max(mmToPx(0.4, pxPerMm), Math.min(fit.fontSizePx, 18) * 0.2);
+          subtitleFits[subtitleFits.length - 1].gapAfter = gap;
+          remainingHeight -= gap;
+        }
+      });
+      if (remainingHeight < -1) {
+        overflow = true;
+      }
+    }
+
+    if (subtitleLines.length > 0 && overflow && mainShare > minMainShare + 0.01) {
+      mainShare = Math.max(minMainShare, mainShare - 0.06);
+      continue;
+    }
+    if (mainFit.ellipsisApplied && mainShare < maxMainShare - 0.01) {
+      mainShare = Math.min(maxMainShare, mainShare + 0.06);
+      continue;
+    }
+    chosenLayout = { mainFit, subtitleFits, mainHeight, subtitleHeight };
+    break;
+  }
+
+  if (!chosenLayout) {
+    const mainFit = fitTextToBox({
+      text: mainLine,
+      fontWeight: 800,
+      maxFontSizePx: textRect.height,
+      minFontSizePx: minFontSizePx,
+      boxWidthPx: textRect.width,
+      boxHeightPx: textRect.height,
+      lineClamp: 2,
+    });
+    return { blocks: [{ fit: mainFit, top: textRect.y }], main: mainFit, subtitles: [] };
+  }
+
+  const blocks = [];
+  const mainFit = chosenLayout.mainFit;
+  const subtitleFits = chosenLayout.subtitleFits;
+
+  const mainContentHeight = mainFit.totalHeightPx;
+  const mainTop = textRect.y + Math.max(0, (chosenLayout.mainHeight - mainContentHeight) / 2);
+  blocks.push({ fit: mainFit, top: mainTop });
+
+  if (subtitleFits.length > 0) {
+    const subtitleContentHeight = subtitleFits.reduce(
+      (sum, fit) => sum + fit.totalHeightPx + (fit.gapAfter || 0),
+      0,
+    );
+    let cursorY = textRect.y + textRect.height - subtitleContentHeight;
+    subtitleFits.forEach((fit, index) => {
+      blocks.push({ fit, top: cursorY });
+      cursorY += fit.totalHeightPx;
+      const gap = fit.gapAfter || 0;
+      if (gap > 0 && index < subtitleFits.length - 1) {
+        cursorY += gap;
+      }
+    });
+  }
+
+  return { blocks, main: mainFit, subtitles: subtitleFits };
+}
+
+export async function renderLabelSVG({
+  geometry,
+  pxPerMm,
+  textLines,
+  hardwareInfo,
+  qrContent,
+  minTextWidthMm = 9,
+  qrGenerator,
+}) {
+  const labelWidthPx = Math.max(1, Math.round(geometry.labelWidthMm * pxPerMm));
+  const labelHeightPx = Math.max(1, Math.round(geometry.labelHeightMm * pxPerMm));
+  const printableWidthPx = Math.max(0, Math.round(geometry.printableWidthMm * pxPerMm));
+  const printableHeightPx = Math.max(0, Math.round(geometry.printableHeightMm * pxPerMm));
+  const marginXPx = Math.max(0, Math.round(geometry.marginX * pxPerMm));
+  const marginYPx = Math.max(0, Math.round(geometry.marginY * pxPerMm));
+
+  const paddingLeftPx = Math.round(mmToPx(1.2, pxPerMm));
+  const paddingRightPx = Math.round(mmToPx(1.2, pxPerMm));
+  const paddingTopPx = Math.round(mmToPx(1, pxPerMm));
+  const paddingBottomPx = Math.round(mmToPx(1, pxPerMm));
+  const gapPx = Math.round(mmToPx(0.8, pxPerMm));
+
+  const contentRect = {
+    x: marginXPx + paddingLeftPx,
+    y: marginYPx + paddingTopPx,
+    width: Math.max(0, printableWidthPx - paddingLeftPx - paddingRightPx),
+    height: Math.max(0, printableHeightPx - paddingTopPx - paddingBottomPx),
+  };
+
+  const minTextWidthPx = Math.max(Math.round(mmToPx(minTextWidthMm, pxPerMm)), Math.round(contentRect.height * 0.75));
+  const labelHeightMm = geometry.labelHeightMm || 0;
+  const stackIcons = Boolean(
+    hardwareInfo &&
+      Array.isArray(hardwareInfo.images) &&
+      hardwareInfo.images.length >= 2 &&
+      (labelHeightMm >= 18 || contentRect.height / Math.max(contentRect.width, 1) > 1.2),
+  );
+
+  const mediaZoneWidthPx = computeMediaZoneWidth({
+    printableWidthPx,
+    printableHeightPx,
+    printableWidthMm: geometry.printableWidthMm,
+    contentWidthPx: contentRect.width,
+    minTextWidthPx,
+    hasMedia: Boolean(hardwareInfo),
+    stackIcons,
+  });
+
+  const mediaRect = {
+    x: contentRect.x,
+    y: contentRect.y,
+    width: mediaZoneWidthPx,
+    height: contentRect.height,
+  };
+
+  const textRect = {
+    x: mediaZoneWidthPx > 0 ? contentRect.x + mediaZoneWidthPx + gapPx : contentRect.x,
+    y: contentRect.y,
+    width: Math.max(0, contentRect.width - mediaZoneWidthPx - (mediaZoneWidthPx > 0 ? gapPx : 0)),
+    height: contentRect.height,
+  };
+
+  let qrLayout = null;
+  const qrText = typeof qrContent === 'string' ? qrContent.trim() : '';
+  let textWidthForContent = textRect.width;
+  if (qrText) {
+    const qrMaxWidth = Math.max(0, textRect.width * 0.38);
+    const qrMaxHeight = textRect.height;
+    const maxQr = Math.min(qrMaxWidth, qrMaxHeight);
+    const qrMin = mmToPx(4, pxPerMm);
+    const textReserve = Math.max(minTextWidthPx, textRect.width * 0.6);
+    const allowedWidth = Math.max(0, textRect.width - textReserve);
+    const qrCandidate = Math.min(maxQr, allowedWidth);
+    if (qrCandidate >= qrMin) {
+      const qrSize = Math.round(qrCandidate);
+      textWidthForContent = Math.max(minTextWidthPx, textRect.width - qrSize - gapPx);
+      const generator = typeof qrGenerator === 'function' ? qrGenerator : generateQrImage;
+      const qrImage = await generator(qrText, qrSize);
+      if (qrImage) {
+        qrLayout = {
+          x: textRect.x + textWidthForContent + gapPx,
+          y: textRect.y + (textRect.height - qrSize) / 2,
+          size: qrImage.sizePx,
+          dataUrl: qrImage.dataUrl,
+        };
+      }
+    }
+  }
+
+  const textLayoutRect = {
+    x: textRect.x,
+    y: textRect.y,
+    width: textWidthForContent,
+    height: textRect.height,
+  };
+
+  const minFontSizePx = toFontPx(MIN_FONT_SIZE_PT, pxPerMm);
+  const textLayout = layoutTextBlocks({
+    textLines,
+    textRect: textLayoutRect,
+    pxPerMm,
+    minFontSizePx,
+  });
+
+  const mediaLayout = layoutMediaZone({
+    hardwareInfo,
+    rect: mediaRect,
+    stackIcons,
+    paddingPx: Math.round(mmToPx(0.6, pxPerMm)),
+    gapPx: Math.round(mmToPx(1, pxPerMm)),
+  });
+
+  const svgParts = [];
+  svgParts.push(
+    `<svg xmlns="${SVG_XMLNS}" xmlns:xlink="http://www.w3.org/1999/xlink" width="${labelWidthPx}" height="${labelHeightPx}" viewBox="0 0 ${labelWidthPx} ${labelHeightPx}">`,
+  );
+  const strokeWidth = formatNumber(mmToPx(0.25, pxPerMm));
+  svgParts.push(
+    `<rect x="0" y="0" width="${labelWidthPx}" height="${labelHeightPx}" fill="${LABEL_BACKGROUND_COLOR}" stroke="${FRAME_STROKE_COLOR}" stroke-width="${strokeWidth}" vector-effect="non-scaling-stroke" />`,
+  );
+
+  for (const element of mediaLayout.elements) {
+    if (element.type === 'image') {
+      const href = await resolveSvgImageHref(element.href);
+      const escapedHref = escapeXml(href);
+      const title = element.title ? `<title>${escapeXml(element.title)}</title>` : '';
+      svgParts.push(
+        `<image x="${formatNumber(element.x)}" y="${formatNumber(element.y)}" width="${formatNumber(element.width)}" height="${formatNumber(element.height)}" href="${escapedHref}" xlink:href="${escapedHref}">${title}</image>`,
+      );
+    } else if (element.type === 'placeholder') {
+      const radius = Math.round(Math.min(element.width, element.height) * 0.12);
+      svgParts.push(
+        `<rect x="${formatNumber(element.x)}" y="${formatNumber(element.y)}" width="${formatNumber(element.width)}" height="${formatNumber(element.height)}" fill="rgba(255,255,255,0.55)" stroke="rgba(15,23,42,0.25)" stroke-width="1" rx="${radius}" ry="${radius}" />`,
+      );
+      const placeholderFont = Math.max(12, Math.round(Math.min(element.width, element.height) * 0.22));
+      const centerX = element.x + element.width / 2;
+      const centerY = element.y + element.height / 2 + placeholderFont * 0.35;
+      svgParts.push(
+        `<text x="${formatNumber(centerX)}" y="${formatNumber(centerY)}" font-size="${placeholderFont}" font-weight="700" text-anchor="middle" fill="${LABEL_TEXT_COLOR}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)}>${escapeXml(element.label || 'Add image')}</text>`,
+      );
+    } else if (element.type === 'icon') {
+      const fontFamily =
+        element.style === 'brands' ? 'Font Awesome 6 Brands' : 'Font Awesome 6 Free';
+      const fontWeight = element.style === 'regular' ? 400 : element.style === 'solid' ? 900 : 400;
+      const glyph = element.unicode ? `&#x${element.unicode};` : '';
+      const title = element.label ? `<title>${escapeXml(element.label)}</title>` : '';
+      svgParts.push(
+        `<g>${title}<text x="${formatNumber(element.x)}" y="${formatNumber(element.y)}" font-family=${JSON.stringify(fontFamily)} font-weight="${fontWeight}" font-size="${formatNumber(element.size)}" text-anchor="middle" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${glyph}</text></g>`,
+      );
+    }
+  }
+
+  const centerAlign = mediaRect.width > 0 || Boolean(qrLayout);
+  textLayout.blocks.forEach(block => {
+    const { fit, top } = block;
+    let baseline = top + fit.fontSizePx;
+    fit.lines.forEach((line, index) => {
+      const lineWidth = Array.isArray(fit.lineWidths) ? fit.lineWidths[index] || 0 : 0;
+      const offset = centerAlign ? Math.max(0, (textLayoutRect.width - lineWidth) / 2) : 0;
+      const x = textLayoutRect.x + offset;
+      const letterSpacing = fit.letterSpacingPx || 0;
+      const weight = fit === textLayout.main ? 800 : 600;
+      svgParts.push(
+        `<text x="${formatNumber(x)}" y="${formatNumber(baseline)}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="${weight}" font-size="${formatNumber(fit.fontSizePx)}" letter-spacing="${formatNumber(letterSpacing)}" fill="${LABEL_TEXT_COLOR}">${escapeXml(line)}</text>`,
+      );
+      baseline += fit.lineHeightPx;
+    });
+  });
+
+  if (qrLayout) {
+    const escapedQrHref = escapeXml(qrLayout.dataUrl);
+    svgParts.push(
+      `<image x="${formatNumber(qrLayout.x)}" y="${formatNumber(qrLayout.y)}" width="${formatNumber(qrLayout.size)}" height="${formatNumber(qrLayout.size)}" href="${escapedQrHref}" xlink:href="${escapedQrHref}" />`,
+    );
+  }
+
+  svgParts.push('</svg>');
+
+  return {
+    svgMarkup: svgParts.join(''),
+    widthPx: labelWidthPx,
+    heightPx: labelHeightPx,
+    printableWidthMm: geometry.printableWidthMm,
+    printableHeightMm: geometry.printableHeightMm,
+  };
+}
+
+export function createSvgDataUrl(svgMarkup) {
+  const encoded = encodeURIComponent(svgMarkup)
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29');
+  return `data:image/svg+xml;charset=utf-8,${encoded}`;
+}
+
+export function loadSvgImage(svgMarkup, widthPx, heightPx) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decoding = 'async';
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Unable to rasterize SVG.'));
+    img.src = createSvgDataUrl(svgMarkup);
+    img.width = widthPx;
+    img.height = heightPx;
+  });
+}
+
+export function canvasToBlob(canvas, type = 'image/png', quality) {
+  if (typeof canvas.toBlob === 'function') {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(blob => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error('Unable to convert canvas to blob.'));
+        }
+      }, type, quality);
+    });
+  }
+  const dataUrl = canvas.toDataURL(type, quality);
+  const base64 = dataUrl.split(',')[1] || '';
+  const binary = typeof atob === 'function' ? atob(base64) : '';
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  const mimeType = dataUrl.split(';')[0].split(':')[1] || type;
+  return Promise.resolve(new Blob([buffer], { type: mimeType }));
+}
+

--- a/js/render.js
+++ b/js/render.js
@@ -34,7 +34,11 @@ import {
   componentImageMap,
   diodeValueLabelMap,
 } from './data.js';
-import { loadQrCodeLibrary } from './lazy-loaders.js';
+import {
+  renderLabelSVG,
+  loadSvgImage,
+  canvasToBlob,
+} from './label/renderLabelSVG.js';
 
 const {
   labelSizeDisplay,
@@ -107,14 +111,6 @@ const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
 const HORIZONTAL_SAFE_MARGIN_PER_SIDE_MM = 2;
 const VERTICAL_SAFE_MARGIN_PER_SIDE_MM = 1;
 const MIN_TEXT_WIDTH_MM = 9;
-const SVG_XMLNS = 'http://www.w3.org/2000/svg';
-const LABEL_FONT_FAMILY = "'Barlow', 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif";
-const LABEL_BACKGROUND_COLOR = '#ffffff';
-const LABEL_TEXT_COLOR = '#000000';
-const FRAME_STROKE_COLOR = 'rgba(100, 116, 139, 0.6)';
-
-const inlineImageCache = new Map();
-
 const previewDimensions = {
   width: 0,
   height: 0,
@@ -124,14 +120,6 @@ let previewResizeObserver = null;
 let previewReadyState = false;
 let previewStatusFrameId = null;
 let previewRenderRequestId = 0;
-
-const textMeasurementCanvas =
-  typeof document !== 'undefined' ? document.createElement('canvas') : null;
-const textMeasurementContext = textMeasurementCanvas
-  ? textMeasurementCanvas.getContext('2d')
-  : null;
-
-const qrCanvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
 
 const fuseIllustrations = {
   Glass: {
@@ -148,10 +136,6 @@ const fuseIllustrations = {
   },
 };
 
-function mmToPx(mm) {
-  return Number.isFinite(mm) ? mm * pxPerMm : 0;
-}
-
 function formatMillimeters(value) {
   if (!Number.isFinite(value)) {
     return '0';
@@ -162,606 +146,6 @@ function formatMillimeters(value) {
   }
   return rounded.toFixed(1);
 }
-
-function formatNumber(value) {
-  if (!Number.isFinite(value)) {
-    return '0';
-  }
-  const rounded = Math.round(value * 1000) / 1000;
-  if (Math.abs(rounded - Math.round(rounded)) < 0.0001) {
-    return String(Math.round(rounded));
-  }
-  return rounded.toString();
-}
-
-function escapeXml(str) {
-  return (str || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function appendUniqueCandidate(list, value) {
-  if (typeof value !== 'string') {
-    return;
-  }
-  const trimmed = value.trim();
-  if (!trimmed || list.includes(trimmed)) {
-    return;
-  }
-  list.push(trimmed);
-}
-
-function resolveToAbsoluteUrl(src) {
-  if (/^(data:|blob:)/i.test(src)) {
-    return src;
-  }
-  if (/^(https?:|file:|\/\/)/i.test(src)) {
-    return src;
-  }
-
-  const candidates = [];
-
-  if (typeof document !== 'undefined') {
-    appendUniqueCandidate(candidates, document.baseURI);
-    if (document.location) {
-      appendUniqueCandidate(candidates, document.location.href);
-      appendUniqueCandidate(candidates, document.location.origin);
-    }
-  }
-  if (typeof window !== 'undefined' && window.location) {
-    appendUniqueCandidate(candidates, window.location.href);
-    appendUniqueCandidate(candidates, window.location.origin);
-  }
-
-  for (const base of candidates) {
-    try {
-      const resolved = new URL(src, base).href;
-      if (resolved) {
-        return resolved;
-      }
-    } catch (error) {
-      console.warn('Unable to resolve SVG image href, trying next base.', error);
-    }
-  }
-
-  if (typeof window !== 'undefined' && window.location && window.location.href) {
-    try {
-      return new URL(src, window.location.href).href;
-    } catch (error) {
-      console.warn('Unable to resolve SVG image href with window href fallback.', error);
-    }
-  }
-
-  return src;
-}
-
-function bufferToBase64(bytes) {
-  if (typeof bytes === 'string') {
-    return bytes;
-  }
-  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
-    let binary = '';
-    const chunkSize = 0x8000;
-    for (let i = 0; i < bytes.length; i += chunkSize) {
-      const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
-      binary += String.fromCharCode(...chunk);
-    }
-    return window.btoa(binary);
-  }
-  if (typeof globalThis !== 'undefined' && globalThis.Buffer) {
-    return globalThis.Buffer.from(bytes).toString('base64');
-  }
-  throw new Error('Base64 encoding is not supported in this environment.');
-}
-
-async function blobToDataUrl(blob) {
-  const arrayBuffer = await blob.arrayBuffer();
-  const bytes = new Uint8Array(arrayBuffer);
-  const base64 = bufferToBase64(bytes);
-  const mimeType = blob.type || 'application/octet-stream';
-  return `data:${mimeType};base64,${base64}`;
-}
-
-function shouldInlineUrl(url) {
-  if (/^data:/i.test(url)) {
-    return false;
-  }
-  if (typeof window === 'undefined' || !window.location) {
-    return false;
-  }
-  try {
-    const parsed = new URL(url, window.location.href);
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'file:') {
-      if (parsed.origin === 'null') {
-        return true;
-      }
-      return parsed.origin === window.location.origin;
-    }
-  } catch (error) {
-    console.warn('Unable to inspect URL for inlining.', error);
-  }
-  return false;
-}
-
-async function resolveSvgImageHref(src) {
-  if (!src) {
-    return '';
-  }
-
-  const absolute = resolveToAbsoluteUrl(src);
-  if (!shouldInlineUrl(absolute)) {
-    return absolute;
-  }
-
-  if (inlineImageCache.has(absolute)) {
-    return inlineImageCache.get(absolute);
-  }
-
-  if (typeof fetch !== 'function') {
-    inlineImageCache.set(absolute, absolute);
-    return absolute;
-  }
-
-  try {
-    const response = await fetch(absolute, { cache: 'force-cache' });
-    if (!response.ok) {
-      throw new Error(`Unexpected response status ${response.status}`);
-    }
-    const blob = await response.blob();
-    const dataUrl = await blobToDataUrl(blob);
-    inlineImageCache.set(absolute, dataUrl);
-    return dataUrl;
-  } catch (error) {
-    console.warn('Unable to inline SVG image asset, using absolute URL instead.', error);
-    inlineImageCache.set(absolute, absolute);
-    return absolute;
-  }
-}
-
-function createSvgDataUrl(svgMarkup) {
-  const encoded = encodeURIComponent(svgMarkup)
-    .replace(/'/g, '%27')
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29');
-  return `data:image/svg+xml;charset=utf-8,${encoded}`;
-}
-
-function measureTextWidth(text, fontSize, fontWeight = 400, fontStyle = 'normal') {
-  if (!text) {
-    return 0;
-  }
-  if (textMeasurementContext) {
-    textMeasurementContext.font = `${fontStyle} ${fontWeight} ${fontSize}px ${LABEL_FONT_FAMILY}`;
-    const metrics = textMeasurementContext.measureText(text);
-    return metrics.width || 0;
-  }
-  return text.length * fontSize * 0.6;
-}
-
-function fitTextSize({
-  text,
-  maxWidth,
-  maxHeight,
-  minSize,
-  startSize,
-  fontWeight = 400,
-  fontStyle = 'normal',
-}) {
-  if (!text) {
-    return { fontSize: minSize, width: 0 };
-  }
-  const safeMin = Math.max(1, minSize || 1);
-  let size = Math.max(safeMin, startSize || safeMin);
-  if (Number.isFinite(maxHeight) && maxHeight > 0) {
-    size = Math.min(size, maxHeight);
-  }
-  let width = measureTextWidth(text, size, fontWeight, fontStyle);
-  let iterations = 0;
-  while (iterations < 50 && size > safeMin && width > maxWidth) {
-    size = Math.max(safeMin, size - 0.5);
-    width = measureTextWidth(text, size, fontWeight, fontStyle);
-    iterations += 1;
-  }
-  return { fontSize: size, width };
-}
-
-function layoutTextLines(lines, box, options = {}) {
-  const { x, y, width, height } = box;
-  const { centerAlign = false } = options;
-  const result = [];
-  if (!(width > 0) || !(height > 0)) {
-    return result;
-  }
-  const items = [
-    { text: lines.line1, weight: 800, minSize: 6, startRatio: 0.45 },
-    { text: lines.line2, weight: 600, minSize: 5, startRatio: 0.22 },
-    { text: lines.line3, weight: 600, minSize: 5, startRatio: 0.22 },
-  ];
-  const prepared = [];
-  items.forEach((item, index) => {
-    const value = (item.text || '').trim();
-    if (!value) {
-      return;
-    }
-    const startSize = Math.min(Math.max(height * item.startRatio, item.minSize), width);
-    const fitted = fitTextSize({
-      text: value,
-      maxWidth: width,
-      maxHeight: height,
-      minSize: item.minSize,
-      startSize,
-      fontWeight: item.weight,
-    });
-    prepared.push({
-      text: value,
-      fontSize: fitted.fontSize,
-      fontWeight: item.weight,
-      fontStyle: 'normal',
-      width: fitted.width,
-      index,
-    });
-  });
-  if (prepared.length === 0) {
-    return result;
-  }
-  const gaps = [];
-  for (let i = 0; i < prepared.length - 1; i += 1) {
-    const current = prepared[i];
-    const next = prepared[i + 1];
-    gaps.push(Math.round(Math.min(current.fontSize, next.fontSize) * 0.2));
-  }
-  const totalTextHeight = prepared.reduce((sum, item) => sum + item.fontSize, 0);
-  const totalGapHeight = gaps.reduce((sum, gap) => sum + gap, 0);
-  const availableHeight = Math.max(0, height - totalTextHeight - totalGapHeight);
-  const startY = y + availableHeight / 2;
-  let baseline = startY;
-  prepared.forEach((item, index) => {
-    baseline += item.fontSize;
-    const offset = centerAlign ? Math.max(0, (width - item.width) / 2) : 0;
-    result.push({
-      text: item.text,
-      fontSize: item.fontSize,
-      fontWeight: item.fontWeight,
-      fontStyle: item.fontStyle,
-      x: x + offset,
-      baseline: baseline,
-      width: item.width,
-    });
-    const gap = gaps[index] || 0;
-    baseline += gap;
-  });
-  return result;
-}
-
-function layoutHardware(imageInfo, options) {
-  const { x, y, height, maxWidth, gap } = options;
-  if (!imageInfo || !(height > 0) || !(maxWidth > 0)) {
-    return { width: 0, elements: [] };
-  }
-
-  const elements = [];
-  let usedWidth = 0;
-  const safeGap = Math.max(0, gap || 0);
-
-  if (imageInfo.type === 'custom-image' || imageInfo.type === 'custom-icon') {
-    const targetWidth = Math.min(maxWidth, Math.max(height * 0.75, Math.min(height, maxWidth)));
-    if (!(targetWidth > 0)) {
-      return { width: 0, elements: [] };
-    }
-    const top = y;
-    if (imageInfo.type === 'custom-image') {
-      if (imageInfo.hasImage && imageInfo.src) {
-        elements.push({
-          type: 'image',
-          href: imageInfo.src,
-          x,
-          y: top,
-          width: targetWidth,
-          height,
-          title: imageInfo.alt || 'Custom image',
-        });
-      } else {
-        elements.push({
-          type: 'placeholder',
-          x,
-          y: top,
-          width: targetWidth,
-          height,
-          label: 'Add image',
-        });
-      }
-    } else if (imageInfo.type === 'custom-icon') {
-      const iconLabel = imageInfo.iconLabel || imageInfo.iconName || 'Custom icon';
-      const svgHref = typeof imageInfo.iconSvgData === 'string' ? imageInfo.iconSvgData : '';
-      const hasSvg = svgHref.trim().length > 0;
-      const hasUnicode = Boolean(imageInfo.iconUnicode);
-      if (hasSvg) {
-        elements.push({
-          type: 'image',
-          href: svgHref,
-          x,
-          y: top,
-          width: targetWidth,
-          height,
-          title: iconLabel,
-        });
-      } else if (imageInfo.hasIcon && hasUnicode) {
-        elements.push({
-          type: 'icon',
-          x,
-          y: top,
-          width: targetWidth,
-          height,
-          unicode: imageInfo.iconUnicode,
-          style: imageInfo.iconStyle || 'solid',
-          label: iconLabel,
-        });
-      } else {
-        elements.push({
-          type: 'placeholder',
-          x,
-          y: top,
-          width: targetWidth,
-          height,
-          label: 'Choose icon',
-        });
-      }
-    }
-    usedWidth = targetWidth;
-    return { width: usedWidth, elements };
-  }
-
-  if (imageInfo.type === 'bolt' || imageInfo.type === 'screw') {
-    const images = Array.isArray(imageInfo.images)
-      ? imageInfo.images.filter(img => img && img.src)
-      : [];
-    if (images.length === 0) {
-      return { width: 0, elements: [] };
-    }
-    const minWidth = Math.min(maxWidth, height);
-    const maxWidthEstimate = Math.min(maxWidth, height * 2);
-    const effectiveWidth = Math.max(minWidth, maxWidthEstimate);
-    const groupGap = Math.max(4, Math.round(safeGap * 1.1));
-    const totalGap = groupGap * Math.max(images.length - 1, 0);
-    const slotWidth = Math.max(1, (effectiveWidth - totalGap) / images.length);
-    let cursorX = x;
-    images.forEach(image => {
-      elements.push({
-        type: 'image',
-        href: image.src,
-        x: cursorX,
-        y,
-        width: slotWidth,
-        height,
-        title: image.alt || 'Hardware reference',
-      });
-      cursorX += slotWidth + groupGap;
-    });
-    const calculatedWidth = cursorX - x - groupGap;
-    usedWidth = Math.min(effectiveWidth, Math.min(maxWidth, calculatedWidth));
-    return { width: usedWidth, elements };
-  }
-
-  if (imageInfo.type === 'fuse-illustration') {
-    const width = Math.max(Math.min(maxWidth, height * 1.15), height * 0.85);
-    const limitedWidth = Math.min(width, maxWidth);
-    const top = y + (height - height) / 2;
-    elements.push({
-      type: 'image',
-      href: imageInfo.src,
-      x,
-      y: top,
-      width: limitedWidth,
-      height,
-      title: imageInfo.alt || 'Fuse illustration',
-    });
-    usedWidth = limitedWidth;
-    return { width: usedWidth, elements };
-  }
-
-  if (imageInfo.type === 'photo') {
-    const minWidth = height * 0.8;
-    const maxWidthEstimate = height * 1.2;
-    const chosenWidth = Math.max(minWidth, Math.min(maxWidthEstimate, maxWidth));
-    const top = y + (height - height) / 2;
-    elements.push({
-      type: 'image',
-      href: imageInfo.src,
-      x,
-      y: top,
-      width: chosenWidth,
-      height,
-      title: imageInfo.alt || 'Hardware illustration',
-    });
-    usedWidth = chosenWidth;
-    return { width: usedWidth, elements };
-  }
-
-  return { width: 0, elements: [] };
-}
-
-async function generateQrImage(content, sizePx) {
-  if (!qrCanvas || !(sizePx > 0) || !content) {
-    return null;
-  }
-  const size = Math.max(1, Math.round(sizePx));
-  qrCanvas.width = size;
-  qrCanvas.height = size;
-  const qrLib = await loadQrCodeLibrary();
-  const renderFn = qrLib && typeof qrLib.toCanvas === 'function' ? qrLib.toCanvas : null;
-  if (!renderFn) {
-    throw new Error('QR code renderer unavailable');
-  }
-  await renderFn.call(qrLib, qrCanvas, content, {
-    width: size,
-    margin: 1,
-    color: {
-      dark: '#000000',
-      light: '#00000000',
-    },
-  });
-  return { dataUrl: qrCanvas.toDataURL('image/png'), sizePx: size };
-}
-
-async function buildLabelSvg() {
-  await ensureFontsReady();
-
-  const geometry = getLabelGeometry();
-  const labelWidthPx = Math.max(1, Math.round(geometry.labelWidthMm * pxPerMm));
-  const labelHeightPx = Math.max(1, Math.round(geometry.labelHeightMm * pxPerMm));
-  const printableWidthPx = Math.max(0, Math.round(geometry.printableWidthMm * pxPerMm));
-  const printableHeightPx = Math.max(0, Math.round(geometry.printableHeightMm * pxPerMm));
-  const marginXPx = Math.max(0, Math.round(geometry.marginX * pxPerMm));
-  const marginYPx = Math.max(0, Math.round(geometry.marginY * pxPerMm));
-
-  const paddingBaseX = Math.round(mmToPx(1.2));
-  const paddingBaseY = Math.round(mmToPx(1));
-  const gapBase = Math.round(mmToPx(0.7));
-
-  const paddingLeftPx = paddingBaseX;
-  const paddingRightPx = paddingBaseX;
-  const paddingTopPx = paddingBaseY;
-  const paddingBottomPx = paddingBaseY;
-
-  const contentXStart = marginXPx + paddingLeftPx;
-  const contentYStart = marginYPx + paddingTopPx;
-  const contentWidthPx = Math.max(0, printableWidthPx - paddingLeftPx - paddingRightPx);
-  const contentHeightPx = Math.max(0, printableHeightPx - paddingTopPx - paddingBottomPx);
-  const minTextWidthPx = Math.max(Math.round(mmToPx(MIN_TEXT_WIDTH_MM)), Math.floor(contentHeightPx * 1.1));
-
-  const hardwareInfo = resolveHardwareImageInfo();
-  const hardwareLayout = layoutHardware(hardwareInfo, {
-    x: contentXStart,
-    y: contentYStart,
-    height: contentHeightPx,
-    maxWidth: Math.max(0, contentWidthPx - minTextWidthPx),
-    gap: gapBase,
-  });
-
-  let textStartX = contentXStart;
-  if (hardwareLayout.width > 0) {
-    textStartX += hardwareLayout.width + gapBase;
-  }
-
-  const textAreaRightLimit = marginXPx + printableWidthPx - paddingRightPx;
-  let availableForText = Math.max(0, textAreaRightLimit - textStartX);
-
-  const qrContent = state.showQr && state.qrContent ? state.qrContent.trim() : '';
-  let qrSizePx = 0;
-  if (qrContent && availableForText > minTextWidthPx) {
-    const qrLimitPx = Math.max(0, availableForText - minTextWidthPx);
-    const qrMaxHeight = contentHeightPx;
-    const candidate = Math.min(qrLimitPx, qrMaxHeight);
-    if (candidate >= Math.round(mmToPx(4))) {
-      qrSizePx = Math.max(1, Math.round(candidate));
-      availableForText = Math.max(0, availableForText - qrSizePx - gapBase);
-    }
-  }
-
-  const textWidthPx = Math.max(minTextWidthPx, availableForText);
-  const textBox = {
-    x: textStartX,
-    y: contentYStart,
-    width: textWidthPx,
-    height: contentHeightPx,
-  };
-  const lines = buildTextLines();
-  const textLayout = layoutTextLines(lines, textBox, {
-    centerAlign: hardwareLayout.width > 0 || qrSizePx > 0,
-  });
-
-  let qrLayout = null;
-  if (qrSizePx > 0 && qrContent) {
-    const qrX = textStartX + textWidthPx + gapBase;
-    const qrY = contentYStart + (contentHeightPx - qrSizePx) / 2;
-    const qrImage = await generateQrImage(qrContent, qrSizePx);
-    if (qrImage) {
-      qrLayout = {
-        x: qrX,
-        y: qrY,
-        size: qrImage.sizePx,
-        dataUrl: qrImage.dataUrl,
-      };
-    }
-  }
-
-  const svgParts = [];
-  svgParts.push(
-    `<svg xmlns="${SVG_XMLNS}" xmlns:xlink="http://www.w3.org/1999/xlink" width="${labelWidthPx}" height="${labelHeightPx}" viewBox="0 0 ${labelWidthPx} ${labelHeightPx}">`,
-  );
-  const strokeWidth = formatNumber(mmToPx(0.25));
-  svgParts.push(
-    `<rect x="0" y="0" width="${labelWidthPx}" height="${labelHeightPx}" fill="${LABEL_BACKGROUND_COLOR}" stroke="${FRAME_STROKE_COLOR}" stroke-width="${strokeWidth}" vector-effect="non-scaling-stroke" />`,
-  );
-
-  for (const element of hardwareLayout.elements) {
-    if (element.type === 'image') {
-      const resolvedHref = await resolveSvgImageHref(element.href);
-      const escapedHref = escapeXml(resolvedHref);
-      svgParts.push(
-        `<image x="${formatNumber(element.x)}" y="${formatNumber(element.y)}" width="${formatNumber(element.width)}" height="${formatNumber(element.height)}" href="${escapedHref}" xlink:href="${escapedHref}">` +
-          (element.title ? `<title>${escapeXml(element.title)}</title>` : '') +
-          '</image>',
-      );
-    } else if (element.type === 'placeholder') {
-      const radius = Math.round(element.height * 0.08);
-      svgParts.push(
-        `<rect x="${formatNumber(element.x)}" y="${formatNumber(element.y)}" width="${formatNumber(element.width)}" height="${formatNumber(element.height)}" fill="rgba(255,255,255,0.55)" stroke="rgba(15,23,42,0.25)" stroke-width="1" rx="${radius}" ry="${radius}" />`,
-      );
-      const placeholderFont = Math.max(10, Math.round(element.height * 0.22));
-      const centerX = element.x + element.width / 2;
-      const centerY = element.y + element.height / 2 + placeholderFont * 0.35;
-      svgParts.push(
-        `<text x="${formatNumber(centerX)}" y="${formatNumber(centerY)}" font-size="${placeholderFont}" font-weight="700" text-anchor="middle" fill="${LABEL_TEXT_COLOR}" font-family=${JSON.stringify(
-          LABEL_FONT_FAMILY,
-        )}>${escapeXml(element.label || 'Add image')}</text>`,
-      );
-    } else if (element.type === 'icon') {
-      const fontFamily =
-        element.style === 'brands' ? 'Font Awesome 6 Brands' : 'Font Awesome 6 Free';
-      const fontWeight = element.style === 'regular' ? 400 : element.style === 'solid' ? 900 : 400;
-      const iconSize = Math.max(12, Math.min(element.width, element.height) * 0.8);
-      const centerX = element.x + element.width / 2;
-      const centerY = element.y + element.height / 2;
-      const glyph = element.unicode ? `&#x${element.unicode};` : '';
-      const title = element.label ? `<title>${escapeXml(element.label)}</title>` : '';
-      svgParts.push(
-        `<g>${title}<text x="${formatNumber(centerX)}" y="${formatNumber(centerY)}" font-family=${JSON.stringify(fontFamily)} font-weight="${fontWeight}" font-size="${formatNumber(iconSize)}" text-anchor="middle" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${glyph}</text></g>`,
-      );
-    }
-  }
-
-  textLayout.forEach(line => {
-    svgParts.push(
-      `<text x="${formatNumber(line.x)}" y="${formatNumber(line.baseline)}" font-family=${JSON.stringify(
-        LABEL_FONT_FAMILY,
-      )} font-weight="${line.fontWeight}" font-size="${formatNumber(line.fontSize)}" fill="${LABEL_TEXT_COLOR}">${escapeXml(
-        line.text,
-      )}</text>`,
-    );
-  });
-
-  if (qrLayout) {
-    const escapedQrHref = escapeXml(qrLayout.dataUrl);
-    svgParts.push(
-      `<image x="${formatNumber(qrLayout.x)}" y="${formatNumber(qrLayout.y)}" width="${formatNumber(qrLayout.size)}" height="${formatNumber(qrLayout.size)}" href="${escapedQrHref}" xlink:href="${escapedQrHref}" />`,
-    );
-  }
-
-  svgParts.push('</svg>');
-
-  return {
-    svgMarkup: svgParts.join(''),
-    widthPx: labelWidthPx,
-    heightPx: labelHeightPx,
-    printableWidthMm: geometry.printableWidthMm,
-    printableHeightMm: geometry.printableHeightMm,
-  };
-}
-
 function announcePreviewStatus(message) {
   if (!previewStatusText) {
     return;
@@ -1957,22 +1341,26 @@ export function updatePreview() {
   announcePreviewStatus('Rendering preview…');
   previewReadyState = false;
 
-  buildLabelSvg()
-    .then(result => {
+  (async () => {
+    try {
+      const result = await renderLabelSvgForState(geometry);
       if (previewRenderRequestId !== requestId) {
         return;
       }
-      const { svgMarkup, widthPx, heightPx } = result;
-      const dataUrl = createSvgDataUrl(svgMarkup);
+      const scale = getRasterScale();
+      const canvas = await rasterizeSvgToCanvas(result.svgMarkup, result.widthPx, result.heightPx, scale);
+      if (previewRenderRequestId !== requestId) {
+        return;
+      }
+      const dataUrl = canvas.toDataURL('image/png');
       labelPreviewImage.src = dataUrl;
       labelPreviewImage.style.display = 'block';
-      labelPreviewImage.style.width = `${widthPx}px`;
-      labelPreviewImage.style.height = `${heightPx}px`;
+      labelPreviewImage.style.width = `${result.widthPx}px`;
+      labelPreviewImage.style.height = `${result.heightPx}px`;
       labelPreviewImage.setAttribute('aria-hidden', 'false');
       previewReadyState = true;
       announcePreviewStatus('Preview updated.');
-    })
-    .catch(error => {
+    } catch (error) {
       if (previewRenderRequestId !== requestId) {
         return;
       }
@@ -1980,7 +1368,8 @@ export function updatePreview() {
       hidePreviewContent();
       previewReadyState = false;
       announcePreviewStatus('Preview unavailable.');
-    });
+    }
+  })();
 }
 async function ensureFontsReady() {
   if (typeof document === 'undefined' || !document.fonts || !document.fonts.ready) {
@@ -1993,74 +1382,68 @@ async function ensureFontsReady() {
   }
 }
 
-function canvasToBlob(canvas, type = 'image/png', quality) {
-  if (typeof canvas.toBlob === 'function') {
-    return new Promise((resolve, reject) => {
-      canvas.toBlob(blob => {
-        if (blob) {
-          resolve(blob);
-        } else {
-          reject(new Error('Unable to convert canvas to blob.'));
-        }
-      }, type, quality);
-    });
-  }
-  const dataUrl = canvas.toDataURL(type, quality);
-  const base64 = dataUrl.split(',')[1] || '';
-  const binary = atob(base64);
-  const buffer = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    buffer[i] = binary.charCodeAt(i);
-  }
-  const mimeType = dataUrl.split(';')[0].split(':')[1] || type;
-  return Promise.resolve(new Blob([buffer], { type: mimeType }));
-}
-
-function loadSvgImage(svgMarkup, widthPx, heightPx) {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.decoding = 'async';
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error('Unable to rasterize SVG.'));
-    img.src = createSvgDataUrl(svgMarkup);
-    img.width = widthPx;
-    img.height = heightPx;
+async function renderLabelSvgForState(geometryOverride) {
+  await ensureFontsReady();
+  const geometry = geometryOverride || getLabelGeometry();
+  const textLines = buildTextLines();
+  const hardwareInfo = resolveHardwareImageInfo();
+  const qrContent = state.showQr && state.qrContent ? state.qrContent.trim() : '';
+  return renderLabelSVG({
+    geometry,
+    pxPerMm,
+    textLines,
+    hardwareInfo,
+    qrContent,
+    minTextWidthMm: MIN_TEXT_WIDTH_MM,
   });
 }
 
-export async function renderLabelPng() {
-  const { svgMarkup, widthPx, heightPx, printableWidthMm, printableHeightMm } =
-    await buildLabelSvg();
+function getRasterScale() {
+  if (typeof window !== 'undefined' && window.devicePixelRatio) {
+    const ratio = Number(window.devicePixelRatio);
+    if (Number.isFinite(ratio) && ratio > 0) {
+      return ratio;
+    }
+  }
+  return 1;
+}
+
+async function rasterizeSvgToCanvas(svgMarkup, widthPx, heightPx, scale) {
   const canvas = document.createElement('canvas');
-  const devicePixelRatio = typeof window !== 'undefined' && window.devicePixelRatio
-    ? window.devicePixelRatio
-    : 1;
-  const scaledWidth = Math.max(1, Math.round(widthPx * devicePixelRatio));
-  const scaledHeight = Math.max(1, Math.round(heightPx * devicePixelRatio));
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const scaledWidth = Math.max(1, Math.round(widthPx * safeScale));
+  const scaledHeight = Math.max(1, Math.round(heightPx * safeScale));
   canvas.width = scaledWidth;
   canvas.height = scaledHeight;
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     throw new Error('Unable to obtain a 2D canvas context for export.');
   }
-  if (devicePixelRatio !== 1) {
-    ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+  if (safeScale !== 1) {
+    ctx.setTransform(safeScale, 0, 0, safeScale, 0, 0);
   }
   const img = await loadSvgImage(svgMarkup, widthPx, heightPx);
   ctx.clearRect(0, 0, widthPx, heightPx);
   ctx.drawImage(img, 0, 0, widthPx, heightPx);
+  return canvas;
+}
+
+export async function renderLabelPng() {
+  const result = await renderLabelSvgForState();
+  const scale = getRasterScale();
+  const canvas = await rasterizeSvgToCanvas(result.svgMarkup, result.widthPx, result.heightPx, scale);
   const blob = await canvasToBlob(canvas, 'image/png');
   return {
     blob,
-    widthPx,
-    heightPx,
-    printableWidthMm,
-    printableHeightMm,
-    svgMarkup,
+    widthPx: result.widthPx,
+    heightPx: result.heightPx,
+    printableWidthMm: result.printableWidthMm,
+    printableHeightMm: result.printableHeightMm,
+    svgMarkup: result.svgMarkup,
   };
 }
 
 export async function renderLabelSvgMarkup() {
-  const { svgMarkup } = await buildLabelSvg();
+  const { svgMarkup } = await renderLabelSvgForState();
   return svgMarkup;
 }

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderLabelSVG, fitTextToBox } from '../js/label/renderLabelSVG.js';
+
+const pxPerMm = 300 / 25.4;
+
+function extractImages(svgMarkup) {
+  const matches = [...svgMarkup.matchAll(/<image[^>]+x="([^"]+)"[^>]+y="([^"]+)"[^>]+width="([^"]+)"[^>]+height="([^"]+)"[^>]*href="([^"]+)"/g)];
+  return matches.map(match => ({
+    x: Number(match[1]),
+    y: Number(match[2]),
+    width: Number(match[3]),
+    height: Number(match[4]),
+    href: match[5],
+  }));
+}
+
+test('37×12 mm labels keep bolt icons side-by-side', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 12,
+    printableWidthMm: 33,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const hardwareInfo = {
+    type: 'bolt',
+    images: [
+      { src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>', alt: 'drive' },
+      { src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>', alt: 'head' },
+    ],
+  };
+  const textLines = { line1: 'M2 × 10', line2: 'Socket Cap', line3: 'Phillips' };
+  const result = await renderLabelSVG({ geometry, pxPerMm, textLines, hardwareInfo, qrContent: '' });
+  const images = extractImages(result.svgMarkup);
+  assert.equal(images.length, 2, 'expected two media images');
+  const [left, right] = images;
+  assert.ok(Math.abs(left.y - right.y) < 1.5, 'icons should align horizontally');
+  assert.ok(right.x > left.x + left.width - 1, 'icons should be side-by-side');
+  assert.ok(left.width > 30 && right.width > 30, 'icons should retain visual size');
+});
+
+test('37×24 mm labels stack bolt icons vertically', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 24,
+    printableWidthMm: 33,
+    printableHeightMm: 22,
+    marginX: 2,
+    marginY: 1,
+  };
+  const hardwareInfo = {
+    type: 'bolt',
+    images: [
+      { src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>', alt: 'drive' },
+      { src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>', alt: 'head' },
+    ],
+  };
+  const textLines = { line1: 'M2 × 10', line2: 'Socket Cap', line3: 'Phillips' };
+  const result = await renderLabelSVG({ geometry, pxPerMm, textLines, hardwareInfo, qrContent: '' });
+  const images = extractImages(result.svgMarkup);
+  assert.equal(images.length, 2, 'expected stacked media images');
+  const [top, bottom] = images;
+  assert.ok(Math.abs(top.x - bottom.x) < 2, 'stacked icons share horizontal center');
+  assert.ok(bottom.y > top.y + top.height - 1, 'icons should be stacked vertically');
+  assert.ok(top.height > 80 && bottom.height > 80, 'stacked icons should scale up');
+});
+
+test('fitTextToBox shrinks long lines and applies ellipsis when needed', () => {
+  const minFontSizePx = (8.25 / 72) * 300;
+  const result = fitTextToBox({
+    text: 'M2.5 × 16 Extremely Long Description That Should Shrink',
+    fontWeight: 800,
+    maxFontSizePx: 140,
+    minFontSizePx,
+    boxWidthPx: 210,
+    boxHeightPx: 120,
+    lineClamp: 2,
+  });
+  assert.ok(result.fontSizePx < 140, 'font size should reduce');
+  assert.ok(result.fontSizePx >= minFontSizePx, 'font size should respect minimum');
+  assert.ok(result.ellipsisApplied, 'main line should ellipsize when overflowing');
+  assert.equal(result.lines.length <= 2, true);
+  assert.ok(result.lines[result.lines.length - 1].endsWith('…'), 'ellipsis should appear on final line');
+});
+
+test('single icon fills the media zone proportionally', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 12,
+    printableWidthMm: 33,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const hardwareInfo = {
+    type: 'photo',
+    src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+    alt: 'photo',
+  };
+  const result = await renderLabelSVG({
+    geometry,
+    pxPerMm,
+    textLines: { line1: 'Bolt', line2: 'Cap Head', line3: '' },
+    hardwareInfo,
+    qrContent: '',
+  });
+  const images = extractImages(result.svgMarkup);
+  assert.equal(images.length, 1, 'single icon should render once');
+  const icon = images[0];
+  assert.ok(Math.abs(icon.width - icon.height) < 0.5, 'icon should remain square within zone');
+  assert.ok(icon.width > 60, 'icon should scale to fill available space');
+});
+
+test('QR generator hook places QR image alongside text', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 12,
+    printableWidthMm: 33,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const qrDataUrl = 'data:image/png;base64,AAAAB';
+  const result = await renderLabelSVG({
+    geometry,
+    pxPerMm,
+    textLines: { line1: 'Label', line2: 'With QR', line3: '' },
+    hardwareInfo: null,
+    qrContent: 'https://example.com',
+    qrGenerator: async (_, size) => ({ dataUrl: qrDataUrl, sizePx: size }),
+  });
+  const images = extractImages(result.svgMarkup);
+  assert.equal(images.length, 1, 'QR should render as a single image when no media icons are present');
+  assert.equal(images[0].href, qrDataUrl);
+  const textMatches = [...result.svgMarkup.matchAll(/<text[^>]+x="([^"]+)"[^>]+y="([^"]+)"/g)];
+  assert.ok(textMatches.length >= 1, 'text should remain present alongside QR');
+  assert.ok(images[0].x > Number(textMatches[0][1]), 'QR should appear to the right of text content');
+});


### PR DESCRIPTION
## Summary
- extract the label rasterization logic into `js/label/renderLabelSVG.js` so preview, download, and QR generation share one SVG-to-PNG workflow
- redesign text fitting and media-zone layout to automatically resize copy, stack icons on tall labels, and keep all content inside the printable padding
- add node-based renderer tests covering icon orientation, text shrinkage, single-icon scaling, and QR placement

## Testing
- npm run lint
- node --test test/labelRenderer.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68defe243b788329b61841f79342a7c8