### PR TITLE
Crop exported labels to printable area

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -920,11 +920,16 @@ export async function renderLabelSVG({
   qrContent,
   minTextWidthMm = 9,
   qrGenerator,
+  cropToPrintable = false,
 }) {
   if (!geometry || !Number.isFinite(pxPerMm)) {
     throw new Error('Invalid geometry or pxPerMm for label rendering.');
   }
   const { labelWidthPx, labelHeightPx, printable } = resolvePrintableRect(geometry, pxPerMm);
+  const outputWidthPx = cropToPrintable ? printable.width : labelWidthPx;
+  const outputHeightPx = cropToPrintable ? printable.height : labelHeightPx;
+  const translationX = cropToPrintable ? -printable.x : 0;
+  const translationY = cropToPrintable ? -printable.y : 0;
   const preset = getActiveLayoutPreset(geometry.printableHeightMm || geometry.labelHeightMm);
   const contentRect = computeContentRect(printable, preset, pxPerMm);
   const mediaItems = resolveMediaItems(hardwareInfo);
@@ -976,24 +981,32 @@ export async function renderLabelSVG({
 
   const svgParts = [];
   svgParts.push(
-    `<svg xmlns="${SVG_XMLNS}" xmlns:xlink="${SVG_XLINK}" width="${labelWidthPx}" height="${labelHeightPx}" viewBox="0 0 ${labelWidthPx} ${labelHeightPx}">`,
+    `<svg xmlns="${SVG_XMLNS}" xmlns:xlink="${SVG_XLINK}" width="${outputWidthPx}" height="${outputHeightPx}" viewBox="0 0 ${outputWidthPx} ${outputHeightPx}">`,
   );
-  const strokeWidth = formatNumber(mmToPx(0.25, pxPerMm));
-  svgParts.push(
-    `<rect x="0" y="0" width="${labelWidthPx}" height="${labelHeightPx}" fill="${LABEL_BACKGROUND_COLOR}" stroke="${FRAME_STROKE_COLOR}" stroke-width="${strokeWidth}" vector-effect="non-scaling-stroke" />`,
-  );
+  if (cropToPrintable) {
+    svgParts.push(
+      `<rect x="0" y="0" width="${outputWidthPx}" height="${outputHeightPx}" fill="${LABEL_BACKGROUND_COLOR}" />`,
+    );
+  } else {
+    const strokeWidth = formatNumber(mmToPx(0.25, pxPerMm));
+    svgParts.push(
+      `<rect x="0" y="0" width="${labelWidthPx}" height="${labelHeightPx}" fill="${LABEL_BACKGROUND_COLOR}" stroke="${FRAME_STROKE_COLOR}" stroke-width="${strokeWidth}" vector-effect="non-scaling-stroke" />`,
+    );
+  }
 
-  svgParts.push(await renderMediaElements(mediaElements));
+  const innerParts = [];
+
+  innerParts.push(await renderMediaElements(mediaElements));
 
   if (textLayout.main.text) {
-    svgParts.push(
+    innerParts.push(
       `<text x="${formatNumber(textLayout.main.x)}" y="${formatNumber(textLayout.main.baseline)}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="800" font-size="${formatNumber(textLayout.main.fontSizePx)}" letter-spacing="${formatNumber(textLayout.main.letterSpacingPx)}" fill="${LABEL_TEXT_COLOR}">${escapeXml(textLayout.main.text)}</text>`,
     );
   }
   if (textLayout.sub && textLayout.sub.lines) {
     let baseline = textLayout.zones.sub.y + textLayout.sub.fontSizePx;
     textLayout.sub.lines.forEach(line => {
-      svgParts.push(
+      innerParts.push(
         `<text x="${formatNumber(textLayout.zones.sub.x)}" y="${formatNumber(baseline)}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="600" font-size="${formatNumber(textLayout.sub.fontSizePx)}" letter-spacing="${formatNumber(textLayout.sub.letterSpacingPx || 0)}" fill="${LABEL_TEXT_COLOR}">${escapeXml(line)}</text>`,
       );
       baseline += textLayout.sub.lineHeightPx;
@@ -1002,7 +1015,7 @@ export async function renderLabelSVG({
 
   if (qrElement) {
     const qrHref = escapeXml(qrElement.href);
-    svgParts.push(
+    innerParts.push(
       `<image x="${formatNumber(qrElement.x)}" y="${formatNumber(qrElement.y)}" width="${formatNumber(qrElement.size)}" height="${formatNumber(qrElement.size)}" href="${qrHref}" xlink:href="${qrHref}" />`,
     );
   }
@@ -1015,7 +1028,7 @@ export async function renderLabelSVG({
     qrContent,
   });
   if (editorState && editorState.active) {
-    svgParts.push(
+    innerParts.push(
       `<g class="layout-overlays" fill="none">${buildDebugOverlays({
         printableRect: printable,
         contentRect,
@@ -1027,12 +1040,19 @@ export async function renderLabelSVG({
     );
   }
 
+  if (cropToPrintable) {
+    const translateAttr = `translate(${formatNumber(translationX)} ${formatNumber(translationY)})`;
+    svgParts.push(`<g transform="${translateAttr}">${innerParts.join('')}</g>`);
+  } else {
+    svgParts.push(innerParts.join(''));
+  }
+
   svgParts.push('</svg>');
 
   return {
     svgMarkup: svgParts.join(''),
-    widthPx: labelWidthPx,
-    heightPx: labelHeightPx,
+    widthPx: outputWidthPx,
+    heightPx: outputHeightPx,
     printableWidthMm: geometry.printableWidthMm,
     printableHeightMm: geometry.printableHeightMm,
   };

--- a/js/render.js
+++ b/js/render.js
@@ -1390,12 +1390,13 @@ async function ensureFontsReady() {
   }
 }
 
-async function renderLabelSvgForState(geometryOverride) {
+async function renderLabelSvgForState(geometryOverride, options = {}) {
   await ensureFontsReady();
   const geometry = geometryOverride || getLabelGeometry();
   const textLines = buildTextLines();
   const hardwareInfo = resolveHardwareImageInfo();
   const qrContent = state.showQr && state.qrContent ? state.qrContent.trim() : '';
+  const { cropToPrintable = false } = options;
   return renderLabelSVG({
     geometry,
     pxPerMm,
@@ -1403,6 +1404,7 @@ async function renderLabelSvgForState(geometryOverride) {
     hardwareInfo,
     qrContent,
     minTextWidthMm: MIN_TEXT_WIDTH_MM,
+    cropToPrintable,
   });
 }
 
@@ -1437,7 +1439,7 @@ async function rasterizeSvgToCanvas(svgMarkup, widthPx, heightPx, scale) {
 }
 
 export async function renderLabelPng() {
-  const result = await renderLabelSvgForState();
+  const result = await renderLabelSvgForState(undefined, { cropToPrintable: true });
   const scale = getRasterScale();
   const canvas = await rasterizeSvgToCanvas(result.svgMarkup, result.widthPx, result.heightPx, scale);
   const blob = await canvasToBlob(canvas, 'image/png');
@@ -1452,6 +1454,6 @@ export async function renderLabelPng() {
 }
 
 export async function renderLabelSvgMarkup() {
-  const { svgMarkup } = await renderLabelSvgForState();
+  const { svgMarkup } = await renderLabelSvgForState(undefined, { cropToPrintable: true });
   return svgMarkup;
 }

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderLabelSVG, fitTextToBox } from '../js/label/renderLabelSVG.js';
+import { renderLabelSVG, fitTextToBox, mmToPx } from '../js/label/renderLabelSVG.js';
 
 const pxPerMm = 300 / 25.4;
 
@@ -233,4 +233,41 @@ test('QR generator hook places QR image alongside text', async () => {
   const textMatches = [...result.svgMarkup.matchAll(/<text[^>]+x="([^"]+)"[^>]+y="([^"]+)"/g)];
   assert.ok(textMatches.length >= 1, 'text should remain present alongside QR');
   assert.ok(images[0].x > Number(textMatches[0][1]), 'QR should appear to the right of text content');
+});
+
+test('cropToPrintable output trims exported dimensions to printable area', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 12,
+    printableWidthMm: 33,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const result = await renderLabelSVG({
+    geometry,
+    pxPerMm,
+    textLines: { line1: 'Label', line2: '', line3: '' },
+    hardwareInfo: null,
+    qrContent: '',
+    cropToPrintable: true,
+  });
+  const expectedWidthPx = Math.round(mmToPx(geometry.printableWidthMm, pxPerMm));
+  const expectedHeightPx = Math.round(mmToPx(geometry.printableHeightMm, pxPerMm));
+  assert.equal(result.widthPx, expectedWidthPx);
+  assert.equal(result.heightPx, expectedHeightPx);
+  assert.match(
+    result.svgMarkup,
+    new RegExp(`<svg[^>]+width="${expectedWidthPx}"[^>]+height="${expectedHeightPx}"`),
+    'cropped SVG should use printable dimensions',
+  );
+  assert.match(
+    result.svgMarkup,
+    /transform="translate\(-?\d+(?:\.\d+)? -?\d+(?:\.\d+)?\)"/,
+    'cropped export should translate content into printable viewBox',
+  );
+  assert.ok(
+    !/stroke="rgba\(100,116,139,0.5\)"/.test(result.svgMarkup),
+    'cropped export should omit outer frame stroke',
+  );
 });


### PR DESCRIPTION
## Summary
- add a `cropToPrintable` rendering path so downloaded/printed labels use the printable bounds while previews retain the full stock size
- update the export helpers to opt into the cropped output and add regression coverage for the new behavior

## Testing
- node --test test/labelRenderer.test.mjs *(fails: existing suite expects DOM QR generation and still fails outside the browser environment)*


------
https://chatgpt.com/codex/tasks/task_e_68e08aed7de48329a0bbcef59cc42b4b