### PR TITLE
Add text alignment controls to layout editor

### DIFF
--- a/js/label/layoutEditor.js
+++ b/js/label/layoutEditor.js
@@ -431,6 +431,18 @@ function bindPresetInputs(panel, heightKey) {
       onChange: value => setValue('text_zone.gap_mm', value),
     }),
   );
+  body.appendChild(
+    createSelectField({
+      label: 'Text alignment',
+      value: preset.text_zone.alignment || 'start',
+      options: [
+        { label: 'Left', value: 'start' },
+        { label: 'Center', value: 'middle' },
+        { label: 'Right', value: 'end' },
+      ],
+      onChange: value => setValue('text_zone.alignment', value),
+    }),
+  );
 
   addSectionTitle('Main line');
   body.appendChild(

--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -11,6 +11,7 @@ export const defaultLayoutPresets = {
     text_zone: {
       top_pct: 58,
       gap_mm: 0.5,
+      alignment: 'start',
       main: {
         min_pt: 7.5,
         max_pt: 11,
@@ -43,6 +44,7 @@ export const defaultLayoutPresets = {
     text_zone: {
       top_pct: 58,
       gap_mm: 0.6,
+      alignment: 'start',
       main: {
         min_pt: 8.5,
         max_pt: 14,
@@ -75,6 +77,7 @@ export const defaultLayoutPresets = {
     text_zone: {
       top_pct: 60,
       gap_mm: 0.8,
+      alignment: 'start',
       main: {
         min_pt: 9.5,
         max_pt: 20,
@@ -107,6 +110,7 @@ export const defaultLayoutPresets = {
     text_zone: {
       top_pct: 60,
       gap_mm: 1,
+      alignment: 'start',
       main: {
         min_pt: 10,
         max_pt: 24,

--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -583,21 +583,55 @@ function buildSubtitleCandidates(textLines, preset) {
   return candidates.filter(candidate => candidate.length > 0);
 }
 
+function resolveTextAlignment(alignment) {
+  const normalized = typeof alignment === 'string' ? alignment.toLowerCase() : '';
+  if (normalized === 'middle' || normalized === 'center') {
+    return 'middle';
+  }
+  if (normalized === 'end' || normalized === 'right') {
+    return 'end';
+  }
+  return 'start';
+}
+
+function computeAlignedX(zoneX, availableWidth, alignment) {
+  if (!(availableWidth > 0)) {
+    return zoneX;
+  }
+  if (alignment === 'end') {
+    return zoneX + availableWidth;
+  }
+  if (alignment === 'middle') {
+    return zoneX + availableWidth / 2;
+  }
+  return zoneX;
+}
+
 export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
   const mainText = (textLines.line1 || '').trim();
   const textPreset = preset.text_zone || {};
   const zones = computeTextZones({ textRect, preset, pxPerMm });
+  const alignment = resolveTextAlignment(textPreset.alignment);
+  const qrSizePx =
+    qrBounds && Number.isFinite(qrBounds.size)
+      ? qrBounds.size
+      : qrBounds && Number.isFinite(qrBounds.width)
+      ? qrBounds.width
+      : 0;
+  const qrMarginPx = qrBounds ? mmToPx(preset.qr?.margin_mm || 0, pxPerMm) : 0;
+  const qrReservedWidthPx = Math.max(0, qrSizePx + qrMarginPx);
+  const mainWidthPx = Math.max(0, zones.main.width - qrReservedWidthPx);
   const mainFit = fitSingleLineText({
     text: mainText,
     fontWeight: 800,
     minPt: textPreset.main?.min_pt ?? 8,
     maxPt: textPreset.main?.max_pt ?? 16,
-    widthPx: Math.max(0, zones.main.width - (qrBounds ? qrBounds.width : 0)),
+    widthPx: mainWidthPx,
     pxPerMm,
     letterSpacingLimit: textPreset.main?.letter_spacing_adj || -0.3,
   });
   const mainHeight = mainFit.text ? mainFit.fontSizePx : 0;
-  const mainX = zones.main.x;
+  const mainX = computeAlignedX(zones.main.x, mainWidthPx, alignment);
 
   const subtitleCandidates = buildSubtitleCandidates(textLines, preset);
   let subtitleFit = {
@@ -616,7 +650,7 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
         minPt: textPreset.sub?.min_pt ?? 7,
         maxPt: textPreset.sub?.max_pt ?? 11,
         lineHeightPct: textPreset.sub?.line_height_pct ?? 115,
-        widthPx: zones.sub.width - (qrBounds ? qrBounds.width : 0),
+        widthPx: Math.max(0, zones.sub.width - qrReservedWidthPx),
         heightPx: zones.sub.height,
         pxPerMm,
       }),
@@ -668,6 +702,8 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
     subtitleLineCount > 0
       ? subtitleFit.fontSizePx + subtitleFit.lineHeightPx * (subtitleLineCount - 1)
       : 0;
+  const subtitleWidthPx = Math.max(0, zones.sub.width - qrReservedWidthPx);
+  const subtitleX = computeAlignedX(zones.sub.x, subtitleWidthPx, alignment);
 
   let blockHeight = 0;
   if (mainHeight > 0) {
@@ -695,6 +731,8 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
     ...subtitleFit,
     height: subtitleHeight,
     lineCount: subtitleLineCount,
+    anchor: alignment,
+    x: subtitleX,
   };
 
   return {
@@ -705,6 +743,7 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
       baseline: mainBaseline,
       height: mainHeight,
       x: mainX,
+      anchor: alignment,
     },
     sub: subtitle,
     zones,
@@ -1059,15 +1098,19 @@ export async function renderLabelSVG({
 
   if (textLayout.main.text) {
     const mainCenterY = textLayout.main.baseline;
+    const mainAnchor = textLayout.main.anchor || 'start';
+    const mainX = textLayout.main.x ?? textLayout.zones.main.x;
     innerParts.push(
-      `<text x="${formatNumber(textLayout.main.x)}" y="${formatNumber(mainCenterY)}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="800" font-size="${formatNumber(textLayout.main.fontSizePx)}" letter-spacing="${formatNumber(textLayout.main.letterSpacingPx)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(textLayout.main.text)}</text>`,
+      `<text x="${formatNumber(mainX)}" y="${formatNumber(mainCenterY)}" text-anchor="${mainAnchor}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="800" font-size="${formatNumber(textLayout.main.fontSizePx)}" letter-spacing="${formatNumber(textLayout.main.letterSpacingPx)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(textLayout.main.text)}</text>`,
     );
   }
   if (textLayout.sub && textLayout.sub.lineCount > 0) {
     let lineCenter = textLayout.zones.sub.y + textLayout.sub.fontSizePx / 2;
+    const subAnchor = textLayout.sub.anchor || 'start';
+    const subX = textLayout.sub.x ?? textLayout.zones.sub.x;
     textLayout.sub.lines.forEach(line => {
       innerParts.push(
-        `<text x="${formatNumber(textLayout.zones.sub.x)}" y="${formatNumber(lineCenter)}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="600" font-size="${formatNumber(textLayout.sub.fontSizePx)}" letter-spacing="${formatNumber(textLayout.sub.letterSpacingPx || 0)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(line)}</text>`,
+        `<text x="${formatNumber(subX)}" y="${formatNumber(lineCenter)}" text-anchor="${subAnchor}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="600" font-size="${formatNumber(textLayout.sub.fontSizePx)}" letter-spacing="${formatNumber(textLayout.sub.letterSpacingPx || 0)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(line)}</text>`,
       );
       lineCenter += textLayout.sub.lineHeightPx;
     });

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderLabelSVG, fitTextToBox, mmToPx } from '../js/label/renderLabelSVG.js';
+import { renderLabelSVG, fitTextToBox, mmToPx, layoutText } from '../js/label/renderLabelSVG.js';
 import {
   setPresetOverride,
   clearPresetOverrides,
@@ -172,6 +172,50 @@ test('single-line labels center the main baseline within the text rect', async (
   );
 });
 
+test('middle text alignment centers both main and subtitle anchors', async () => {
+  clearPresetOverrides();
+  try {
+    const geometry = {
+      labelWidthMm: 37,
+      labelHeightMm: 12,
+      printableWidthMm: 33,
+      printableHeightMm: 10,
+      marginX: 2,
+      marginY: 1,
+    };
+    setPresetOverride(geometry.printableHeightMm, {
+      text_zone: { alignment: 'middle' },
+    });
+    const textLines = { line1: 'Centered', line2: 'Subtitle', line3: '' };
+    const result = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines,
+      hardwareInfo: null,
+      qrContent: '',
+    });
+    const expectedCenterX = result.textRect.x + result.textRect.width / 2;
+    assert.equal(result.textLayout.main.anchor, 'middle');
+    assert.equal(result.textLayout.sub.anchor, 'middle');
+    assert.ok(
+      Math.abs(result.textLayout.main.x - expectedCenterX) < 0.51,
+      `main anchor (${result.textLayout.main.x.toFixed(2)}) should equal text rect midpoint (${expectedCenterX.toFixed(2)})`,
+    );
+    assert.ok(
+      Math.abs(result.textLayout.sub.x - expectedCenterX) < 0.51,
+      `subtitle anchor (${result.textLayout.sub.x.toFixed(2)}) should equal text rect midpoint (${expectedCenterX.toFixed(2)})`,
+    );
+    const mainMatch = result.svgMarkup.match(/<text[^>]*font-weight="800"[^>]*>/);
+    assert.ok(mainMatch, 'expected main text element with font-weight 800');
+    assert.match(mainMatch[0], /text-anchor="middle"/);
+    const subtitleMatch = result.svgMarkup.match(/<text[^>]*font-weight="600"[^>]*>/);
+    assert.ok(subtitleMatch, 'expected subtitle text element with font-weight 600');
+    assert.match(subtitleMatch[0], /text-anchor="middle"/);
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
 test('main line shrinks before ellipsizing', async () => {
   const geometry = {
     labelWidthMm: 80,
@@ -263,6 +307,75 @@ test('QR generator hook places QR image alongside text', async () => {
   const textMatches = [...result.svgMarkup.matchAll(/<text[^>]+x="([^"]+)"[^>]+y="([^"]+)"/g)];
   assert.ok(textMatches.length >= 1, 'text should remain present alongside QR');
   assert.ok(images[0].x > Number(textMatches[0][1]), 'QR should appear to the right of text content');
+});
+
+test('end text alignment anchors text to the right edge when QR is absent', async () => {
+  clearPresetOverrides();
+  try {
+    const geometry = {
+      labelWidthMm: 37,
+      labelHeightMm: 12,
+      printableWidthMm: 33,
+      printableHeightMm: 10,
+      marginX: 2,
+      marginY: 1,
+    };
+    setPresetOverride(geometry.printableHeightMm, {
+      text_zone: { alignment: 'end' },
+    });
+    const result = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines: { line1: 'Right Edge', line2: 'Subtitle', line3: '' },
+      hardwareInfo: null,
+      qrContent: '',
+    });
+    const expectedRightX = result.textRect.x + result.textRect.width;
+    assert.equal(result.textLayout.main.anchor, 'end');
+    assert.equal(result.textLayout.sub.anchor, 'end');
+    assert.ok(
+      Math.abs(result.textLayout.main.x - expectedRightX) < 0.51,
+      `main anchor (${result.textLayout.main.x.toFixed(2)}) should equal text rect right edge (${expectedRightX.toFixed(2)})`,
+    );
+    assert.ok(
+      Math.abs(result.textLayout.sub.x - expectedRightX) < 0.51,
+      `subtitle anchor (${result.textLayout.sub.x.toFixed(2)}) should equal text rect right edge (${expectedRightX.toFixed(2)})`,
+    );
+    const mainMatch = result.svgMarkup.match(/<text[^>]*font-weight="800"[^>]*>/);
+    assert.ok(mainMatch, 'expected main text element');
+    assert.match(mainMatch[0], /text-anchor="end"/);
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
+test('layoutText keeps end-aligned anchors clear of QR bounds', () => {
+  clearPresetOverrides();
+  try {
+    const preset = getActiveLayoutPreset(12);
+    const override = {
+      ...preset,
+      text_zone: { ...preset.text_zone, alignment: 'end' },
+    };
+    const textRect = { x: 20, y: 10, width: 160, height: 60 };
+    const qrSizePx = 48;
+    const qrMarginPx = mmToPx(override.qr.margin_mm || 0, pxPerMm);
+    const layout = layoutText({
+      textLines: { line1: 'QR Label', line2: '', line3: '' },
+      textRect,
+      preset: override,
+      pxPerMm,
+      qrBounds: { size: qrSizePx },
+    });
+    const expectedAnchor = textRect.x + textRect.width - (qrSizePx + qrMarginPx);
+    assert.equal(layout.main.anchor, 'end');
+    assert.ok(
+      Math.abs(layout.main.x - expectedAnchor) < 0.51,
+      `main anchor (${layout.main.x.toFixed(2)}) should align with QR clearance (${expectedAnchor.toFixed(2)})`,
+    );
+  } finally {
+    clearPresetOverrides();
+  }
 });
 
 test('cropToPrintable output trims exported dimensions to printable area', async () => {


### PR DESCRIPTION
## Summary
- add a text alignment option to the hidden layout editor and propagate it through preset defaults
- update the SVG text layout to honor start/center/end anchors and keep end-aligned text clear of QR bounds
- expand renderer tests to cover center and end alignment behaviour

## Testing
- node --test test/labelRenderer.test.mjs *(fails: environment lacks canvas/QR support so existing fitTextToBox and QR expectations fail)*

------
https://chatgpt.com/codex/tasks/task_e_68e09377cc508329bf0713c02dd5e5f4