### PR TITLE
Add configurable main line font weight

### DIFF
--- a/js/label/layoutEditor.js
+++ b/js/label/layoutEditor.js
@@ -475,6 +475,17 @@ function bindPresetInputs(panel, heightKey) {
       onChange: value => setValue('text_zone.main.letter_spacing_adj', value),
     }),
   );
+  body.appendChild(
+    createSelectField({
+      label: 'Font weight',
+      value: String(preset.text_zone.main.font_weight ?? 800),
+      options: [
+        { label: 'Regular (600)', value: '600' },
+        { label: 'Bold (800)', value: '800' },
+      ],
+      onChange: value => setValue('text_zone.main.font_weight', Number(value)),
+    }),
+  );
 
   addSectionTitle('Subtitles');
   body.appendChild(

--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -16,6 +16,7 @@ export const defaultLayoutPresets = {
         min_pt: 7.5,
         max_pt: 11,
         letter_spacing_adj: -0.3,
+        font_weight: 800,
       },
       sub: {
         min_pt: 6.8,
@@ -49,6 +50,7 @@ export const defaultLayoutPresets = {
         min_pt: 8.5,
         max_pt: 14,
         letter_spacing_adj: -0.3,
+        font_weight: 800,
       },
       sub: {
         min_pt: 7.2,
@@ -82,6 +84,7 @@ export const defaultLayoutPresets = {
         min_pt: 9.5,
         max_pt: 20,
         letter_spacing_adj: -0.35,
+        font_weight: 800,
       },
       sub: {
         min_pt: 8,
@@ -115,6 +118,7 @@ export const defaultLayoutPresets = {
         min_pt: 10,
         max_pt: 24,
         letter_spacing_adj: -0.35,
+        font_weight: 800,
       },
       sub: {
         min_pt: 9,

--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -610,6 +610,7 @@ function computeAlignedX(zoneX, availableWidth, alignment) {
 export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
   const mainText = (textLines.line1 || '').trim();
   const textPreset = preset.text_zone || {};
+  const mainFontWeight = textPreset.main?.font_weight ?? 800;
   const zones = computeTextZones({ textRect, preset, pxPerMm });
   const alignment = resolveTextAlignment(textPreset.alignment);
   const qrSizePx =
@@ -623,7 +624,7 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
   const mainWidthPx = Math.max(0, zones.main.width - qrReservedWidthPx);
   const mainFit = fitSingleLineText({
     text: mainText,
-    fontWeight: 800,
+    fontWeight: mainFontWeight,
     minPt: textPreset.main?.min_pt ?? 8,
     maxPt: textPreset.main?.max_pt ?? 16,
     widthPx: mainWidthPx,
@@ -744,6 +745,7 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
       height: mainHeight,
       x: mainX,
       anchor: alignment,
+      fontWeight: mainFontWeight,
     },
     sub: subtitle,
     zones,
@@ -890,6 +892,7 @@ function ensureTextFits({
   const minTextWidthPx = hasText ? mmToPx(minTextWidthMm || 9, pxPerMm) : 0;
   const textGapPx = mediaPresent && hasText ? mmToPx(MEDIA_TEXT_GAP_MM, pxPerMm) : 0;
   let mediaWidthPx = mediaPresent ? mediaZoneWidthPx : 0;
+  const mainFontWeight = preset.text_zone?.main?.font_weight ?? 800;
   for (let i = 0; i < 4; i += 1) {
     const textWidth = Math.max(0, contentRect.width - mediaWidthPx - textGapPx);
     if (textWidth >= minTextWidthPx - 0.5) {
@@ -906,7 +909,7 @@ function ensureTextFits({
 
   let mainFit = fitSingleLineText({
     text: textLines.line1,
-    fontWeight: 800,
+    fontWeight: mainFontWeight,
     minPt: preset.text_zone.main.min_pt,
     maxPt: preset.text_zone.main.max_pt,
     widthPx: textRect.width,
@@ -926,7 +929,7 @@ function ensureTextFits({
       );
       mainFit = fitSingleLineText({
         text: textLines.line1,
-        fontWeight: 800,
+        fontWeight: mainFontWeight,
         minPt: preset.text_zone.main.min_pt,
         maxPt: preset.text_zone.main.max_pt,
         widthPx: textRect.width,
@@ -1100,8 +1103,9 @@ export async function renderLabelSVG({
     const mainCenterY = textLayout.main.baseline;
     const mainAnchor = textLayout.main.anchor || 'start';
     const mainX = textLayout.main.x ?? textLayout.zones.main.x;
+    const mainFontWeight = textLayout.main.fontWeight ?? preset.text_zone?.main?.font_weight ?? 800;
     innerParts.push(
-      `<text x="${formatNumber(mainX)}" y="${formatNumber(mainCenterY)}" text-anchor="${mainAnchor}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="800" font-size="${formatNumber(textLayout.main.fontSizePx)}" letter-spacing="${formatNumber(textLayout.main.letterSpacingPx)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(textLayout.main.text)}</text>`,
+      `<text x="${formatNumber(mainX)}" y="${formatNumber(mainCenterY)}" text-anchor="${mainAnchor}" font-family=${JSON.stringify(LABEL_FONT_FAMILY)} font-weight="${mainFontWeight}" font-size="${formatNumber(textLayout.main.fontSizePx)}" letter-spacing="${formatNumber(textLayout.main.letterSpacingPx)}" dominant-baseline="middle" fill="${LABEL_TEXT_COLOR}">${escapeXml(textLayout.main.text)}</text>`,
     );
   }
   if (textLayout.sub && textLayout.sub.lineCount > 0) {

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -21,6 +21,16 @@ function extractImages(svgMarkup) {
   }));
 }
 
+function getPresetMainFontWeight(heightMm) {
+  const preset = getActiveLayoutPreset(heightMm);
+  return preset.text_zone?.main?.font_weight ?? 800;
+}
+
+function findMainTextElements(svgMarkup, fontWeight) {
+  const pattern = new RegExp(`<text[^>]*font-weight="${fontWeight}"[^>]*>([^<]+)<\\/text>`, 'g');
+  return [...svgMarkup.matchAll(pattern)];
+}
+
 test('37×12 mm labels keep bolt icons side-by-side', async () => {
   const geometry = {
     labelWidthMm: 37,
@@ -96,7 +106,8 @@ test('37×18 mm labels stack bolt icons vertically with balanced spacing', async
   const [top, bottom] = images;
   assert.ok(Math.abs(top.x - bottom.x) < 2, 'icons should stay centered when stacked');
   assert.ok(bottom.y > top.y + top.height - 1, 'stacked icons should not overlap');
-  const textMatches = [...result.svgMarkup.matchAll(/font-weight="800"[^>]*>([^<]+)<\/text>/g)];
+  const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+  const textMatches = findMainTextElements(result.svgMarkup, mainFontWeight);
   assert.equal(textMatches.length, 1, 'main line should render once');
   assert.equal(textMatches[0][1].trim(), 'M2 × 10', 'main line should remain intact');
 });
@@ -205,8 +216,9 @@ test('middle text alignment centers both main and subtitle anchors', async () =>
       Math.abs(result.textLayout.sub.x - expectedCenterX) < 0.51,
       `subtitle anchor (${result.textLayout.sub.x.toFixed(2)}) should equal text rect midpoint (${expectedCenterX.toFixed(2)})`,
     );
-    const mainMatch = result.svgMarkup.match(/<text[^>]*font-weight="800"[^>]*>/);
-    assert.ok(mainMatch, 'expected main text element with font-weight 800');
+    const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+    const mainMatch = result.svgMarkup.match(new RegExp(`<text[^>]*font-weight="${mainFontWeight}"[^>]*>`));
+    assert.ok(mainMatch, 'expected main text element with configured font weight');
     assert.match(mainMatch[0], /text-anchor="middle"/);
     const subtitleMatch = result.svgMarkup.match(/<text[^>]*font-weight="600"[^>]*>/);
     assert.ok(subtitleMatch, 'expected subtitle text element with font-weight 600');
@@ -231,7 +243,8 @@ test('main line shrinks before ellipsizing', async () => {
     line3: '',
   };
   const result = await renderLabelSVG({ geometry, pxPerMm, textLines, hardwareInfo: null, qrContent: '' });
-  const mainMatches = [...result.svgMarkup.matchAll(/font-weight="800"[^>]*>([^<]+)<\/text>/g)];
+  const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+  const mainMatches = findMainTextElements(result.svgMarkup, mainFontWeight);
   assert.equal(mainMatches.length, 1, 'main line should render exactly once');
   assert.equal(mainMatches[0][1].trim(), 'M2.5 × 16 Countersunk Socket Cap');
 });
@@ -251,9 +264,43 @@ test('main line only ellipsizes when unavoidable', async () => {
     line3: '',
   };
   const result = await renderLabelSVG({ geometry, pxPerMm, textLines, hardwareInfo: null, qrContent: '' });
-  const mainMatches = [...result.svgMarkup.matchAll(/font-weight="800"[^>]*>([^<]+)<\/text>/g)];
+  const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+  const mainMatches = findMainTextElements(result.svgMarkup, mainFontWeight);
   assert.equal(mainMatches.length, 1, 'main line should still occupy one line');
   assert.ok(mainMatches[0][1].trim().endsWith('…'), 'ellipsis should appear only when absolutely required');
+});
+
+test('main font weight follows preset overrides', async () => {
+  clearPresetOverrides();
+  try {
+    const geometry = {
+      labelWidthMm: 37,
+      labelHeightMm: 12,
+      printableWidthMm: 33,
+      printableHeightMm: 10,
+      marginX: 2,
+      marginY: 1,
+    };
+    setPresetOverride(geometry.printableHeightMm, {
+      text_zone: { main: { font_weight: 600 } },
+    });
+    const textLines = { line1: 'Non-Bold', line2: '', line3: '' };
+    const result = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines,
+      hardwareInfo: null,
+      qrContent: '',
+    });
+    const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+    assert.equal(mainFontWeight, 600, 'override should adjust active preset weight');
+    const mainMatches = findMainTextElements(result.svgMarkup, mainFontWeight);
+    assert.equal(mainMatches.length, 1, 'main line should render once with overridden weight');
+    assert.equal(mainMatches[0][1].trim(), 'Non-Bold');
+    assert.equal(result.textLayout.main.fontWeight, mainFontWeight);
+  } finally {
+    clearPresetOverrides();
+  }
 });
 
 test('subtitle lines remain distinct with optional ellipsis on the last line', async () => {
@@ -341,7 +388,8 @@ test('end text alignment anchors text to the right edge when QR is absent', asyn
       Math.abs(result.textLayout.sub.x - expectedRightX) < 0.51,
       `subtitle anchor (${result.textLayout.sub.x.toFixed(2)}) should equal text rect right edge (${expectedRightX.toFixed(2)})`,
     );
-    const mainMatch = result.svgMarkup.match(/<text[^>]*font-weight="800"[^>]*>/);
+    const mainFontWeight = getPresetMainFontWeight(geometry.printableHeightMm);
+    const mainMatch = result.svgMarkup.match(new RegExp(`<text[^>]*font-weight="${mainFontWeight}"[^>]*>`));
     assert.ok(mainMatch, 'expected main text element');
     assert.match(mainMatch[0], /text-anchor="end"/);
   } finally {


### PR DESCRIPTION
## Summary
- add a `font_weight` default to every preset so existing labels stay bold by default
- expose the main line weight in the layout editor and thread the configured value through text layout/rendering
- update label renderer tests to expect the configured weight and cover an override scenario

## Testing
- `node --test test/labelRenderer.test.mjs` *(fails: pre-existing assertions about fitTextToBox, subtitle wrapping, and QR output)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a4802de48329b31cd9f27cbbbb7e