### PR TITLE
Handle layout editor query parameter activation correctly

### DIFF
--- a/js/label/layoutEditor.js
+++ b/js/label/layoutEditor.js
@@ -27,10 +27,10 @@ function isBrowser() {
 
 function shouldActivateFromQuery() {
   if (!isBrowser()) {
-    return false;
+    return null;
   }
   const params = new URLSearchParams(window.location.search);
-  return params.get('layoutEditor') === '1';
+  return params.get('layoutEditor');
 }
 
 function restoreActiveFlag() {
@@ -66,10 +66,17 @@ function evaluateActivation() {
     return true;
   }
   const fromQuery = shouldActivateFromQuery();
-  if (fromQuery) {
+  if (fromQuery === '0') {
+    editorState.active = false;
+    persistActiveFlag(false);
+    return false;
+  }
+  if (fromQuery === '1') {
     editorState.active = true;
-    persistActiveFlag(true);
     return true;
+  }
+  if (fromQuery !== null) {
+    return false;
   }
   const stored = restoreActiveFlag();
   if (stored) {


### PR DESCRIPTION
## Summary
- return the raw `layoutEditor` query string so the editor can distinguish explicit opt-in and opt-out values
- update activation evaluation to clear stored activation on `layoutEditor=0`, avoid persisting `layoutEditor=1`, and rely on storage only when no query is present

## Testing
- Manual verification in a browser (Playwright) that `layoutEditor` query parameters toggle session activation and persistence as expected


------
https://chatgpt.com/codex/tasks/task_e_68e0a9a5ce1483299d91513e28c1957a