### PR TITLE
Adjust Oswald font weight for label headlines

### DIFF
--- a/style.css
+++ b/style.css
@@ -932,7 +932,7 @@ main {
 
 .text-line {
   line-height: 1;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.01em;
 }
 


### PR DESCRIPTION
## Summary
- update the `.text-line` rule to use Oswald's available 700 weight for rendered headlines

## Testing
- manual: refreshed the label preview in the browser to confirm the updated font weight renders correctly

------
https://chatgpt.com/codex/tasks/task_e_68e0b95e4d848329835f8f0a9b3bcc2c