### PR TITLE
Limit main label font weight to available faces

### DIFF
--- a/js/label/layoutEditor.js
+++ b/js/label/layoutEditor.js
@@ -485,11 +485,8 @@ function bindPresetInputs(panel, heightKey) {
   body.appendChild(
     createSelectField({
       label: 'Font weight',
-      value: String(Math.max(700, preset.text_zone.main.font_weight ?? 800)),
-      options: [
-        { label: 'Bold (700)', value: '700' },
-        { label: 'Extra Bold (800)', value: '800' },
-      ],
+      value: String(Math.min(700, preset.text_zone.main.font_weight ?? 700)),
+      options: [{ label: 'Bold (700)', value: '700' }],
       onChange: value => setValue('text_zone.main.font_weight', Number(value)),
     }),
   );

--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -16,7 +16,7 @@ export const defaultLayoutPresets = {
         min_pt: 7.5,
         max_pt: 11,
         letter_spacing_adj: -0.3,
-        font_weight: 800,
+        font_weight: 700,
       },
       sub: {
         min_pt: 6.8,
@@ -50,7 +50,7 @@ export const defaultLayoutPresets = {
         min_pt: 8.5,
         max_pt: 14,
         letter_spacing_adj: -0.3,
-        font_weight: 800,
+        font_weight: 700,
       },
       sub: {
         min_pt: 7.2,
@@ -84,7 +84,7 @@ export const defaultLayoutPresets = {
         min_pt: 9.5,
         max_pt: 20,
         letter_spacing_adj: -0.35,
-        font_weight: 800,
+        font_weight: 700,
       },
       sub: {
         min_pt: 8,
@@ -118,7 +118,7 @@ export const defaultLayoutPresets = {
         min_pt: 10,
         max_pt: 24,
         letter_spacing_adj: -0.35,
-        font_weight: 800,
+        font_weight: 700,
       },
       sub: {
         min_pt: 9,

--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -24,6 +24,7 @@ const QR_SIDE_PX_MIN = 24;
 const ICON_PADDING_MM = 0.4;
 const MEDIA_TEXT_GAP_MM = 0.6;
 const MIN_MAIN_FONT_WEIGHT = 700;
+const MAX_MAIN_FONT_WEIGHT = 700;
 
 const inlineImageCache = new Map();
 
@@ -49,11 +50,11 @@ function clamp(value, min, max) {
 function resolveMainFontWeight(weight, fallback = 800) {
   const fallbackNumeric = Number(fallback);
   const fallbackWeight = Number.isFinite(fallbackNumeric)
-    ? Math.max(MIN_MAIN_FONT_WEIGHT, fallbackNumeric)
+    ? clamp(fallbackNumeric, MIN_MAIN_FONT_WEIGHT, MAX_MAIN_FONT_WEIGHT)
     : MIN_MAIN_FONT_WEIGHT;
   const numericWeight = Number(weight);
   if (Number.isFinite(numericWeight)) {
-    return Math.max(MIN_MAIN_FONT_WEIGHT, numericWeight);
+    return clamp(numericWeight, MIN_MAIN_FONT_WEIGHT, MAX_MAIN_FONT_WEIGHT);
   }
   return fallbackWeight;
 }

--- a/js/render.js
+++ b/js/render.js
@@ -1379,7 +1379,7 @@ export function updatePreview() {
     }
   })();
 }
-const LABEL_FONT_WEIGHTS = [600, 700, 800];
+const LABEL_FONT_WEIGHTS = [600, 700];
 let labelFontLoadPromise = null;
 
 async function ensureFontsReady() {


### PR DESCRIPTION
## Summary
- reduce main text preset font weights to 700 so layouts only request available faces
- limit the layout editor and renderer to 700-weight main text and clamp overrides accordingly
- stop preloading the unused 800 font weight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0c2339788832994a837a2367f1793