### PR TITLE
Merge default presets when exporting with overrides

### DIFF
--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -271,10 +271,21 @@ export function setPresetOverride(heightMm, preset) {
 }
 
 export function exportLayoutPresets(includeDefaults = false) {
-  if (includeDefaults) {
-    return JSON.stringify(defaultLayoutPresets, null, 2);
-  }
   const overrides = loadPresetOverrides();
+  if (includeDefaults) {
+    const merged = {};
+    Object.keys(defaultLayoutPresets).forEach(key => {
+      const base = clone(defaultLayoutPresets[key]);
+      const override = overrides[key];
+      merged[key] = override ? deepMerge(base, override) : base;
+    });
+    Object.keys(overrides).forEach(key => {
+      if (!(key in merged)) {
+        merged[key] = clone(overrides[key]);
+      }
+    });
+    return JSON.stringify(merged, null, 2);
+  }
   if (!overrides || Object.keys(overrides).length === 0) {
     return JSON.stringify({}, null, 2);
   }

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -6,6 +6,8 @@ import {
   setPresetOverride,
   clearPresetOverrides,
   getActiveLayoutPreset,
+  exportLayoutPresets,
+  defaultLayoutPresets,
 } from '../js/label/layoutPresets.js';
 
 const pxPerMm = 300 / 25.4;
@@ -168,6 +170,35 @@ test('main text font weight clamps legacy presets to bold minimum', async () => 
         `subtitle weight ${element.fontWeight} should remain lighter than main ${mainText.fontWeight}`,
       );
     });
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
+test('exporting presets with defaults merges overrides', () => {
+  clearPresetOverrides();
+  try {
+    const heightKey = 12;
+    const override = {
+      text_zone: {
+        main: {
+          font_weight: 745,
+        },
+      },
+    };
+    setPresetOverride(heightKey, override);
+    const exported = exportLayoutPresets(true);
+    const parsed = JSON.parse(exported);
+    assert.equal(
+      parsed[String(heightKey)].padding_mm,
+      defaultLayoutPresets[String(heightKey)].padding_mm,
+      'defaults should remain in exported presets',
+    );
+    assert.equal(
+      parsed[String(heightKey)].text_zone.main.font_weight,
+      override.text_zone.main.font_weight,
+      'export should merge override values with defaults',
+    );
   } finally {
     clearPresetOverrides();
   }


### PR DESCRIPTION
## Summary
- merge default layout presets with any overrides before exporting to JSON
- add a regression test ensuring include-default exports reflect override values

## Testing
- node --test *(fails: existing suite depends on @jest/globals and has pre-existing assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d3d6569c8329b0e928dffa367ba1