### PR TITLE
Fix layout preset export handling for zero overrides

### DIFF
--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -274,13 +274,15 @@ export function exportLayoutPresets(includeDefaults = false) {
   const overrides = loadPresetOverrides();
   if (includeDefaults) {
     const merged = {};
-    Object.keys(defaultLayoutPresets).forEach(key => {
-      const base = clone(defaultLayoutPresets[key]);
-      const override = overrides[key];
-      merged[key] = override ? deepMerge(base, override) : base;
-    });
-    Object.keys(overrides).forEach(key => {
-      if (!(key in merged)) {
+    const overrideKeys = overrides ? Object.keys(overrides) : [];
+    const mergedKeys = new Set([...Object.keys(defaultLayoutPresets), ...overrideKeys]);
+    mergedKeys.forEach(key => {
+      const hasDefault = Object.hasOwn(defaultLayoutPresets, key);
+      const hasOverride = overrides ? Object.hasOwn(overrides, key) : false;
+      if (hasDefault) {
+        const base = clone(defaultLayoutPresets[key]);
+        merged[key] = hasOverride ? deepMerge(base, overrides[key]) : base;
+      } else if (hasOverride) {
         merged[key] = clone(overrides[key]);
       }
     });

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -204,6 +204,24 @@ test('exporting presets with defaults merges overrides', () => {
   }
 });
 
+test('exporting presets with defaults preserves zero-value overrides', () => {
+  clearPresetOverrides();
+  try {
+    const heightKey = 12;
+    const override = { padding_mm: 0 };
+    setPresetOverride(heightKey, override);
+    const exported = exportLayoutPresets(true);
+    const parsed = JSON.parse(exported);
+    assert.equal(
+      parsed[String(heightKey)].padding_mm,
+      override.padding_mm,
+      'export should include explicit zero overrides when merging defaults',
+    );
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
 test('fitTextToBox shrinks long lines and applies ellipsis when needed', () => {
   const pxPerMm = 300 / 25.4;
   const minPt = 8.25;


### PR DESCRIPTION
## Summary
- build merged preset export from the union of default and overridden keys so falsy values like zero are preserved
- add a regression test covering zero padding overrides when exporting with defaults

## Testing
- node --test --test-name-pattern "preserves zero-value overrides" test/labelRenderer.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e0dafbca908329b04db9f638f4118b