### PR TITLE
Support fuse illustration aspect ratios

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -383,6 +383,17 @@ export function fitTextToBox(options) {
   return fitMultiLineText(options);
 }
 
+function attachAspectRatio(target, ...ratioCandidates) {
+  for (const candidate of ratioCandidates) {
+    const ratio = Number(candidate);
+    if (Number.isFinite(ratio) && ratio > 0) {
+      target.aspectRatio = ratio;
+      break;
+    }
+  }
+  return target;
+}
+
 function resolveMediaItems(hardwareInfo) {
   if (!hardwareInfo) {
     return [];
@@ -390,11 +401,14 @@ function resolveMediaItems(hardwareInfo) {
   if (hardwareInfo.type === 'custom-image') {
     if (hardwareInfo.hasImage && hardwareInfo.src) {
       return [
-        {
-          kind: 'image',
-          href: hardwareInfo.src,
-          alt: hardwareInfo.alt || 'Custom image',
-        },
+        attachAspectRatio(
+          {
+            kind: 'image',
+            href: hardwareInfo.src,
+            alt: hardwareInfo.alt || 'Custom image',
+          },
+          hardwareInfo.aspectRatio,
+        ),
       ];
     }
     return [];
@@ -402,11 +416,14 @@ function resolveMediaItems(hardwareInfo) {
   if (hardwareInfo.type === 'custom-icon') {
     if (hardwareInfo.iconSvgData) {
       return [
-        {
-          kind: 'image',
-          href: hardwareInfo.iconSvgData,
-          alt: hardwareInfo.iconLabel || hardwareInfo.iconName || 'Custom icon',
-        },
+        attachAspectRatio(
+          {
+            kind: 'image',
+            href: hardwareInfo.iconSvgData,
+            alt: hardwareInfo.iconLabel || hardwareInfo.iconName || 'Custom icon',
+          },
+          hardwareInfo.aspectRatio,
+        ),
       ];
     }
     if (hardwareInfo.hasIcon && hardwareInfo.iconUnicode) {
@@ -426,29 +443,41 @@ function resolveMediaItems(hardwareInfo) {
       return [];
     }
     return [
-      {
-        kind: 'image',
-        href: hardwareInfo.src,
-        alt: hardwareInfo.alt || 'Reference illustration',
-      },
+      attachAspectRatio(
+        {
+          kind: 'image',
+          href: hardwareInfo.src,
+          alt: hardwareInfo.alt || 'Reference illustration',
+        },
+        hardwareInfo.aspectRatio,
+      ),
     ];
   }
   if (hardwareInfo.images && Array.isArray(hardwareInfo.images)) {
     return hardwareInfo.images
       .filter(image => image && image.src)
-      .map((image, index) => ({
-        kind: 'image',
-        href: image.src,
-        alt: image.alt || `Reference ${index + 1}`,
-      }));
+      .map((image, index) =>
+        attachAspectRatio(
+          {
+            kind: 'image',
+            href: image.src,
+            alt: image.alt || `Reference ${index + 1}`,
+          },
+          image.aspectRatio,
+          hardwareInfo.aspectRatio,
+        ),
+      );
   }
   if (hardwareInfo.src) {
     return [
-      {
-        kind: 'image',
-        href: hardwareInfo.src,
-        alt: hardwareInfo.alt || 'Reference illustration',
-      },
+      attachAspectRatio(
+        {
+          kind: 'image',
+          href: hardwareInfo.src,
+          alt: hardwareInfo.alt || 'Reference illustration',
+        },
+        hardwareInfo.aspectRatio,
+      ),
     ];
   }
   return [];
@@ -849,6 +878,23 @@ function layoutIcons({
   const count = mediaItems.length;
   const innerWidth = Math.max(0, rect.width - paddingPx * 2);
   const innerHeight = Math.max(0, rect.height - paddingPx * 2);
+  const resolveDimensions = (item, availableWidth, availableHeight) => {
+    const widthLimit = Math.max(0, availableWidth);
+    const heightLimit = Math.max(0, availableHeight);
+    const ratio = Number(item.aspectRatio);
+    if (Number.isFinite(ratio) && ratio > 0 && widthLimit > 0 && heightLimit > 0) {
+      let width = Math.min(widthLimit, heightLimit * ratio);
+      let height = width / ratio;
+      if (height > heightLimit) {
+        height = heightLimit;
+        width = Math.min(widthLimit, height * ratio);
+        height = width / ratio;
+      }
+      return { width, height };
+    }
+    const size = Math.min(widthLimit, heightLimit);
+    return { width: size, height: size };
+  };
   if (count === 1 || preset.icon_layout === 'column') {
     const slotHeight =
       count <= 1
@@ -856,10 +902,10 @@ function layoutIcons({
         : (innerHeight - gapPx * (count - 1)) / count;
     let cursorY = rect.y + paddingPx;
     mediaItems.forEach(item => {
-      const size = Math.min(innerWidth, slotHeight);
-      const x = rect.x + (rect.width - size) / 2;
-      const y = cursorY + (slotHeight - size) / 2;
-      items.push({ ...item, x, y, width: size, height: size });
+      const { width, height } = resolveDimensions(item, innerWidth, slotHeight);
+      const x = rect.x + (rect.width - width) / 2;
+      const y = cursorY + (slotHeight - height) / 2;
+      items.push({ ...item, x, y, width, height });
       cursorY += slotHeight + gapPx;
     });
     return items;
@@ -868,10 +914,10 @@ function layoutIcons({
   const slotWidth = (innerWidth - gapPx * (count - 1)) / count;
   let cursorX = rect.x + paddingPx;
   mediaItems.forEach(item => {
-    const size = Math.min(slotWidth, innerHeight);
-    const x = cursorX + (slotWidth - size) / 2;
-    const y = rect.y + (rect.height - size) / 2;
-    items.push({ ...item, x, y, width: size, height: size });
+    const { width, height } = resolveDimensions(item, slotWidth, innerHeight);
+    const x = cursorX + (slotWidth - width) / 2;
+    const y = rect.y + (rect.height - height) / 2;
+    items.push({ ...item, x, y, width, height });
     cursorX += slotWidth + gapPx;
   });
   return items;

--- a/js/render.js
+++ b/js/render.js
@@ -134,14 +134,17 @@ const fuseIllustrations = {
   Glass: {
     src: 'images/fuses/glass_fuse.svg',
     alt: 'Glass fuse illustration',
+    aspectRatio: 926 / 307,
   },
   Ceramic: {
     src: 'images/fuses/ceramic_fuse.svg',
     alt: 'Ceramic fuse illustration',
+    aspectRatio: 926 / 307,
   },
   Blade: {
     src: 'images/fuses/blade_fuse.svg',
     alt: 'Blade fuse illustration',
+    aspectRatio: 854 / 797,
   },
 };
 
@@ -960,6 +963,7 @@ function resolveHardwareImageInfo() {
       type: 'fuse-illustration',
       src: illustration.src,
       alt: illustration.alt,
+      aspectRatio: illustration.aspectRatio,
     };
   }
   if (state.hardwareType === 'Threaded Heat Insert') {

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -504,6 +504,43 @@ test('single icon fills the media zone proportionally', async () => {
   assert.ok(icon.width > 60, 'icon should scale to fill available space');
 });
 
+test('fuse illustrations honor provided aspect ratio hints', async () => {
+  const geometry = {
+    labelWidthMm: 37,
+    labelHeightMm: 12,
+    printableWidthMm: 33,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const hardwareInfo = {
+    type: 'fuse-illustration',
+    src: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+    alt: 'Glass fuse illustration',
+    aspectRatio: 926 / 307,
+  };
+  const result = await renderLabelSVG({
+    geometry,
+    pxPerMm,
+    textLines: { line1: 'Fuse', line2: 'Glass', line3: '' },
+    hardwareInfo,
+    qrContent: '',
+  });
+  const images = extractImages(result.svgMarkup);
+  assert.equal(images.length, 1, 'expected fuse illustration to render once');
+  const [illustration] = images;
+  assert.ok(illustration.height > 0, 'fuse illustration should have non-zero height');
+  assert.ok(
+    illustration.width > illustration.height,
+    `expected wide fuse illustration (width ${illustration.width} > height ${illustration.height})`,
+  );
+  const measuredRatio = illustration.width / illustration.height;
+  assert.ok(
+    measuredRatio > 2,
+    `expected fuse illustration ratio to exceed 2:1, received ${measuredRatio.toFixed(2)}`,
+  );
+});
+
 test('single-line labels center the main baseline within the text rect', async () => {
   const geometry = {
     labelWidthMm: 37,


### PR DESCRIPTION
## Summary
- add aspect ratio metadata to fuse illustrations and include it with the hardware payload
- propagate optional aspect ratio hints through media resolution and icon layout sizing logic
- add a renderer test that confirms wide fuse artwork renders wider than tall

## Testing
- node --test test/labelRenderer.test.mjs *(fails: known layout editor and QR tests that require DOM context)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f786cc1883299b1736dd863c1ffb