### PR TITLE
Shorten screw labels and keep compact subtitles single-line

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -289,9 +289,9 @@ export const boltDriveOptions = [
 ];
 
 export const screwTypeOptions = [
-  { id: 'countersunk_wood_screw', label: 'Countersunk Wood Screw', image: 'countersunk_wood_screw' },
-  { id: 'pan_head_wood_screw', label: 'Pan Head Wood Screw', image: 'pan_head_wood_screw' },
-  { id: 'self_drilling_hex_screw', label: 'Self-drilling Hex Screw', image: 'self_drilling_hex_screw' },
+  { id: 'countersunk_wood_screw', label: 'Countersunk', image: 'countersunk_wood_screw' },
+  { id: 'pan_head_wood_screw', label: 'Pan head', image: 'pan_head_wood_screw' },
+  { id: 'self_drilling_hex_screw', label: 'Self-drilling', image: 'self_drilling_hex_screw' },
 ];
 
 export const boltHeadMap = new Map(boltHeadOptions.map(option => [option.id, option]));

--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -283,6 +283,7 @@ function fitMultiLineText({
   heightPx,
   pxPerMm,
   allowEllipsis = true,
+  noWrap = false,
 }) {
   const normalizedLines = Array.isArray(lines)
     ? lines
@@ -310,7 +311,15 @@ function fitMultiLineText({
     let candidate = null;
     for (let i = 0; i < MAX_FIT_ITERATIONS && high - low > 0.2; i += 1) {
       const mid = (low + high) / 2;
-      const layout = layoutLines(normalizedLines, mid, fontWeight, letterSpacingPx, widthPx, lineHeightPct);
+      const layout = layoutLines(
+        normalizedLines,
+        mid,
+        fontWeight,
+        letterSpacingPx,
+        widthPx,
+        lineHeightPct,
+        { noWrap },
+      );
       const fitsHeight = layout.totalHeightPx <= heightPx + 0.25;
       if (layout.fitsWidth && fitsHeight) {
         candidate = { ...layout, fontSizePx: mid, letterSpacingPx };
@@ -320,7 +329,15 @@ function fitMultiLineText({
       }
     }
     if (!candidate) {
-      const layout = layoutLines(normalizedLines, minPx, fontWeight, letterSpacingPx, widthPx, lineHeightPct);
+      const layout = layoutLines(
+        normalizedLines,
+        minPx,
+        fontWeight,
+        letterSpacingPx,
+        widthPx,
+        lineHeightPct,
+        { noWrap },
+      );
       candidate = { ...layout, fontSizePx: minPx, letterSpacingPx };
       if (!layout.fitsWidth && allowEllipsis) {
         const lastIndex = layout.lines.length - 1;
@@ -364,12 +381,22 @@ function fitMultiLineText({
   return { ...best, lineHeightPx };
 }
 
-function layoutLines(lines, fontSizePx, fontWeight, letterSpacingPx, widthPx, lineHeightPct) {
+function layoutLines(
+  lines,
+  fontSizePx,
+  fontWeight,
+  letterSpacingPx,
+  widthPx,
+  lineHeightPct,
+  { noWrap = false } = {},
+) {
   const layoutLinesArray = [];
   const widths = [];
   const lineHeightPx = fontSizePx * (lineHeightPct / 100);
   lines.forEach(line => {
-    const measurements = wrapWords(line, fontSizePx, fontWeight, letterSpacingPx, widthPx);
+    const measurements = noWrap
+      ? [line]
+      : wrapWords(line, fontSizePx, fontWeight, letterSpacingPx, widthPx);
     measurements.forEach(entry => {
       layoutLinesArray.push(entry);
       widths.push(measureTextWidth(entry, fontSizePx, fontWeight, LABEL_FONT_FAMILY, letterSpacingPx));
@@ -710,19 +737,23 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
     ellipsisApplied: false,
   };
   if (subtitleCandidates.length > 0) {
-    const candidateFits = subtitleCandidates.map(candidate => ({
-      fit: fitMultiLineText({
-        lines: candidate,
-        fontWeight: 300,
-        minPt: textPreset.sub?.min_pt ?? 7,
-        maxPt: textPreset.sub?.max_pt ?? 11,
-        lineHeightPct: textPreset.sub?.line_height_pct ?? 115,
-        widthPx: Math.max(0, zones.sub.width - qrReservedWidthPx),
-        heightPx: zones.sub.height,
-        pxPerMm,
-      }),
-      isCompact: candidate.length === 1,
-    }));
+    const candidateFits = subtitleCandidates.map(candidate => {
+      const isCompact = candidate.length === 1;
+      return {
+        fit: fitMultiLineText({
+          lines: candidate,
+          fontWeight: 300,
+          minPt: textPreset.sub?.min_pt ?? 7,
+          maxPt: textPreset.sub?.max_pt ?? 11,
+          lineHeightPct: textPreset.sub?.line_height_pct ?? 115,
+          widthPx: Math.max(0, zones.sub.width - qrReservedWidthPx),
+          heightPx: zones.sub.height,
+          pxPerMm,
+          noWrap: isCompact,
+        }),
+        isCompact,
+      };
+    });
 
     const multiLineCandidates = candidateFits.filter(candidate => !candidate.isCompact);
     const multiLineWithoutEllipsis = multiLineCandidates.filter(

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -707,9 +707,40 @@ test('subtitle lines remain distinct with optional ellipsis on the last line', a
   nonFinalLines.forEach(line => {
     assert.ok(!line.trim().endsWith('…'), 'only final subtitle line should ellipsize when needed');
   });
+  const finalLine = subtitleLines[subtitleLines.length - 1]?.trim() ?? '';
+  const ellipsisCount = subtitleLines.filter(line => line.includes('…')).length;
+  if (ellipsisCount > 0) {
+    assert.equal(ellipsisCount, 1, 'ellipsis should appear on at most one subtitle line');
+    assert.ok(finalLine.endsWith('…'), 'ellipsis should only appear on the final subtitle line');
+  } else {
+    assert.ok(finalLine.length > 0, 'final subtitle line should contain text when ellipsis is unnecessary');
+  }
+
+  const compactGeometry = {
+    labelWidthMm: 20,
+    labelHeightMm: 12,
+    printableWidthMm: 16,
+    printableHeightMm: 10,
+    marginX: 2,
+    marginY: 1,
+  };
+  const compactResult = await renderLabelSVG({
+    geometry: compactGeometry,
+    pxPerMm,
+    textLines: { line1: 'M4 × 12', line2: 'Pan head', line3: '' },
+    hardwareInfo: null,
+    qrContent: '',
+  });
+  const compactSubtitleLines = compactResult.textLayout.sub?.lines || [];
+  assert.equal(
+    compactSubtitleLines.length,
+    1,
+    'compact screw subtitle should stay on a single line without wrapping',
+  );
+  const compactText = compactSubtitleLines[0]?.trim() ?? '';
   assert.ok(
-    subtitleLines[subtitleLines.length - 1].trim().endsWith('…'),
-    'second subtitle line may ellipsize when space runs out',
+    compactText === 'Pan head' || compactText.startsWith('Pan hea'),
+    'compact subtitle should surface the updated Pan head screw label',
   );
 });
 


### PR DESCRIPTION
## Summary
- abbreviate the screw `screwTypeOptions` labels so downstream consumers receive concise names
- teach the subtitle fitting logic to disable word wrapping for compact candidates, relying on scaling or ellipsis instead
- expand the label renderer test to cover the new one-line screw subtitle behavior and updated label text

## Testing
- `node --test test/labelRenderer.test.mjs` *(fails: existing suite depends on DOM helpers and missing jest globals in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e100c600a083299ce1013a65a7fe18