### PR TITLE
Improve label text toggles and layout preset resolution

### DIFF
--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -234,8 +234,21 @@ export function clearPresetOverrides() {
   notifyPresetListeners();
 }
 
+function parseHeightValue(heightMm) {
+  if (typeof heightMm === 'string') {
+    const match = heightMm.match(/-?\d+(?:\.\d+)?/);
+    if (match) {
+      const parsed = Number.parseFloat(match[0]);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return Number(heightMm);
+}
+
 function resolveKey(heightMm) {
-  const numeric = Number(heightMm);
+  const numeric = parseHeightValue(heightMm);
   if (!Number.isFinite(numeric) || numeric <= 0) {
     return '12';
   }
@@ -279,7 +292,7 @@ function deepMerge(base, override) {
 export function getActiveLayoutPreset(heightMm) {
   const key = resolveKey(heightMm);
   const base = defaultLayoutPresets[key] || defaultLayoutPresets['12'];
-  const override = getPresetOverride(key);
+  const override = getPresetOverride(heightMm);
   if (!override) {
     return clone(base);
   }

--- a/js/render.js
+++ b/js/render.js
@@ -779,9 +779,21 @@ export function updateTextOptionsVisibility(options = {}) {
   const { animate = true } = options;
   const shouldShow = Boolean(state.showText);
   const restoreTransition = animate ? null : temporarilyDisableTransition(textOptionsWrapper);
+  if (!shouldShow) {
+    const measuredHeight = textOptionsWrapper.scrollHeight;
+    if (measuredHeight > 0) {
+      textOptionsWrapper.style.maxHeight = `${measuredHeight}px`;
+      void textOptionsWrapper.offsetHeight;
+    }
+  }
   textToggle.setAttribute('aria-expanded', shouldShow ? 'true' : 'false');
   textOptionsWrapper.classList.toggle('is-collapsed', !shouldShow);
   textOptionsWrapper.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+  if (shouldShow) {
+    textOptionsWrapper.style.removeProperty('maxHeight');
+  } else {
+    textOptionsWrapper.style.maxHeight = '0px';
+  }
   textMainToggle.disabled = !shouldShow;
   textInfoToggle.disabled = !shouldShow;
   textOptionsWrapper.querySelectorAll('.label-suboption').forEach(suboption => {

--- a/style.css
+++ b/style.css
@@ -268,7 +268,11 @@ main {
   border-left: 2px solid var(--bs-border-color, rgba(148, 163, 184, 0.35));
   overflow: hidden;
   max-height: 400px;
-  transition: max-height 0.25s ease, opacity 0.2s ease, margin-top 0.2s ease;
+  transition:
+    max-height 0.25s ease,
+    opacity 0.2s ease,
+    margin-top 0.2s ease,
+    padding-left 0.2s ease;
 }
 
 .label-suboptions.is-collapsed {
@@ -276,6 +280,8 @@ main {
   pointer-events: none;
   margin-top: 0 !important;
   border-left-color: transparent;
+  max-height: 0;
+  padding-left: 0;
 }
 
 .label-suboptions.is-collapsed .label-suboption {

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -523,6 +523,19 @@ test('exporting presets with defaults preserves zero-value overrides', () => {
   }
 });
 
+test('getActiveLayoutPreset resolves heights expressed with units', () => {
+  clearPresetOverrides();
+  try {
+    const preset = getActiveLayoutPreset('18mm');
+    const expected = defaultLayoutPresets['18'];
+    assert.ok(expected, 'expected a default preset for 18 mm labels');
+    assert.equal(preset.icon_layout, expected.icon_layout);
+    assert.deepEqual(preset.text_zone.main, expected.text_zone.main);
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
 test('icon padding and media/text gap persist through export and import', () => {
   clearPresetOverrides();
   try {


### PR DESCRIPTION
## Summary
- hide and animate the label text sub-options when the main text toggle is disabled
- ensure layout presets accept heights expressed with units and merge overrides correctly
- add a regression test that exercises the 18 mm preset resolution

## Testing
- npm run lint
- node --test test/labelRenderer.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e12aeecedc8329b92060587a9e3df6