### PR TITLE
Adjust label preview header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1557,6 +1557,17 @@
               <i class="fa-solid fa-eye me-2" aria-hidden="true"></i>
               <span>Label Preview</span>
             </h2>
+            <div class="size-info text-muted small">
+              <span
+                id="preview-status-text"
+                class="visually-hidden"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+              ></span>
+              <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
+              <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
+            </div>
             <button
               type="button"
               class="section-toggle-button"
@@ -1570,17 +1581,6 @@
             </button>
           </div>
           <div class="collapsible-content" id="label-preview-content" data-collapsible-content>
-            <div class="size-info text-muted small mb-3">
-              <span
-                id="preview-status-text"
-                class="visually-hidden"
-                role="status"
-                aria-live="polite"
-                aria-atomic="true"
-              ></span>
-              <div id="label-size-display">55&nbsp;mm ×&nbsp;12&nbsp;mm (label size)</div>
-              <div id="print-area-display">51&nbsp;mm ×&nbsp;10&nbsp;mm (printable area)</div>
-            </div>
             <div class="label-preview-viewport">
               <div id="preview-container" class="label-preview">
                 <div id="preview-placeholder" class="preview-placeholder">

--- a/style.css
+++ b/style.css
@@ -755,8 +755,11 @@ main {
 
 .size-info {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-left: auto;
+  text-align: right;
+  gap: 0.125rem;
 }
 
 .label-preview-viewport {


### PR DESCRIPTION
## Summary
- move the label size and printable area displays into the preview section header alongside the title
- update the header size-info styles to stack the metrics on two right-aligned lines while keeping the status text accessible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e147acbb4083298668ebbadff8e076