### PR TITLE
Fix dark mode header logo color

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,11 +109,11 @@
       </div>
       <header class="title-section text-center mb-4">
         <div class="title-brand d-flex align-items-center justify-content-center gap-3 mb-2">
-          <img
-            src="images/icons/logo.svg"
+          <span
             class="title-logo"
-            alt="Gridfinity Label Maker logo"
-          />
+            role="img"
+            aria-label="Gridfinity Label Maker logo"
+          ></span>
           <h1 class="title-heading mb-0">Gridfinity Label Maker</h1>
         </div>
         <p class="text-muted mb-0">Design and print perfectly sized storage labels.</p>

--- a/style.css
+++ b/style.css
@@ -132,11 +132,12 @@ main {
 
 .title-logo {
   width: clamp(3rem, 10vw, 4.5rem);
-  height: auto;
-}
-
-:root[data-theme='dark'] .title-logo {
-  color: var(--bs-body-color);
+  aspect-ratio: 1 / 1;
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask: url('images/icons/logo.svg') center / contain no-repeat;
+          mask: url('images/icons/logo.svg') center / contain no-repeat;
+  flex-shrink: 0;
 }
 
 .title-heading {


### PR DESCRIPTION
## Summary
- replace the header logo image with an inline element that can inherit text color
- apply a CSS mask that paints the logo with the current text color so it remains visible in dark mode

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1485cbc308329bc17885c1f1b6e91