### PR TITLE
Fix clearing text options max height reset

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -790,7 +790,7 @@ export function updateTextOptionsVisibility(options = {}) {
   textOptionsWrapper.classList.toggle('is-collapsed', !shouldShow);
   textOptionsWrapper.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
   if (shouldShow) {
-    textOptionsWrapper.style.removeProperty('maxHeight');
+    textOptionsWrapper.style.removeProperty('max-height');
   } else {
     textOptionsWrapper.style.maxHeight = '0px';
   }


### PR DESCRIPTION
## Summary
- ensure the text options panel removes the inline max-height style when shown so transitions restore properly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14cd548d88329ad48ce82f3345eb9