### PR TITLE
Add Potentiometer component support

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,13 @@
                         <option value="Diode" data-img="images/diodes/diode_through_hole.svg" data-cat="Electrical">
                           Diode
                         </option>
+                        <option
+                          value="Potentiometer"
+                          data-img="images/potentiometer/potentiometer.svg"
+                          data-cat="Electrical"
+                        >
+                          Potentiometer
+                        </option>
                       </optgroup>
                       <optgroup label="Mechanical">
                         <option value="Bearing" data-img="images/bearings/bearing.svg" data-cat="Mechanical">
@@ -716,6 +723,100 @@
                       </div>
                       <div
                         id="diode-value-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div class="col-12 col-lg-6 d-none" id="potentiometer-value-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="potentiometer-value-picker-button"
+                        >Potentiometer Value</label
+                      >
+                      <div class="bolt-drive-picker" id="potentiometer-value-picker">
+                        <select
+                          id="potentiometer-value-select"
+                          class="visually-hidden"
+                          aria-labelledby="potentiometer-value-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="potentiometer-value-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="potentiometer-value-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="potentiometer-value-picker-list"
+                          role="listbox"
+                          aria-labelledby="potentiometer-value-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="potentiometer-value-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div class="col-12 col-lg-6 d-none" id="potentiometer-taper-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="potentiometer-taper-picker-button"
+                        >Potentiometer Taper</label
+                      >
+                      <div class="bolt-drive-picker" id="potentiometer-taper-picker">
+                        <select
+                          id="potentiometer-taper-select"
+                          class="visually-hidden"
+                          aria-labelledby="potentiometer-taper-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="potentiometer-taper-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="potentiometer-taper-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="potentiometer-taper-picker-list"
+                          role="listbox"
+                          aria-labelledby="potentiometer-taper-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="potentiometer-taper-message"
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>

--- a/js/controls.js
+++ b/js/controls.js
@@ -13,6 +13,8 @@ import {
   populateResistorValues,
   populateCapacitorValues,
   populateDiodeValues,
+  populatePotentiometerValues,
+  populatePotentiometerTapers,
   populateWasherTypeOptions,
   updateCustomImageUi,
   ensureCustomIconAsset,
@@ -32,6 +34,8 @@ import {
   setResistorValueSelection,
   setCapacitorValueSelection,
   setDiodeValueSelection,
+  setPotentiometerValueSelection,
+  setPotentiometerTaperSelection,
   syncConnectorSeriesPicker,
   updateComponentValueUi,
 } from './forms.js';
@@ -100,6 +104,8 @@ function applyStateToControls() {
   setResistorValueSelection(state.resistorValue || '', { triggerUpdate: false });
   setCapacitorValueSelection(state.capacitorValue || '', { triggerUpdate: false });
   setDiodeValueSelection(state.diodeValue || '', { triggerUpdate: false });
+  setPotentiometerValueSelection(state.potentiometerValue || '', { triggerUpdate: false });
+  setPotentiometerTaperSelection(state.potentiometerTaper || '', { triggerUpdate: false });
   updateComponentValueUi({ resetIfHidden: false });
 
   if (lengthInput) {
@@ -173,6 +179,8 @@ function init() {
   populateResistorValues();
   populateCapacitorValues();
   populateDiodeValues();
+  populatePotentiometerValues();
+  populatePotentiometerTapers();
   populateWasherTypeOptions();
   populateSwitchTypePicker();
   updateCustomImageUi();

--- a/js/data.js
+++ b/js/data.js
@@ -102,7 +102,7 @@ export const switchTypeImageMap = new Map(
   switchTypeOptions.map(option => [option.id, option.image]),
 );
 
-export const electricalComponentTypes = ['Resistor', 'Capacitor', 'Diode'];
+export const electricalComponentTypes = ['Resistor', 'Capacitor', 'Diode', 'Potentiometer'];
 
 export const componentImageMap = {
   Resistor: {
@@ -119,6 +119,11 @@ export const componentImageMap = {
     'Through-Hole': 'images/diodes/diode_through_hole.svg',
     SMD: 'images/diodes/diode_smd.svg',
     default: 'images/diodes/diode_through_hole.svg',
+  },
+  Potentiometer: {
+    'Through-Hole': 'images/potentiometer/potentiometer.svg',
+    SMD: 'images/potentiometer/potentiometer.svg',
+    default: 'images/potentiometer/potentiometer.svg',
   },
 };
 
@@ -232,6 +237,36 @@ export const capacitorValueOptions = Array.from(capacitorValueSet)
     const label = formatCapacitorValue(value);
     return { id: label, label };
   });
+
+export const potentiometerValueOptions = [
+  { id: '1 kΩ', label: '1 kΩ', image: 'images/potentiometer/potentiometer.svg' },
+  { id: '10 kΩ', label: '10 kΩ', image: 'images/potentiometer/potentiometer.svg' },
+  { id: '100 kΩ', label: '100 kΩ', image: 'images/potentiometer/potentiometer.svg' },
+  { id: '1 MΩ', label: '1 MΩ', image: 'images/potentiometer/potentiometer.svg' },
+];
+
+export const potentiometerTaperOptions = [
+  {
+    id: 'Linear (B)',
+    label: 'Linear (B)',
+    image: 'images/potentiometer/potentiometer.svg',
+  },
+  {
+    id: 'Logarithmic (A)',
+    label: 'Logarithmic (A)',
+    image: 'images/potentiometer/potentiometer.svg',
+  },
+  {
+    id: 'Reverse Log (C)',
+    label: 'Reverse Log (C)',
+    image: 'images/potentiometer/potentiometer.svg',
+  },
+  {
+    id: 'Multi-turn Trimmer',
+    label: 'Multi-turn Trimmer',
+    image: 'images/potentiometer/potentiometer.svg',
+  },
+];
 
 export const diodeValueOptions = [
   { id: '1N4148', label: '1N4148 Signal Diode' },
@@ -393,6 +428,11 @@ export const hardwareCatalog = {
     { code: 'General Purpose', name: 'Rectifier Diode' },
     { code: 'Signal', name: 'Small Signal Diode' },
   ],
+  Potentiometer: [
+    { code: 'Panel-Mount Linear', name: 'Panel-Mount Linear Potentiometer' },
+    { code: 'Panel-Mount Log', name: 'Panel-Mount Logarithmic Potentiometer' },
+    { code: 'Trimmer', name: 'Multi-turn Trimmer Potentiometer' },
+  ],
   Switch: [],
   Fuse: [
     { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
@@ -426,6 +466,7 @@ export const hardwareTypeImageMap = {
   Bearing: 'images/bearings/bearing.svg',
   Washer: 'images/washers/plain_washer.svg',
   Diode: 'images/diodes/diode_through_hole.svg',
+  Potentiometer: 'images/potentiometer/potentiometer.svg',
 };
 
 export const PRE_INSULATED_CRIMP_CATEGORY_ID = 'pre-insulated-crimp';

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -88,6 +88,18 @@ const diodeValuePickerButton = document.getElementById('diode-value-picker-butto
 const diodeValuePickerList = document.getElementById('diode-value-picker-list');
 const diodeValueSelect = document.getElementById('diode-value-select');
 const diodeValueMessage = document.getElementById('diode-value-message');
+const potentiometerValueField = document.getElementById('potentiometer-value-field');
+const potentiometerValuePicker = document.getElementById('potentiometer-value-picker');
+const potentiometerValuePickerButton = document.getElementById('potentiometer-value-picker-button');
+const potentiometerValuePickerList = document.getElementById('potentiometer-value-picker-list');
+const potentiometerValueSelect = document.getElementById('potentiometer-value-select');
+const potentiometerValueMessage = document.getElementById('potentiometer-value-message');
+const potentiometerTaperField = document.getElementById('potentiometer-taper-field');
+const potentiometerTaperPicker = document.getElementById('potentiometer-taper-picker');
+const potentiometerTaperPickerButton = document.getElementById('potentiometer-taper-picker-button');
+const potentiometerTaperPickerList = document.getElementById('potentiometer-taper-picker-list');
+const potentiometerTaperSelect = document.getElementById('potentiometer-taper-select');
+const potentiometerTaperMessage = document.getElementById('potentiometer-taper-message');
 const bearingOptionsContainer = document.getElementById('bearing-options-container');
 const bearingTypePicker = document.getElementById('bearing-type-picker');
 const bearingTypePickerButton = document.getElementById('bearing-type-picker-button');
@@ -282,6 +294,18 @@ export const elements = {
   diodeValuePickerList,
   diodeValueSelect,
   diodeValueMessage,
+  potentiometerValueField,
+  potentiometerValuePicker,
+  potentiometerValuePickerButton,
+  potentiometerValuePickerList,
+  potentiometerValueSelect,
+  potentiometerValueMessage,
+  potentiometerTaperField,
+  potentiometerTaperPicker,
+  potentiometerTaperPickerButton,
+  potentiometerTaperPickerList,
+  potentiometerTaperSelect,
+  potentiometerTaperMessage,
   bearingOptionsContainer,
   bearingTypePicker,
   bearingTypePickerButton,

--- a/js/events.js
+++ b/js/events.js
@@ -39,6 +39,8 @@ import {
   setResistorValueSelection,
   setCapacitorValueSelection,
   setDiodeValueSelection,
+  setPotentiometerValueSelection,
+  setPotentiometerTaperSelection,
   updateComponentValueUi,
   setBearingTypeSelection,
   syncBearingTypePicker,
@@ -83,6 +85,14 @@ const {
   diodeValuePicker,
   diodeValuePickerButton,
   diodeValuePickerList,
+  potentiometerValueSelect,
+  potentiometerValuePicker,
+  potentiometerValuePickerButton,
+  potentiometerValuePickerList,
+  potentiometerTaperSelect,
+  potentiometerTaperPicker,
+  potentiometerTaperPickerButton,
+  potentiometerTaperPickerList,
   bearingTypeSelect,
   bearingTypePicker,
   bearingTypePickerButton,
@@ -176,6 +186,8 @@ let componentMountPickerOpen = false;
 let resistorValuePickerOpen = false;
 let capacitorValuePickerOpen = false;
 let diodeValuePickerOpen = false;
+let potentiometerValuePickerOpen = false;
+let potentiometerTaperPickerOpen = false;
 let bearingTypePickerOpen = false;
 let customIconPickerOpen = false;
 let connectorCategoryPickerOpen = false;
@@ -2279,6 +2291,432 @@ function handleDiodeValueListFocusOut() {
   }, 0);
 }
 
+function getPotentiometerValueOptionElements() {
+  if (!potentiometerValuePickerList) {
+    return [];
+  }
+  return Array.from(potentiometerValuePickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusPotentiometerValueOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getPotentiometerValueOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openPotentiometerValuePicker() {
+  if (
+    !potentiometerValuePicker ||
+    !potentiometerValuePickerButton ||
+    !potentiometerValuePickerList
+  ) {
+    return;
+  }
+  if (potentiometerValuePickerButton.disabled || potentiometerValuePickerOpen) {
+    return;
+  }
+  potentiometerValuePickerOpen = true;
+  potentiometerValuePicker.classList.add('is-open');
+  potentiometerValuePickerList.hidden = false;
+  potentiometerValuePickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getPotentiometerValueOptionElements();
+  const currentValue =
+    typeof state.potentiometerValue === 'string' ? state.potentiometerValue : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusPotentiometerValueOption(selectedOption || options[0]);
+}
+
+function closePotentiometerValuePicker({ focusButton = false } = {}) {
+  if (
+    !potentiometerValuePicker ||
+    !potentiometerValuePickerButton ||
+    !potentiometerValuePickerList
+  ) {
+    return;
+  }
+  if (!potentiometerValuePickerOpen) {
+    if (focusButton && !potentiometerValuePickerButton.disabled) {
+      potentiometerValuePickerButton.focus();
+    }
+    return;
+  }
+  potentiometerValuePickerOpen = false;
+  potentiometerValuePicker.classList.remove('is-open');
+  potentiometerValuePickerList.hidden = true;
+  potentiometerValuePickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !potentiometerValuePickerButton.disabled) {
+    potentiometerValuePickerButton.focus();
+  }
+}
+
+function togglePotentiometerValuePicker() {
+  if (potentiometerValuePickerOpen) {
+    closePotentiometerValuePicker({ focusButton: false });
+  } else {
+    openPotentiometerValuePicker();
+  }
+}
+
+function movePotentiometerValueOption(delta) {
+  const options = getPotentiometerValueOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && potentiometerValuePickerList && potentiometerValuePickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue =
+      typeof state.potentiometerValue === 'string' ? state.potentiometerValue : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusPotentiometerValueOption(nextOption);
+  }
+}
+
+function handlePotentiometerValueButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openPotentiometerValuePicker();
+    movePotentiometerValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openPotentiometerValuePicker();
+    movePotentiometerValueOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    togglePotentiometerValuePicker();
+    return;
+  }
+  if (key === 'Escape' && potentiometerValuePickerOpen) {
+    event.preventDefault();
+    closePotentiometerValuePicker({ focusButton: true });
+  }
+}
+
+function handlePotentiometerValueListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    movePotentiometerValueOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    movePotentiometerValueOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getPotentiometerValueOptionElements();
+    if (options.length > 0) {
+      focusPotentiometerValueOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getPotentiometerValueOptionElements();
+    if (options.length > 0) {
+      focusPotentiometerValueOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setPotentiometerValueSelection(option.dataset.value || '');
+        closePotentiometerValuePicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closePotentiometerValuePicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closePotentiometerValuePicker();
+  }
+}
+
+function handlePotentiometerValueListClick(event) {
+  if (!potentiometerValuePickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !potentiometerValuePickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setPotentiometerValueSelection(option.dataset.value || '');
+  closePotentiometerValuePicker({ focusButton: true });
+}
+
+function handlePotentiometerValueListFocusOut() {
+  if (!potentiometerValuePickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!potentiometerValuePickerOpen) {
+      return;
+    }
+    if (!potentiometerValuePicker) {
+      closePotentiometerValuePicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !potentiometerValuePicker.contains(active)) {
+      closePotentiometerValuePicker();
+    }
+  }, 0);
+}
+
+function getPotentiometerTaperOptionElements() {
+  if (!potentiometerTaperPickerList) {
+    return [];
+  }
+  return Array.from(potentiometerTaperPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusPotentiometerTaperOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getPotentiometerTaperOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openPotentiometerTaperPicker() {
+  if (
+    !potentiometerTaperPicker ||
+    !potentiometerTaperPickerButton ||
+    !potentiometerTaperPickerList
+  ) {
+    return;
+  }
+  if (potentiometerTaperPickerButton.disabled || potentiometerTaperPickerOpen) {
+    return;
+  }
+  potentiometerTaperPickerOpen = true;
+  potentiometerTaperPicker.classList.add('is-open');
+  potentiometerTaperPickerList.hidden = false;
+  potentiometerTaperPickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getPotentiometerTaperOptionElements();
+  const currentValue =
+    typeof state.potentiometerTaper === 'string' ? state.potentiometerTaper : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusPotentiometerTaperOption(selectedOption || options[0]);
+}
+
+function closePotentiometerTaperPicker({ focusButton = false } = {}) {
+  if (
+    !potentiometerTaperPicker ||
+    !potentiometerTaperPickerButton ||
+    !potentiometerTaperPickerList
+  ) {
+    return;
+  }
+  if (!potentiometerTaperPickerOpen) {
+    if (focusButton && !potentiometerTaperPickerButton.disabled) {
+      potentiometerTaperPickerButton.focus();
+    }
+    return;
+  }
+  potentiometerTaperPickerOpen = false;
+  potentiometerTaperPicker.classList.remove('is-open');
+  potentiometerTaperPickerList.hidden = true;
+  potentiometerTaperPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !potentiometerTaperPickerButton.disabled) {
+    potentiometerTaperPickerButton.focus();
+  }
+}
+
+function togglePotentiometerTaperPicker() {
+  if (potentiometerTaperPickerOpen) {
+    closePotentiometerTaperPicker({ focusButton: false });
+  } else {
+    openPotentiometerTaperPicker();
+  }
+}
+
+function movePotentiometerTaperOption(delta) {
+  const options = getPotentiometerTaperOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && potentiometerTaperPickerList && potentiometerTaperPickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue =
+      typeof state.potentiometerTaper === 'string' ? state.potentiometerTaper : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusPotentiometerTaperOption(nextOption);
+  }
+}
+
+function handlePotentiometerTaperButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openPotentiometerTaperPicker();
+    movePotentiometerTaperOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openPotentiometerTaperPicker();
+    movePotentiometerTaperOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    togglePotentiometerTaperPicker();
+    return;
+  }
+  if (key === 'Escape' && potentiometerTaperPickerOpen) {
+    event.preventDefault();
+    closePotentiometerTaperPicker({ focusButton: true });
+  }
+}
+
+function handlePotentiometerTaperListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    movePotentiometerTaperOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    movePotentiometerTaperOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getPotentiometerTaperOptionElements();
+    if (options.length > 0) {
+      focusPotentiometerTaperOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getPotentiometerTaperOptionElements();
+    if (options.length > 0) {
+      focusPotentiometerTaperOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setPotentiometerTaperSelection(option.dataset.value || '');
+        closePotentiometerTaperPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closePotentiometerTaperPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closePotentiometerTaperPicker();
+  }
+}
+
+function handlePotentiometerTaperListClick(event) {
+  if (!potentiometerTaperPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !potentiometerTaperPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setPotentiometerTaperSelection(option.dataset.value || '');
+  closePotentiometerTaperPicker({ focusButton: true });
+}
+
+function handlePotentiometerTaperListFocusOut() {
+  if (!potentiometerTaperPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!potentiometerTaperPickerOpen) {
+      return;
+    }
+    if (!potentiometerTaperPicker) {
+      closePotentiometerTaperPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !potentiometerTaperPicker.contains(active)) {
+      closePotentiometerTaperPicker();
+    }
+  }, 0);
+}
+
 function getBearingTypeOptionElements() {
   if (!bearingTypePickerList) {
     return [];
@@ -4305,6 +4743,46 @@ export function initEventHandlers() {
     capacitorValuePickerList.addEventListener('focusout', handleCapacitorValueListFocusOut);
   }
 
+  if (potentiometerValueSelect) {
+    potentiometerValueSelect.addEventListener('change', () => {
+      setPotentiometerValueSelection(potentiometerValueSelect.value);
+    });
+  }
+
+  if (potentiometerValuePickerButton && potentiometerValuePickerList) {
+    potentiometerValuePickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      togglePotentiometerValuePicker();
+    });
+    potentiometerValuePickerButton.addEventListener(
+      'keydown',
+      handlePotentiometerValueButtonKeydown,
+    );
+    potentiometerValuePickerList.addEventListener('click', handlePotentiometerValueListClick);
+    potentiometerValuePickerList.addEventListener('keydown', handlePotentiometerValueListKeydown);
+    potentiometerValuePickerList.addEventListener('focusout', handlePotentiometerValueListFocusOut);
+  }
+
+  if (potentiometerTaperSelect) {
+    potentiometerTaperSelect.addEventListener('change', () => {
+      setPotentiometerTaperSelection(potentiometerTaperSelect.value);
+    });
+  }
+
+  if (potentiometerTaperPickerButton && potentiometerTaperPickerList) {
+    potentiometerTaperPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      togglePotentiometerTaperPicker();
+    });
+    potentiometerTaperPickerButton.addEventListener(
+      'keydown',
+      handlePotentiometerTaperButtonKeydown,
+    );
+    potentiometerTaperPickerList.addEventListener('click', handlePotentiometerTaperListClick);
+    potentiometerTaperPickerList.addEventListener('keydown', handlePotentiometerTaperListKeydown);
+    potentiometerTaperPickerList.addEventListener('focusout', handlePotentiometerTaperListFocusOut);
+  }
+
   if (bearingTypeSelect) {
     bearingTypeSelect.addEventListener('change', () => {
       setBearingTypeSelection(bearingTypeSelect.value);
@@ -4635,6 +5113,8 @@ export function initEventHandlers() {
     resistorValuePicker ||
     capacitorValuePicker ||
     diodeValuePicker ||
+    potentiometerValuePicker ||
+    potentiometerTaperPicker ||
     bearingTypePicker ||
     connectorCategoryPicker ||
     connectorSeriesPicker ||
@@ -4657,6 +5137,9 @@ export function initEventHandlers() {
     closeComponentMountPicker();
     closeResistorValuePicker();
     closeCapacitorValuePicker();
+    closeDiodeValuePicker();
+    closePotentiometerValuePicker();
+    closePotentiometerTaperPicker();
   });
 
   document.addEventListener('gridfinity:custom-icon-picker-close', () => {

--- a/js/forms.js
+++ b/js/forms.js
@@ -22,6 +22,8 @@ import {
   resistorValueOptions,
   capacitorValueOptions,
   diodeValueOptions,
+  potentiometerValueOptions,
+  potentiometerTaperOptions,
   connectorCategoryImageMap,
   getConnectorSeriesImage,
 } from './data.js';
@@ -105,6 +107,16 @@ const {
   diodeValuePickerButton,
   diodeValuePickerList,
   diodeValueSelect,
+  potentiometerValueField,
+  potentiometerValuePicker,
+  potentiometerValuePickerButton,
+  potentiometerValuePickerList,
+  potentiometerValueSelect,
+  potentiometerTaperField,
+  potentiometerTaperPicker,
+  potentiometerTaperPickerButton,
+  potentiometerTaperPickerList,
+  potentiometerTaperSelect,
   bearingOptionsContainer,
   bearingTypePicker,
   bearingTypePickerButton,
@@ -226,6 +238,14 @@ const CAPACITOR_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validCapacitorValues = new Set(capacitorValueOptions.map(option => option.id));
 const DIODE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validDiodeValues = new Set(diodeValueOptions.map(option => option.id));
+const POTENTIOMETER_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validPotentiometerValues = new Set(
+  potentiometerValueOptions.map(option => option.id),
+);
+const POTENTIOMETER_TAPER_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validPotentiometerTapers = new Set(
+  potentiometerTaperOptions.map(option => option.id),
+);
 const BEARING_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validBearingCodes = new Set(bearingOptions.map(option => option.code));
 const CONNECTOR_CATEGORY_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -935,6 +955,8 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
   const showResistorValues = showComponentFields && category === 'Resistor';
   const showCapacitorValues = showComponentFields && category === 'Capacitor';
   const showDiodeValues = showComponentFields && category === 'Diode';
+  const showPotentiometerValues = showComponentFields && category === 'Potentiometer';
+  const showPotentiometerTaper = showPotentiometerValues;
 
   if (resistorValueField) {
     resistorValueField.classList.toggle('d-none', !showResistorValues);
@@ -1049,11 +1071,91 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
     state.diodeValue = '';
   }
 
+  if (potentiometerValueField) {
+    potentiometerValueField.classList.toggle('d-none', !showPotentiometerValues);
+    potentiometerValueField.setAttribute('aria-hidden', showPotentiometerValues ? 'false' : 'true');
+  }
+
+  if (potentiometerValueSelect) {
+    potentiometerValueSelect.disabled = !showPotentiometerValues;
+  }
+
+  if (potentiometerValuePickerButton) {
+    potentiometerValuePickerButton.disabled = !showPotentiometerValues;
+    const isOpen = Boolean(
+      showPotentiometerValues &&
+        potentiometerValuePicker &&
+        potentiometerValuePicker.classList.contains('is-open'),
+    );
+    potentiometerValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (potentiometerValuePickerList) {
+    const shouldHideList =
+      !showPotentiometerValues ||
+      !potentiometerValuePicker ||
+      !potentiometerValuePicker.classList.contains('is-open');
+    potentiometerValuePickerList.hidden = shouldHideList;
+  }
+
+  if (potentiometerValuePicker) {
+    if (!showPotentiometerValues) {
+      potentiometerValuePicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    potentiometerValuePicker.classList.toggle('is-disabled', !showPotentiometerValues);
+  }
+
+  if (!showPotentiometerValues && resetIfHidden) {
+    state.potentiometerValue = '';
+  }
+
+  if (potentiometerTaperField) {
+    potentiometerTaperField.classList.toggle('d-none', !showPotentiometerTaper);
+    potentiometerTaperField.setAttribute('aria-hidden', showPotentiometerTaper ? 'false' : 'true');
+  }
+
+  if (potentiometerTaperSelect) {
+    potentiometerTaperSelect.disabled = !showPotentiometerTaper;
+  }
+
+  if (potentiometerTaperPickerButton) {
+    potentiometerTaperPickerButton.disabled = !showPotentiometerTaper;
+    const isOpen = Boolean(
+      showPotentiometerTaper &&
+        potentiometerTaperPicker &&
+        potentiometerTaperPicker.classList.contains('is-open'),
+    );
+    potentiometerTaperPickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (potentiometerTaperPickerList) {
+    const shouldHideList =
+      !showPotentiometerTaper ||
+      !potentiometerTaperPicker ||
+      !potentiometerTaperPicker.classList.contains('is-open');
+    potentiometerTaperPickerList.hidden = shouldHideList;
+  }
+
+  if (potentiometerTaperPicker) {
+    if (!showPotentiometerTaper) {
+      potentiometerTaperPicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    potentiometerTaperPicker.classList.toggle('is-disabled', !showPotentiometerTaper);
+  }
+
+  if (!showPotentiometerTaper && resetIfHidden) {
+    state.potentiometerTaper = '';
+  }
+
   refreshComponentMountPickerIcons();
   syncComponentMountPicker({ isValid: true });
   syncResistorValuePicker({ isValid: true });
   syncCapacitorValuePicker({ isValid: true });
   syncDiodeValuePicker({ isValid: true });
+  syncPotentiometerValuePicker({ isValid: true });
+  syncPotentiometerTaperPicker({ isValid: true });
 }
 
 export function syncResistorValuePicker({ isValid = true } = {}) {
@@ -1349,6 +1451,340 @@ export function setDiodeValueSelection(nextValue, { triggerUpdate = true } = {})
 
   state.diodeValue = sanitizedValue;
   syncDiodeValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function populatePotentiometerValues() {
+  if (!potentiometerValueSelect) {
+    return;
+  }
+
+  const previousValue =
+    typeof state.potentiometerValue === 'string' ? state.potentiometerValue : '';
+
+  potentiometerValueSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = POTENTIOMETER_VALUE_PLACEHOLDER_TEXT;
+  potentiometerValueSelect.appendChild(placeholder);
+
+  potentiometerValueOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    potentiometerValueSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validPotentiometerValues.has(previousValue) ? previousValue : '';
+  state.potentiometerValue = sanitizedValue;
+  potentiometerValueSelect.value = sanitizedValue;
+
+  if (potentiometerValuePickerList) {
+    potentiometerValuePickerList.innerHTML = '';
+    potentiometerValueOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      const imageSrc = option.image || '';
+      if (imageSrc) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = imageSrc;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      potentiometerValuePickerList.appendChild(item);
+    });
+    potentiometerValuePickerList.hidden = true;
+  }
+
+  if (potentiometerValuePickerButton) {
+    potentiometerValuePickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncPotentiometerValuePicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
+export function populatePotentiometerTapers() {
+  if (!potentiometerTaperSelect) {
+    return;
+  }
+
+  const previousValue =
+    typeof state.potentiometerTaper === 'string' ? state.potentiometerTaper : '';
+
+  potentiometerTaperSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = POTENTIOMETER_TAPER_PLACEHOLDER_TEXT;
+  potentiometerTaperSelect.appendChild(placeholder);
+
+  potentiometerTaperOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    potentiometerTaperSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validPotentiometerTapers.has(previousValue) ? previousValue : '';
+  state.potentiometerTaper = sanitizedValue;
+  potentiometerTaperSelect.value = sanitizedValue;
+
+  if (potentiometerTaperPickerList) {
+    potentiometerTaperPickerList.innerHTML = '';
+    potentiometerTaperOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      const imageSrc = option.image || '';
+      if (imageSrc) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = imageSrc;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      potentiometerTaperPickerList.appendChild(item);
+    });
+    potentiometerTaperPickerList.hidden = true;
+  }
+
+  if (potentiometerTaperPickerButton) {
+    potentiometerTaperPickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncPotentiometerTaperPicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
+export function syncPotentiometerValuePicker({ isValid = true } = {}) {
+  if (!potentiometerValueSelect) {
+    return;
+  }
+
+  const currentValue =
+    typeof state.potentiometerValue === 'string' ? state.potentiometerValue : '';
+  const sanitizedValue = validPotentiometerValues.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.potentiometerValue = sanitizedValue;
+  }
+
+  potentiometerValueSelect.value = sanitizedValue;
+  if (!sanitizedValue && potentiometerValueSelect.options.length > 0) {
+    potentiometerValueSelect.selectedIndex = 0;
+  }
+
+  const imageSrc = sanitizedValue ? 'images/potentiometer/potentiometer.svg' : '';
+
+  if (potentiometerValuePickerButton) {
+    const label =
+      potentiometerValuePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper =
+      potentiometerValuePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    let iconImage = iconWrapper
+      ? iconWrapper.querySelector('.bolt-drive-picker__current-icon-image')
+      : null;
+
+    if (label) {
+      label.textContent = sanitizedValue
+        ? sanitizedValue
+        : POTENTIOMETER_VALUE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper) {
+      if (imageSrc) {
+        if (!iconImage) {
+          iconImage = document.createElement('img');
+          iconImage.className = 'bolt-drive-picker__current-icon-image';
+          iconImage.alt = '';
+          iconImage.loading = 'lazy';
+          iconImage.decoding = 'async';
+          iconWrapper.appendChild(iconImage);
+        }
+        iconWrapper.classList.remove('is-empty');
+        iconImage.src = imageSrc;
+        iconImage.hidden = false;
+      } else {
+        if (iconImage) {
+          iconImage.hidden = true;
+          iconImage.removeAttribute('src');
+        }
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      potentiometerValuePickerButton.classList.remove('is-invalid');
+      potentiometerValuePickerButton.removeAttribute('aria-invalid');
+    } else {
+      potentiometerValuePickerButton.classList.add('is-invalid');
+      potentiometerValuePickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (potentiometerValuePicker) {
+    potentiometerValuePicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (potentiometerValuePickerList) {
+    const optionElements = Array.from(
+      potentiometerValuePickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function syncPotentiometerTaperPicker({ isValid = true } = {}) {
+  if (!potentiometerTaperSelect) {
+    return;
+  }
+
+  const currentValue =
+    typeof state.potentiometerTaper === 'string' ? state.potentiometerTaper : '';
+  const sanitizedValue = validPotentiometerTapers.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.potentiometerTaper = sanitizedValue;
+  }
+
+  potentiometerTaperSelect.value = sanitizedValue;
+  if (!sanitizedValue && potentiometerTaperSelect.options.length > 0) {
+    potentiometerTaperSelect.selectedIndex = 0;
+  }
+
+  const imageSrc = sanitizedValue ? 'images/potentiometer/potentiometer.svg' : '';
+
+  if (potentiometerTaperPickerButton) {
+    const label =
+      potentiometerTaperPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper =
+      potentiometerTaperPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    let iconImage = iconWrapper
+      ? iconWrapper.querySelector('.bolt-drive-picker__current-icon-image')
+      : null;
+
+    if (label) {
+      label.textContent = sanitizedValue
+        ? sanitizedValue
+        : POTENTIOMETER_TAPER_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper) {
+      if (imageSrc) {
+        if (!iconImage) {
+          iconImage = document.createElement('img');
+          iconImage.className = 'bolt-drive-picker__current-icon-image';
+          iconImage.alt = '';
+          iconImage.loading = 'lazy';
+          iconImage.decoding = 'async';
+          iconWrapper.appendChild(iconImage);
+        }
+        iconWrapper.classList.remove('is-empty');
+        iconImage.src = imageSrc;
+        iconImage.hidden = false;
+      } else {
+        if (iconImage) {
+          iconImage.hidden = true;
+          iconImage.removeAttribute('src');
+        }
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      potentiometerTaperPickerButton.classList.remove('is-invalid');
+      potentiometerTaperPickerButton.removeAttribute('aria-invalid');
+    } else {
+      potentiometerTaperPickerButton.classList.add('is-invalid');
+      potentiometerTaperPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (potentiometerTaperPicker) {
+    potentiometerTaperPicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (potentiometerTaperPickerList) {
+    const optionElements = Array.from(
+      potentiometerTaperPickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setPotentiometerValueSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validPotentiometerValues.has(desiredValue) ? desiredValue : '';
+  const previousValue =
+    typeof state.potentiometerValue === 'string' ? state.potentiometerValue : '';
+
+  state.potentiometerValue = sanitizedValue;
+  syncPotentiometerValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function setPotentiometerTaperSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validPotentiometerTapers.has(desiredValue) ? desiredValue : '';
+  const previousValue =
+    typeof state.potentiometerTaper === 'string' ? state.potentiometerTaper : '';
+
+  state.potentiometerTaper = sanitizedValue;
+  syncPotentiometerTaperPicker({ isValid: true });
 
   if (triggerUpdate && previousValue !== sanitizedValue) {
     updateDownloadState();

--- a/js/render.js
+++ b/js/render.js
@@ -10,6 +10,8 @@ import {
   syncComponentMountPicker,
   syncResistorValuePicker,
   syncCapacitorValuePicker,
+  syncPotentiometerValuePicker,
+  syncPotentiometerTaperPicker,
   syncBearingTypePicker,
   syncWasherTypePicker,
   syncNutTypePicker,
@@ -103,6 +105,12 @@ const {
   capacitorValueField,
   capacitorValueSelect,
   capacitorValueMessage,
+  potentiometerValueField,
+  potentiometerValueSelect,
+  potentiometerValueMessage,
+  potentiometerTaperField,
+  potentiometerTaperSelect,
+  potentiometerTaperMessage,
   customLine1Input,
   customLine1Field,
   customLine1Message,
@@ -347,11 +355,20 @@ export function isLabelReady() {
     const category = state.componentCategory || state.hardwareType;
     const requiresResistorValue = category === 'Resistor';
     const requiresCapacitorValue = category === 'Capacitor';
+    const requiresPotentiometerDetails = category === 'Potentiometer';
     if (requiresResistorValue) {
       return Boolean(state.componentCategory && state.componentMount && state.resistorValue);
     }
     if (requiresCapacitorValue) {
       return Boolean(state.componentCategory && state.componentMount && state.capacitorValue);
+    }
+    if (requiresPotentiometerDetails) {
+      return Boolean(
+        state.componentCategory &&
+          state.componentMount &&
+          state.potentiometerValue &&
+          state.potentiometerTaper,
+      );
     }
     return Boolean(state.componentCategory && state.componentMount);
   }
@@ -642,8 +659,13 @@ function applyValidationFeedback() {
     const category = (state.componentCategory || state.hardwareType || '').trim();
     const requiresResistorValue = category === 'Resistor';
     const requiresCapacitorValue = category === 'Capacitor';
+    const requiresPotentiometerValue = category === 'Potentiometer';
     const resistorValid = !requiresResistorValue || Boolean(state.resistorValue);
     const capacitorValid = !requiresCapacitorValue || Boolean(state.capacitorValue);
+    const potentiometerValueValid =
+      !requiresPotentiometerValue || Boolean(state.potentiometerValue);
+    const potentiometerTaperValid =
+      !requiresPotentiometerValue || Boolean(state.potentiometerTaper);
     updateInputFieldState({
       input: resistorValueSelect,
       container: resistorValueField,
@@ -658,8 +680,24 @@ function applyValidationFeedback() {
       valid: capacitorValid,
       message: '',
     });
+    updateInputFieldState({
+      input: potentiometerValueSelect,
+      container: potentiometerValueField,
+      messageElement: potentiometerValueMessage,
+      valid: potentiometerValueValid,
+      message: potentiometerValueValid ? '' : 'Select a potentiometer value',
+    });
+    updateInputFieldState({
+      input: potentiometerTaperSelect,
+      container: potentiometerTaperField,
+      messageElement: potentiometerTaperMessage,
+      valid: potentiometerTaperValid,
+      message: potentiometerTaperValid ? '' : 'Select a taper',
+    });
     syncResistorValuePicker({ isValid: resistorValid });
     syncCapacitorValuePicker({ isValid: capacitorValid });
+    syncPotentiometerValuePicker({ isValid: potentiometerValueValid });
+    syncPotentiometerTaperPicker({ isValid: potentiometerTaperValid });
   } else {
     updateRadioGroupFeedback({
       radios: componentCategoryRadios,
@@ -691,6 +729,22 @@ function applyValidationFeedback() {
     });
     syncResistorValuePicker({ isValid: true });
     syncCapacitorValuePicker({ isValid: true });
+    updateInputFieldState({
+      input: potentiometerValueSelect,
+      container: potentiometerValueField,
+      messageElement: potentiometerValueMessage,
+      valid: true,
+      message: '',
+    });
+    updateInputFieldState({
+      input: potentiometerTaperSelect,
+      container: potentiometerTaperField,
+      messageElement: potentiometerTaperMessage,
+      valid: true,
+      message: '',
+    });
+    syncPotentiometerValuePicker({ isValid: true });
+    syncPotentiometerTaperPicker({ isValid: true });
   }
 
   if (hardwareType === 'Custom') {
@@ -1228,6 +1282,19 @@ function buildTextLines() {
     if (category === 'Capacitor') {
       const line1 = state.capacitorValue || 'Capacitor';
       const line2 = 'Capacitor';
+      const line3Parts = [];
+      if (state.componentMount) {
+        line3Parts.push(state.componentMount);
+      }
+      if (state.notes) {
+        line3Parts.push(state.notes);
+      }
+      return applyTextVisibility({ line1, line2, line3: line3Parts.join(' — ') });
+    }
+    if (category === 'Potentiometer') {
+      const line1 = state.potentiometerValue || 'Potentiometer';
+      const taperLabel = state.potentiometerTaper ? state.potentiometerTaper : '';
+      const line2 = taperLabel ? `${taperLabel} Potentiometer` : 'Potentiometer';
       const line3Parts = [];
       if (state.componentMount) {
         line3Parts.push(state.componentMount);

--- a/js/state.js
+++ b/js/state.js
@@ -29,6 +29,8 @@ export const state = {
   resistorValue: '',
   capacitorValue: '',
   diodeValue: '',
+  potentiometerValue: '',
+  potentiometerTaper: '',
   bearingType: '',
   bearingDetails: '',
   customLine1: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -15,6 +15,8 @@ import {
   resistorValueOptions,
   capacitorValueOptions,
   diodeValueOptions,
+  potentiometerValueOptions,
+  potentiometerTaperOptions,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -48,6 +50,8 @@ const FIELD_MAP = {
   resistorValue: 'rv',
   capacitorValue: 'cv',
   diodeValue: 'dv',
+  potentiometerValue: 'pv',
+  potentiometerTaper: 'pt',
   bearingType: 'bt',
   bearingDetails: 'bd',
   customLine1: 'c1',
@@ -80,6 +84,12 @@ const componentMountOptions = new Set(componentMountOptionList.map(option => opt
 const resistorValueOptionSet = new Set(resistorValueOptions.map(option => option.id));
 const capacitorValueOptionSet = new Set(capacitorValueOptions.map(option => option.id));
 const diodeValueOptionSet = new Set(diodeValueOptions.map(option => option.id));
+const potentiometerValueOptionSet = new Set(
+  potentiometerValueOptions.map(option => option.id),
+);
+const potentiometerTaperOptionSet = new Set(
+  potentiometerTaperOptions.map(option => option.id),
+);
 const heightOptions = new Set(
   Array.isArray(elements.heightRadios)
     ? elements.heightRadios
@@ -345,6 +355,18 @@ function applyExpandedPayload(expanded) {
   if (typeof expanded.diodeValue === 'string' && diodeValueOptionSet.has(expanded.diodeValue)) {
     state.diodeValue = expanded.diodeValue;
   }
+  if (
+    typeof expanded.potentiometerValue === 'string' &&
+    potentiometerValueOptionSet.has(expanded.potentiometerValue)
+  ) {
+    state.potentiometerValue = expanded.potentiometerValue;
+  }
+  if (
+    typeof expanded.potentiometerTaper === 'string' &&
+    potentiometerTaperOptionSet.has(expanded.potentiometerTaper)
+  ) {
+    state.potentiometerTaper = expanded.potentiometerTaper;
+  }
   if (typeof expanded.bearingType === 'string') {
     const trimmed = expanded.bearingType.trim();
     if (!trimmed) {
@@ -361,6 +383,8 @@ function applyExpandedPayload(expanded) {
     state.resistorValue = '';
     state.capacitorValue = '';
     state.diodeValue = '';
+    state.potentiometerValue = '';
+    state.potentiometerTaper = '';
   }
 
   const activeCategory = state.componentCategory || state.hardwareType || '';
@@ -372,6 +396,10 @@ function applyExpandedPayload(expanded) {
   }
   if (activeCategory !== 'Diode') {
     state.diodeValue = '';
+  }
+  if (activeCategory !== 'Potentiometer') {
+    state.potentiometerValue = '';
+    state.potentiometerTaper = '';
   }
 
   const sanitizedThread = sanitizeThreadSize(expanded.threadSize, state.hardwareType);


### PR DESCRIPTION
## Summary
- add the Potentiometer hardware option with dedicated value and taper controls in the form UI
- extend shared data, state management, events, rendering, and serialization logic to recognize Potentiometer selections and imagery
- update validation and previews so Potentiometer choices participate in readiness checks, chip icons, and share URLs

## Testing
- npm run lint *(fails: existing unused variable warning in js/label/layoutPresets.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e156f505f08329984108e06585c93b