### PR TITLE
Add MOSFET component support

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,9 @@
                         <option value="Diode" data-img="images/diodes/diode_through_hole.svg" data-cat="Electrical">
                           Diode
                         </option>
+                        <option value="MOSFET" data-img="images/mosfet/mosfet.svg" data-cat="Electrical">
+                          MOSFET
+                        </option>
                         <option
                           value="Potentiometer"
                           data-img="images/potentiometer/potentiometer.svg"
@@ -723,6 +726,100 @@
                       </div>
                       <div
                         id="diode-value-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div class="col-12 col-lg-6 d-none" id="mosfet-channel-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="mosfet-channel-picker-button"
+                        >MOSFET Channel Type</label
+                      >
+                      <div class="bolt-drive-picker" id="mosfet-channel-picker">
+                        <select
+                          id="mosfet-channel-select"
+                          class="visually-hidden"
+                          aria-labelledby="mosfet-channel-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="mosfet-channel-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="mosfet-channel-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="mosfet-channel-picker-list"
+                          role="listbox"
+                          aria-labelledby="mosfet-channel-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="mosfet-channel-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div class="col-12 col-lg-6 d-none" id="mosfet-part-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="mosfet-part-picker-button"
+                        >MOSFET Part Number</label
+                      >
+                      <div class="bolt-drive-picker" id="mosfet-part-picker">
+                        <select
+                          id="mosfet-part-select"
+                          class="visually-hidden"
+                          aria-labelledby="mosfet-part-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="mosfet-part-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="mosfet-part-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="mosfet-part-picker-list"
+                          role="listbox"
+                          aria-labelledby="mosfet-part-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="mosfet-part-message"
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>

--- a/js/controls.js
+++ b/js/controls.js
@@ -13,6 +13,8 @@ import {
   populateResistorValues,
   populateCapacitorValues,
   populateDiodeValues,
+  populateMosfetChannels,
+  populateMosfetParts,
   populatePotentiometerValues,
   populatePotentiometerTapers,
   populateWasherTypeOptions,
@@ -34,6 +36,8 @@ import {
   setResistorValueSelection,
   setCapacitorValueSelection,
   setDiodeValueSelection,
+  setMosfetChannelSelection,
+  setMosfetPartSelection,
   setPotentiometerValueSelection,
   setPotentiometerTaperSelection,
   syncConnectorSeriesPicker,
@@ -104,6 +108,8 @@ function applyStateToControls() {
   setResistorValueSelection(state.resistorValue || '', { triggerUpdate: false });
   setCapacitorValueSelection(state.capacitorValue || '', { triggerUpdate: false });
   setDiodeValueSelection(state.diodeValue || '', { triggerUpdate: false });
+  setMosfetChannelSelection(state.mosfetChannel || '', { triggerUpdate: false });
+  setMosfetPartSelection(state.mosfetPart || '', { triggerUpdate: false });
   setPotentiometerValueSelection(state.potentiometerValue || '', { triggerUpdate: false });
   setPotentiometerTaperSelection(state.potentiometerTaper || '', { triggerUpdate: false });
   updateComponentValueUi({ resetIfHidden: false });
@@ -179,6 +185,8 @@ function init() {
   populateResistorValues();
   populateCapacitorValues();
   populateDiodeValues();
+  populateMosfetChannels();
+  populateMosfetParts();
   populatePotentiometerValues();
   populatePotentiometerTapers();
   populateWasherTypeOptions();

--- a/js/data.js
+++ b/js/data.js
@@ -102,7 +102,13 @@ export const switchTypeImageMap = new Map(
   switchTypeOptions.map(option => [option.id, option.image]),
 );
 
-export const electricalComponentTypes = ['Resistor', 'Capacitor', 'Diode', 'Potentiometer'];
+export const electricalComponentTypes = [
+  'Resistor',
+  'Capacitor',
+  'Diode',
+  'Potentiometer',
+  'MOSFET',
+];
 
 export const componentImageMap = {
   Resistor: {
@@ -124,6 +130,11 @@ export const componentImageMap = {
     'Through-Hole': 'images/potentiometer/potentiometer.svg',
     SMD: 'images/potentiometer/potentiometer.svg',
     default: 'images/potentiometer/potentiometer.svg',
+  },
+  MOSFET: {
+    'Through-Hole': 'images/mosfet/mosfet.svg',
+    SMD: 'images/mosfet/mosfet.svg',
+    default: 'images/mosfet/mosfet.svg',
   },
 };
 
@@ -291,6 +302,51 @@ export const diodeValueLabelMap = diodeValueOptions.reduce((map, option) => {
   return map;
 }, {});
 
+export const mosfetChannelOptions = [
+  {
+    id: 'N-Channel Logic-Level',
+    label: 'N-Channel Logic-Level',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  {
+    id: 'N-Channel Power',
+    label: 'N-Channel Power',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  {
+    id: 'P-Channel',
+    label: 'P-Channel',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  {
+    id: 'Dual MOSFET',
+    label: 'Dual MOSFET',
+    image: 'images/mosfet/mosfet.svg',
+  },
+];
+
+export const mosfetPartOptions = [
+  {
+    id: 'IRLZ44N',
+    label: 'IRLZ44N Logic-Level MOSFET',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  { id: 'AO3400A', label: 'AO3400A MOSFET', image: 'images/mosfet/mosfet.svg' },
+  { id: 'BS170', label: 'BS170 MOSFET', image: 'images/mosfet/mosfet.svg' },
+  { id: 'IRF520', label: 'IRF520 MOSFET', image: 'images/mosfet/mosfet.svg' },
+  { id: 'FQP30N06L', label: 'FQP30N06L MOSFET', image: 'images/mosfet/mosfet.svg' },
+];
+
+export const mosfetChannelLabelMap = mosfetChannelOptions.reduce((map, option) => {
+  map[option.id] = option.label;
+  return map;
+}, {});
+
+export const mosfetPartLabelMap = mosfetPartOptions.reduce((map, option) => {
+  map[option.id] = option.label;
+  return map;
+}, {});
+
 export const boltHeadOptions = [
   { id: 'button_head', label: 'Button Head', image: 'button_head' },
   { id: 'cap_head', label: 'Socket Cap', image: 'cap_head' },
@@ -433,6 +489,11 @@ export const hardwareCatalog = {
     { code: 'Panel-Mount Log', name: 'Panel-Mount Logarithmic Potentiometer' },
     { code: 'Trimmer', name: 'Multi-turn Trimmer Potentiometer' },
   ],
+  MOSFET: [
+    { code: 'Logic-Level N-Channel', name: 'N-Channel Logic-Level MOSFET' },
+    { code: 'Power N-Channel', name: 'N-Channel Power MOSFET' },
+    { code: 'P-Channel', name: 'P-Channel MOSFET' },
+  ],
   Switch: [],
   Fuse: [
     { code: 'IEC 60127-2', name: 'Time-Lag Cartridge Fuse' },
@@ -467,6 +528,7 @@ export const hardwareTypeImageMap = {
   Washer: 'images/washers/plain_washer.svg',
   Diode: 'images/diodes/diode_through_hole.svg',
   Potentiometer: 'images/potentiometer/potentiometer.svg',
+  MOSFET: 'images/mosfet/mosfet.svg',
 };
 
 export const PRE_INSULATED_CRIMP_CATEGORY_ID = 'pre-insulated-crimp';

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -88,6 +88,18 @@ const diodeValuePickerButton = document.getElementById('diode-value-picker-butto
 const diodeValuePickerList = document.getElementById('diode-value-picker-list');
 const diodeValueSelect = document.getElementById('diode-value-select');
 const diodeValueMessage = document.getElementById('diode-value-message');
+const mosfetChannelField = document.getElementById('mosfet-channel-field');
+const mosfetChannelPicker = document.getElementById('mosfet-channel-picker');
+const mosfetChannelPickerButton = document.getElementById('mosfet-channel-picker-button');
+const mosfetChannelPickerList = document.getElementById('mosfet-channel-picker-list');
+const mosfetChannelSelect = document.getElementById('mosfet-channel-select');
+const mosfetChannelMessage = document.getElementById('mosfet-channel-message');
+const mosfetPartField = document.getElementById('mosfet-part-field');
+const mosfetPartPicker = document.getElementById('mosfet-part-picker');
+const mosfetPartPickerButton = document.getElementById('mosfet-part-picker-button');
+const mosfetPartPickerList = document.getElementById('mosfet-part-picker-list');
+const mosfetPartSelect = document.getElementById('mosfet-part-select');
+const mosfetPartMessage = document.getElementById('mosfet-part-message');
 const potentiometerValueField = document.getElementById('potentiometer-value-field');
 const potentiometerValuePicker = document.getElementById('potentiometer-value-picker');
 const potentiometerValuePickerButton = document.getElementById('potentiometer-value-picker-button');
@@ -294,6 +306,18 @@ export const elements = {
   diodeValuePickerList,
   diodeValueSelect,
   diodeValueMessage,
+  mosfetChannelField,
+  mosfetChannelPicker,
+  mosfetChannelPickerButton,
+  mosfetChannelPickerList,
+  mosfetChannelSelect,
+  mosfetChannelMessage,
+  mosfetPartField,
+  mosfetPartPicker,
+  mosfetPartPickerButton,
+  mosfetPartPickerList,
+  mosfetPartSelect,
+  mosfetPartMessage,
   potentiometerValueField,
   potentiometerValuePicker,
   potentiometerValuePickerButton,

--- a/js/events.js
+++ b/js/events.js
@@ -39,6 +39,8 @@ import {
   setResistorValueSelection,
   setCapacitorValueSelection,
   setDiodeValueSelection,
+  setMosfetChannelSelection,
+  setMosfetPartSelection,
   setPotentiometerValueSelection,
   setPotentiometerTaperSelection,
   updateComponentValueUi,
@@ -85,6 +87,14 @@ const {
   diodeValuePicker,
   diodeValuePickerButton,
   diodeValuePickerList,
+  mosfetChannelSelect,
+  mosfetChannelPicker,
+  mosfetChannelPickerButton,
+  mosfetChannelPickerList,
+  mosfetPartSelect,
+  mosfetPartPicker,
+  mosfetPartPickerButton,
+  mosfetPartPickerList,
   potentiometerValueSelect,
   potentiometerValuePicker,
   potentiometerValuePickerButton,
@@ -186,6 +196,8 @@ let componentMountPickerOpen = false;
 let resistorValuePickerOpen = false;
 let capacitorValuePickerOpen = false;
 let diodeValuePickerOpen = false;
+let mosfetChannelPickerOpen = false;
+let mosfetPartPickerOpen = false;
 let potentiometerValuePickerOpen = false;
 let potentiometerTaperPickerOpen = false;
 let bearingTypePickerOpen = false;
@@ -2287,6 +2299,424 @@ function handleDiodeValueListFocusOut() {
     const active = document.activeElement;
     if (!active || !diodeValuePicker.contains(active)) {
       closeDiodeValuePicker();
+    }
+  }, 0);
+}
+
+function getMosfetChannelOptionElements() {
+  if (!mosfetChannelPickerList) {
+    return [];
+  }
+  return Array.from(mosfetChannelPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusMosfetChannelOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getMosfetChannelOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openMosfetChannelPicker() {
+  if (!mosfetChannelPicker || !mosfetChannelPickerButton || !mosfetChannelPickerList) {
+    return;
+  }
+  if (mosfetChannelPickerButton.disabled) {
+    return;
+  }
+  if (mosfetChannelPickerOpen) {
+    return;
+  }
+  mosfetChannelPickerOpen = true;
+  mosfetChannelPicker.classList.add('is-open');
+  mosfetChannelPickerList.hidden = false;
+  mosfetChannelPickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getMosfetChannelOptionElements();
+  const currentValue = typeof state.mosfetChannel === 'string' ? state.mosfetChannel : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusMosfetChannelOption(selectedOption || options[0]);
+}
+
+function closeMosfetChannelPicker({ focusButton = false } = {}) {
+  if (!mosfetChannelPicker || !mosfetChannelPickerButton || !mosfetChannelPickerList) {
+    return;
+  }
+  if (!mosfetChannelPickerOpen) {
+    if (focusButton && !mosfetChannelPickerButton.disabled) {
+      mosfetChannelPickerButton.focus();
+    }
+    return;
+  }
+  mosfetChannelPickerOpen = false;
+  mosfetChannelPicker.classList.remove('is-open');
+  mosfetChannelPickerList.hidden = true;
+  mosfetChannelPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !mosfetChannelPickerButton.disabled) {
+    mosfetChannelPickerButton.focus();
+  }
+}
+
+function toggleMosfetChannelPicker() {
+  if (mosfetChannelPickerOpen) {
+    closeMosfetChannelPicker({ focusButton: false });
+  } else {
+    openMosfetChannelPicker();
+  }
+}
+
+function moveMosfetChannelOption(delta) {
+  if (!mosfetChannelPickerList) {
+    return;
+  }
+  const options = getMosfetChannelOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && mosfetChannelPickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.mosfetChannel === 'string' ? state.mosfetChannel : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusMosfetChannelOption(nextOption);
+  }
+}
+
+function handleMosfetChannelButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openMosfetChannelPicker();
+    moveMosfetChannelOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openMosfetChannelPicker();
+    moveMosfetChannelOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleMosfetChannelPicker();
+    return;
+  }
+  if (key === 'Escape' && mosfetChannelPickerOpen) {
+    event.preventDefault();
+    closeMosfetChannelPicker({ focusButton: true });
+  }
+}
+
+function handleMosfetChannelListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveMosfetChannelOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveMosfetChannelOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getMosfetChannelOptionElements();
+    if (options.length > 0) {
+      focusMosfetChannelOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getMosfetChannelOptionElements();
+    if (options.length > 0) {
+      focusMosfetChannelOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setMosfetChannelSelection(option.dataset.value || '');
+        closeMosfetChannelPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeMosfetChannelPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeMosfetChannelPicker();
+  }
+}
+
+function handleMosfetChannelListClick(event) {
+  if (!mosfetChannelPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !mosfetChannelPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setMosfetChannelSelection(option.dataset.value || '');
+  closeMosfetChannelPicker({ focusButton: true });
+}
+
+function handleMosfetChannelListFocusOut() {
+  if (!mosfetChannelPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!mosfetChannelPickerOpen) {
+      return;
+    }
+    if (!mosfetChannelPicker) {
+      closeMosfetChannelPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !mosfetChannelPicker.contains(active)) {
+      closeMosfetChannelPicker();
+    }
+  }, 0);
+}
+
+function getMosfetPartOptionElements() {
+  if (!mosfetPartPickerList) {
+    return [];
+  }
+  return Array.from(mosfetPartPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusMosfetPartOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getMosfetPartOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openMosfetPartPicker() {
+  if (!mosfetPartPicker || !mosfetPartPickerButton || !mosfetPartPickerList) {
+    return;
+  }
+  if (mosfetPartPickerButton.disabled) {
+    return;
+  }
+  if (mosfetPartPickerOpen) {
+    return;
+  }
+  mosfetPartPickerOpen = true;
+  mosfetPartPicker.classList.add('is-open');
+  mosfetPartPickerList.hidden = false;
+  mosfetPartPickerButton.setAttribute('aria-expanded', 'true');
+
+  const options = getMosfetPartOptionElements();
+  const currentValue = typeof state.mosfetPart === 'string' ? state.mosfetPart : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusMosfetPartOption(selectedOption || options[0]);
+}
+
+function closeMosfetPartPicker({ focusButton = false } = {}) {
+  if (!mosfetPartPicker || !mosfetPartPickerButton || !mosfetPartPickerList) {
+    return;
+  }
+  if (!mosfetPartPickerOpen) {
+    if (focusButton && !mosfetPartPickerButton.disabled) {
+      mosfetPartPickerButton.focus();
+    }
+    return;
+  }
+  mosfetPartPickerOpen = false;
+  mosfetPartPicker.classList.remove('is-open');
+  mosfetPartPickerList.hidden = true;
+  mosfetPartPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !mosfetPartPickerButton.disabled) {
+    mosfetPartPickerButton.focus();
+  }
+}
+
+function toggleMosfetPartPicker() {
+  if (mosfetPartPickerOpen) {
+    closeMosfetPartPicker({ focusButton: false });
+  } else {
+    openMosfetPartPicker();
+  }
+}
+
+function moveMosfetPartOption(delta) {
+  if (!mosfetPartPickerList) {
+    return;
+  }
+  const options = getMosfetPartOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && mosfetPartPickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.mosfetPart === 'string' ? state.mosfetPart : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusMosfetPartOption(nextOption);
+  }
+}
+
+function handleMosfetPartButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openMosfetPartPicker();
+    moveMosfetPartOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openMosfetPartPicker();
+    moveMosfetPartOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleMosfetPartPicker();
+    return;
+  }
+  if (key === 'Escape' && mosfetPartPickerOpen) {
+    event.preventDefault();
+    closeMosfetPartPicker({ focusButton: true });
+  }
+}
+
+function handleMosfetPartListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveMosfetPartOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveMosfetPartOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getMosfetPartOptionElements();
+    if (options.length > 0) {
+      focusMosfetPartOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getMosfetPartOptionElements();
+    if (options.length > 0) {
+      focusMosfetPartOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setMosfetPartSelection(option.dataset.value || '');
+        closeMosfetPartPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeMosfetPartPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeMosfetPartPicker();
+  }
+}
+
+function handleMosfetPartListClick(event) {
+  if (!mosfetPartPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !mosfetPartPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setMosfetPartSelection(option.dataset.value || '');
+  closeMosfetPartPicker({ focusButton: true });
+}
+
+function handleMosfetPartListFocusOut() {
+  if (!mosfetPartPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!mosfetPartPickerOpen) {
+      return;
+    }
+    if (!mosfetPartPicker) {
+      closeMosfetPartPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !mosfetPartPicker.contains(active)) {
+      closeMosfetPartPicker();
     }
   }, 0);
 }
@@ -4472,6 +4902,26 @@ function handleDocumentPointer(event) {
       closeDiodeValuePicker();
     }
   }
+  if (mosfetChannelPickerOpen && mosfetChannelPicker) {
+    if (!(target instanceof Node) || !mosfetChannelPicker.contains(target)) {
+      closeMosfetChannelPicker();
+    }
+  }
+  if (mosfetPartPickerOpen && mosfetPartPicker) {
+    if (!(target instanceof Node) || !mosfetPartPicker.contains(target)) {
+      closeMosfetPartPicker();
+    }
+  }
+  if (mosfetChannelPickerOpen && mosfetChannelPicker) {
+    if (!(target instanceof Node) || !mosfetChannelPicker.contains(target)) {
+      closeMosfetChannelPicker();
+    }
+  }
+  if (mosfetPartPickerOpen && mosfetPartPicker) {
+    if (!(target instanceof Node) || !mosfetPartPicker.contains(target)) {
+      closeMosfetPartPicker();
+    }
+  }
   if (bearingTypePickerOpen && bearingTypePicker) {
     if (!(target instanceof Node) || !bearingTypePicker.contains(target)) {
       closeBearingTypePicker();
@@ -4724,6 +5174,40 @@ export function initEventHandlers() {
     diodeValuePickerList.addEventListener('click', handleDiodeValueListClick);
     diodeValuePickerList.addEventListener('keydown', handleDiodeValueListKeydown);
     diodeValuePickerList.addEventListener('focusout', handleDiodeValueListFocusOut);
+  }
+
+  if (mosfetChannelSelect) {
+    mosfetChannelSelect.addEventListener('change', () => {
+      setMosfetChannelSelection(mosfetChannelSelect.value);
+    });
+  }
+
+  if (mosfetChannelPickerButton && mosfetChannelPickerList) {
+    mosfetChannelPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleMosfetChannelPicker();
+    });
+    mosfetChannelPickerButton.addEventListener('keydown', handleMosfetChannelButtonKeydown);
+    mosfetChannelPickerList.addEventListener('click', handleMosfetChannelListClick);
+    mosfetChannelPickerList.addEventListener('keydown', handleMosfetChannelListKeydown);
+    mosfetChannelPickerList.addEventListener('focusout', handleMosfetChannelListFocusOut);
+  }
+
+  if (mosfetPartSelect) {
+    mosfetPartSelect.addEventListener('change', () => {
+      setMosfetPartSelection(mosfetPartSelect.value);
+    });
+  }
+
+  if (mosfetPartPickerButton && mosfetPartPickerList) {
+    mosfetPartPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleMosfetPartPicker();
+    });
+    mosfetPartPickerButton.addEventListener('keydown', handleMosfetPartButtonKeydown);
+    mosfetPartPickerList.addEventListener('click', handleMosfetPartListClick);
+    mosfetPartPickerList.addEventListener('keydown', handleMosfetPartListKeydown);
+    mosfetPartPickerList.addEventListener('focusout', handleMosfetPartListFocusOut);
   }
 
   if (capacitorValueSelect) {
@@ -5113,6 +5597,8 @@ export function initEventHandlers() {
     resistorValuePicker ||
     capacitorValuePicker ||
     diodeValuePicker ||
+    mosfetChannelPicker ||
+    mosfetPartPicker ||
     potentiometerValuePicker ||
     potentiometerTaperPicker ||
     bearingTypePicker ||
@@ -5138,6 +5624,8 @@ export function initEventHandlers() {
     closeResistorValuePicker();
     closeCapacitorValuePicker();
     closeDiodeValuePicker();
+    closeMosfetChannelPicker();
+    closeMosfetPartPicker();
     closePotentiometerValuePicker();
     closePotentiometerTaperPicker();
   });

--- a/js/forms.js
+++ b/js/forms.js
@@ -22,6 +22,8 @@ import {
   resistorValueOptions,
   capacitorValueOptions,
   diodeValueOptions,
+  mosfetChannelOptions,
+  mosfetPartOptions,
   potentiometerValueOptions,
   potentiometerTaperOptions,
   connectorCategoryImageMap,
@@ -107,6 +109,16 @@ const {
   diodeValuePickerButton,
   diodeValuePickerList,
   diodeValueSelect,
+  mosfetChannelField,
+  mosfetChannelPicker,
+  mosfetChannelPickerButton,
+  mosfetChannelPickerList,
+  mosfetChannelSelect,
+  mosfetPartField,
+  mosfetPartPicker,
+  mosfetPartPickerButton,
+  mosfetPartPickerList,
+  mosfetPartSelect,
   potentiometerValueField,
   potentiometerValuePicker,
   potentiometerValuePickerButton,
@@ -238,6 +250,10 @@ const CAPACITOR_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validCapacitorValues = new Set(capacitorValueOptions.map(option => option.id));
 const DIODE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validDiodeValues = new Set(diodeValueOptions.map(option => option.id));
+const MOSFET_CHANNEL_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validMosfetChannels = new Set(mosfetChannelOptions.map(option => option.id));
+const MOSFET_PART_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const validMosfetParts = new Set(mosfetPartOptions.map(option => option.id));
 const POTENTIOMETER_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validPotentiometerValues = new Set(
   potentiometerValueOptions.map(option => option.id),
@@ -955,6 +971,8 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
   const showResistorValues = showComponentFields && category === 'Resistor';
   const showCapacitorValues = showComponentFields && category === 'Capacitor';
   const showDiodeValues = showComponentFields && category === 'Diode';
+  const showMosfetChannels = showComponentFields && category === 'MOSFET';
+  const showMosfetParts = showMosfetChannels;
   const showPotentiometerValues = showComponentFields && category === 'Potentiometer';
   const showPotentiometerTaper = showPotentiometerValues;
 
@@ -1069,6 +1087,80 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
 
   if (!showDiodeValues && resetIfHidden) {
     state.diodeValue = '';
+  }
+
+  if (mosfetChannelField) {
+    mosfetChannelField.classList.toggle('d-none', !showMosfetChannels);
+    mosfetChannelField.setAttribute('aria-hidden', showMosfetChannels ? 'false' : 'true');
+  }
+
+  if (mosfetChannelSelect) {
+    mosfetChannelSelect.disabled = !showMosfetChannels;
+  }
+
+  if (mosfetChannelPickerButton) {
+    mosfetChannelPickerButton.disabled = !showMosfetChannels;
+    const isOpen = Boolean(
+      showMosfetChannels &&
+        mosfetChannelPicker &&
+        mosfetChannelPicker.classList.contains('is-open'),
+    );
+    mosfetChannelPickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (mosfetChannelPickerList) {
+    const shouldHideList =
+      !showMosfetChannels ||
+      !mosfetChannelPicker ||
+      !mosfetChannelPicker.classList.contains('is-open');
+    mosfetChannelPickerList.hidden = shouldHideList;
+  }
+
+  if (mosfetChannelPicker) {
+    if (!showMosfetChannels) {
+      mosfetChannelPicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    mosfetChannelPicker.classList.toggle('is-disabled', !showMosfetChannels);
+  }
+
+  if (!showMosfetChannels && resetIfHidden) {
+    state.mosfetChannel = '';
+  }
+
+  if (mosfetPartField) {
+    mosfetPartField.classList.toggle('d-none', !showMosfetParts);
+    mosfetPartField.setAttribute('aria-hidden', showMosfetParts ? 'false' : 'true');
+  }
+
+  if (mosfetPartSelect) {
+    mosfetPartSelect.disabled = !showMosfetParts;
+  }
+
+  if (mosfetPartPickerButton) {
+    mosfetPartPickerButton.disabled = !showMosfetParts;
+    const isOpen = Boolean(
+      showMosfetParts && mosfetPartPicker && mosfetPartPicker.classList.contains('is-open'),
+    );
+    mosfetPartPickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  if (mosfetPartPickerList) {
+    const shouldHideList =
+      !showMosfetParts || !mosfetPartPicker || !mosfetPartPicker.classList.contains('is-open');
+    mosfetPartPickerList.hidden = shouldHideList;
+  }
+
+  if (mosfetPartPicker) {
+    if (!showMosfetParts) {
+      mosfetPartPicker.classList.remove('is-open');
+      document.dispatchEvent(new CustomEvent('gridfinity:component-picker-close'));
+    }
+    mosfetPartPicker.classList.toggle('is-disabled', !showMosfetParts);
+  }
+
+  if (!showMosfetParts && resetIfHidden) {
+    state.mosfetPart = '';
   }
 
   if (potentiometerValueField) {
@@ -1334,6 +1426,145 @@ export function populateDiodeValues() {
   updateComponentValueUi({ resetIfHidden: false });
 }
 
+export function populateMosfetChannels() {
+  if (!mosfetChannelSelect) {
+    return;
+  }
+
+  const previousValue =
+    typeof state.mosfetChannel === 'string' ? state.mosfetChannel : '';
+
+  mosfetChannelSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = MOSFET_CHANNEL_PLACEHOLDER_TEXT;
+  mosfetChannelSelect.appendChild(placeholder);
+
+  mosfetChannelOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    mosfetChannelSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validMosfetChannels.has(previousValue) ? previousValue : '';
+  state.mosfetChannel = sanitizedValue;
+  mosfetChannelSelect.value = sanitizedValue;
+
+  if (mosfetChannelPickerList) {
+    mosfetChannelPickerList.innerHTML = '';
+    mosfetChannelOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      const imageSrc = option.image || '';
+      if (imageSrc) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = imageSrc;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      mosfetChannelPickerList.appendChild(item);
+    });
+    mosfetChannelPickerList.hidden = true;
+  }
+
+  if (mosfetChannelPickerButton) {
+    mosfetChannelPickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncMosfetChannelPicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
+export function populateMosfetParts() {
+  if (!mosfetPartSelect) {
+    return;
+  }
+
+  const previousValue = typeof state.mosfetPart === 'string' ? state.mosfetPart : '';
+
+  mosfetPartSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = MOSFET_PART_PLACEHOLDER_TEXT;
+  mosfetPartSelect.appendChild(placeholder);
+
+  mosfetPartOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    mosfetPartSelect.appendChild(opt);
+  });
+
+  const sanitizedValue = validMosfetParts.has(previousValue) ? previousValue : '';
+  state.mosfetPart = sanitizedValue;
+  mosfetPartSelect.value = sanitizedValue;
+
+  if (mosfetPartPickerList) {
+    mosfetPartPickerList.innerHTML = '';
+    mosfetPartOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      const imageSrc = option.image || '';
+      if (imageSrc) {
+        const image = document.createElement('img');
+        image.className = 'bolt-drive-picker__option-icon-image';
+        image.src = imageSrc;
+        image.alt = '';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        icon.appendChild(image);
+      } else {
+        icon.classList.add('is-empty');
+      }
+      item.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
+
+      mosfetPartPickerList.appendChild(item);
+    });
+    mosfetPartPickerList.hidden = true;
+  }
+
+  if (mosfetPartPickerButton) {
+    mosfetPartPickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncMosfetPartPicker({ isValid: true });
+  updateComponentValueUi({ resetIfHidden: false });
+}
+
 export function syncCapacitorValuePicker({ isValid = true } = {}) {
   if (!capacitorValueSelect) {
     return;
@@ -1451,6 +1682,192 @@ export function setDiodeValueSelection(nextValue, { triggerUpdate = true } = {})
 
   state.diodeValue = sanitizedValue;
   syncDiodeValuePicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function syncMosfetChannelPicker({ isValid = true } = {}) {
+  if (!mosfetChannelSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.mosfetChannel === 'string' ? state.mosfetChannel : '';
+  const sanitizedValue = validMosfetChannels.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.mosfetChannel = sanitizedValue;
+  }
+
+  mosfetChannelSelect.value = sanitizedValue;
+  if (!sanitizedValue && mosfetChannelSelect.options.length > 0) {
+    mosfetChannelSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = mosfetChannelOptions.find(option => option.id === sanitizedValue);
+  const imageSrc = selectedOption && selectedOption.image ? selectedOption.image : '';
+
+  if (mosfetChannelPickerButton) {
+    const label = mosfetChannelPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = mosfetChannelPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    let iconImage = iconWrapper
+      ? iconWrapper.querySelector('.bolt-drive-picker__current-icon-image')
+      : null;
+
+    if (label) {
+      label.textContent = sanitizedValue
+        ? selectedOption?.label || sanitizedValue
+        : MOSFET_CHANNEL_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper) {
+      if (imageSrc) {
+        if (!iconImage) {
+          iconImage = document.createElement('img');
+          iconImage.className = 'bolt-drive-picker__current-icon-image';
+          iconImage.alt = '';
+          iconImage.loading = 'lazy';
+          iconImage.decoding = 'async';
+          iconWrapper.appendChild(iconImage);
+        }
+        iconWrapper.classList.remove('is-empty');
+        iconImage.src = imageSrc;
+        iconImage.hidden = false;
+      } else {
+        if (iconImage) {
+          iconImage.hidden = true;
+          iconImage.removeAttribute('src');
+        }
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      mosfetChannelPickerButton.classList.remove('is-invalid');
+      mosfetChannelPickerButton.removeAttribute('aria-invalid');
+    } else {
+      mosfetChannelPickerButton.classList.add('is-invalid');
+      mosfetChannelPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (mosfetChannelPicker) {
+    mosfetChannelPicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (mosfetChannelPickerList) {
+    const optionElements = Array.from(
+      mosfetChannelPickerList.querySelectorAll('[role="option"]'),
+    );
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setMosfetChannelSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validMosfetChannels.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.mosfetChannel === 'string' ? state.mosfetChannel : '';
+
+  state.mosfetChannel = sanitizedValue;
+  syncMosfetChannelPicker({ isValid: true });
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updateDownloadState();
+    updatePreview();
+  }
+}
+
+export function syncMosfetPartPicker({ isValid = true } = {}) {
+  if (!mosfetPartSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.mosfetPart === 'string' ? state.mosfetPart : '';
+  const sanitizedValue = validMosfetParts.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.mosfetPart = sanitizedValue;
+  }
+
+  mosfetPartSelect.value = sanitizedValue;
+  if (!sanitizedValue && mosfetPartSelect.options.length > 0) {
+    mosfetPartSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = mosfetPartOptions.find(option => option.id === sanitizedValue);
+  const imageSrc = selectedOption && selectedOption.image ? selectedOption.image : '';
+
+  if (mosfetPartPickerButton) {
+    const label = mosfetPartPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = mosfetPartPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    let iconImage = iconWrapper
+      ? iconWrapper.querySelector('.bolt-drive-picker__current-icon-image')
+      : null;
+
+    if (label) {
+      label.textContent = sanitizedValue
+        ? selectedOption?.label || sanitizedValue
+        : MOSFET_PART_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper) {
+      if (imageSrc) {
+        if (!iconImage) {
+          iconImage = document.createElement('img');
+          iconImage.className = 'bolt-drive-picker__current-icon-image';
+          iconImage.alt = '';
+          iconImage.loading = 'lazy';
+          iconImage.decoding = 'async';
+          iconWrapper.appendChild(iconImage);
+        }
+        iconWrapper.classList.remove('is-empty');
+        iconImage.src = imageSrc;
+        iconImage.hidden = false;
+      } else {
+        if (iconImage) {
+          iconImage.hidden = true;
+          iconImage.removeAttribute('src');
+        }
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      mosfetPartPickerButton.classList.remove('is-invalid');
+      mosfetPartPickerButton.removeAttribute('aria-invalid');
+    } else {
+      mosfetPartPickerButton.classList.add('is-invalid');
+      mosfetPartPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (mosfetPartPicker) {
+    mosfetPartPicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (mosfetPartPickerList) {
+    const optionElements = Array.from(mosfetPartPickerList.querySelectorAll('[role="option"]'));
+    optionElements.forEach(optionElement => {
+      const isSelected = optionElement.dataset.value === sanitizedValue;
+      optionElement.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      optionElement.classList.toggle('is-selected', isSelected);
+      optionElement.tabIndex = -1;
+    });
+  }
+}
+
+export function setMosfetPartSelection(nextValue, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextValue === 'string' ? nextValue.trim() : '';
+  const sanitizedValue = validMosfetParts.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.mosfetPart === 'string' ? state.mosfetPart : '';
+
+  state.mosfetPart = sanitizedValue;
+  syncMosfetPartPicker({ isValid: true });
 
   if (triggerUpdate && previousValue !== sanitizedValue) {
     updateDownloadState();

--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -282,7 +282,8 @@ function extractBaseOverride(entry) {
   if (!entry || typeof entry !== 'object') {
     return null;
   }
-  const { [PARTS_KEY]: _, ...base } = entry;
+  const base = { ...entry };
+  delete base[PARTS_KEY];
   return Object.keys(base).length > 0 ? base : null;
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -10,6 +10,8 @@ import {
   syncComponentMountPicker,
   syncResistorValuePicker,
   syncCapacitorValuePicker,
+  syncMosfetChannelPicker,
+  syncMosfetPartPicker,
   syncPotentiometerValuePicker,
   syncPotentiometerTaperPicker,
   syncBearingTypePicker,
@@ -35,6 +37,8 @@ import {
   electricalComponentTypes,
   componentImageMap,
   diodeValueLabelMap,
+  mosfetChannelLabelMap,
+  mosfetPartLabelMap,
 } from './data.js';
 import {
   renderLabelSVG,
@@ -105,6 +109,12 @@ const {
   capacitorValueField,
   capacitorValueSelect,
   capacitorValueMessage,
+  mosfetChannelField,
+  mosfetChannelSelect,
+  mosfetChannelMessage,
+  mosfetPartField,
+  mosfetPartSelect,
+  mosfetPartMessage,
   potentiometerValueField,
   potentiometerValueSelect,
   potentiometerValueMessage,
@@ -356,11 +366,20 @@ export function isLabelReady() {
     const requiresResistorValue = category === 'Resistor';
     const requiresCapacitorValue = category === 'Capacitor';
     const requiresPotentiometerDetails = category === 'Potentiometer';
+    const requiresMosfetDetails = category === 'MOSFET';
     if (requiresResistorValue) {
       return Boolean(state.componentCategory && state.componentMount && state.resistorValue);
     }
     if (requiresCapacitorValue) {
       return Boolean(state.componentCategory && state.componentMount && state.capacitorValue);
+    }
+    if (requiresMosfetDetails) {
+      return Boolean(
+        state.componentCategory &&
+          state.componentMount &&
+          state.mosfetChannel &&
+          state.mosfetPart,
+      );
     }
     if (requiresPotentiometerDetails) {
       return Boolean(
@@ -659,9 +678,12 @@ function applyValidationFeedback() {
     const category = (state.componentCategory || state.hardwareType || '').trim();
     const requiresResistorValue = category === 'Resistor';
     const requiresCapacitorValue = category === 'Capacitor';
+    const requiresMosfetDetails = category === 'MOSFET';
     const requiresPotentiometerValue = category === 'Potentiometer';
     const resistorValid = !requiresResistorValue || Boolean(state.resistorValue);
     const capacitorValid = !requiresCapacitorValue || Boolean(state.capacitorValue);
+    const mosfetChannelValid = !requiresMosfetDetails || Boolean(state.mosfetChannel);
+    const mosfetPartValid = !requiresMosfetDetails || Boolean(state.mosfetPart);
     const potentiometerValueValid =
       !requiresPotentiometerValue || Boolean(state.potentiometerValue);
     const potentiometerTaperValid =
@@ -681,6 +703,20 @@ function applyValidationFeedback() {
       message: '',
     });
     updateInputFieldState({
+      input: mosfetChannelSelect,
+      container: mosfetChannelField,
+      messageElement: mosfetChannelMessage,
+      valid: mosfetChannelValid,
+      message: mosfetChannelValid ? '' : 'Select a channel type',
+    });
+    updateInputFieldState({
+      input: mosfetPartSelect,
+      container: mosfetPartField,
+      messageElement: mosfetPartMessage,
+      valid: mosfetPartValid,
+      message: mosfetPartValid ? '' : 'Choose a MOSFET part number',
+    });
+    updateInputFieldState({
       input: potentiometerValueSelect,
       container: potentiometerValueField,
       messageElement: potentiometerValueMessage,
@@ -696,6 +732,8 @@ function applyValidationFeedback() {
     });
     syncResistorValuePicker({ isValid: resistorValid });
     syncCapacitorValuePicker({ isValid: capacitorValid });
+    syncMosfetChannelPicker({ isValid: mosfetChannelValid });
+    syncMosfetPartPicker({ isValid: mosfetPartValid });
     syncPotentiometerValuePicker({ isValid: potentiometerValueValid });
     syncPotentiometerTaperPicker({ isValid: potentiometerTaperValid });
   } else {
@@ -727,8 +765,24 @@ function applyValidationFeedback() {
       valid: true,
       message: '',
     });
+    updateInputFieldState({
+      input: mosfetChannelSelect,
+      container: mosfetChannelField,
+      messageElement: mosfetChannelMessage,
+      valid: true,
+      message: '',
+    });
+    updateInputFieldState({
+      input: mosfetPartSelect,
+      container: mosfetPartField,
+      messageElement: mosfetPartMessage,
+      valid: true,
+      message: '',
+    });
     syncResistorValuePicker({ isValid: true });
     syncCapacitorValuePicker({ isValid: true });
+    syncMosfetChannelPicker({ isValid: true });
+    syncMosfetPartPicker({ isValid: true });
     updateInputFieldState({
       input: potentiometerValueSelect,
       container: potentiometerValueField,
@@ -1290,6 +1344,33 @@ function buildTextLines() {
         line3Parts.push(state.notes);
       }
       return applyTextVisibility({ line1, line2, line3: line3Parts.join(' — ') });
+    }
+    if (category === 'MOSFET') {
+      const channelId = state.mosfetChannel || '';
+      const partId = state.mosfetPart || '';
+      const channelLabel = channelId ? mosfetChannelLabelMap[channelId] || channelId : '';
+      const partLabel = partId ? mosfetPartLabelMap[partId] || partId : '';
+      const line1 = partLabel || 'MOSFET';
+      const line2Parts = [];
+      if (channelLabel) {
+        line2Parts.push(channelLabel);
+      }
+      const includesMosfet = channelLabel.toLowerCase().includes('mosfet');
+      if (!includesMosfet) {
+        line2Parts.push('MOSFET');
+      }
+      const line3Parts = [];
+      if (state.componentMount) {
+        line3Parts.push(state.componentMount);
+      }
+      if (state.notes) {
+        line3Parts.push(state.notes);
+      }
+      return applyTextVisibility({
+        line1,
+        line2: line2Parts.filter(Boolean).join(' — '),
+        line3: line3Parts.join(' — '),
+      });
     }
     if (category === 'Potentiometer') {
       const line1 = state.potentiometerValue || 'Potentiometer';

--- a/js/state.js
+++ b/js/state.js
@@ -29,6 +29,8 @@ export const state = {
   resistorValue: '',
   capacitorValue: '',
   diodeValue: '',
+  mosfetChannel: '',
+  mosfetPart: '',
   potentiometerValue: '',
   potentiometerTaper: '',
   bearingType: '',

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -15,6 +15,8 @@ import {
   resistorValueOptions,
   capacitorValueOptions,
   diodeValueOptions,
+  mosfetChannelOptions,
+  mosfetPartOptions,
   potentiometerValueOptions,
   potentiometerTaperOptions,
 } from './data.js';
@@ -50,6 +52,8 @@ const FIELD_MAP = {
   resistorValue: 'rv',
   capacitorValue: 'cv',
   diodeValue: 'dv',
+  mosfetChannel: 'mc',
+  mosfetPart: 'mp',
   potentiometerValue: 'pv',
   potentiometerTaper: 'pt',
   bearingType: 'bt',
@@ -84,6 +88,8 @@ const componentMountOptions = new Set(componentMountOptionList.map(option => opt
 const resistorValueOptionSet = new Set(resistorValueOptions.map(option => option.id));
 const capacitorValueOptionSet = new Set(capacitorValueOptions.map(option => option.id));
 const diodeValueOptionSet = new Set(diodeValueOptions.map(option => option.id));
+const mosfetChannelOptionSet = new Set(mosfetChannelOptions.map(option => option.id));
+const mosfetPartOptionSet = new Set(mosfetPartOptions.map(option => option.id));
 const potentiometerValueOptionSet = new Set(
   potentiometerValueOptions.map(option => option.id),
 );
@@ -356,6 +362,15 @@ function applyExpandedPayload(expanded) {
     state.diodeValue = expanded.diodeValue;
   }
   if (
+    typeof expanded.mosfetChannel === 'string' &&
+    mosfetChannelOptionSet.has(expanded.mosfetChannel)
+  ) {
+    state.mosfetChannel = expanded.mosfetChannel;
+  }
+  if (typeof expanded.mosfetPart === 'string' && mosfetPartOptionSet.has(expanded.mosfetPart)) {
+    state.mosfetPart = expanded.mosfetPart;
+  }
+  if (
     typeof expanded.potentiometerValue === 'string' &&
     potentiometerValueOptionSet.has(expanded.potentiometerValue)
   ) {
@@ -383,6 +398,8 @@ function applyExpandedPayload(expanded) {
     state.resistorValue = '';
     state.capacitorValue = '';
     state.diodeValue = '';
+    state.mosfetChannel = '';
+    state.mosfetPart = '';
     state.potentiometerValue = '';
     state.potentiometerTaper = '';
   }
@@ -396,6 +413,10 @@ function applyExpandedPayload(expanded) {
   }
   if (activeCategory !== 'Diode') {
     state.diodeValue = '';
+  }
+  if (activeCategory !== 'MOSFET') {
+    state.mosfetChannel = '';
+    state.mosfetPart = '';
   }
   if (activeCategory !== 'Potentiometer') {
     state.potentiometerValue = '';

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { fuseValues } from '../js/data.js';
+import { fuseValues, mosfetChannelOptions, mosfetPartOptions } from '../js/data.js';
 
 const createClassListMock = () => ({
   add: jest.fn(),
@@ -179,5 +179,26 @@ describe('populateFuseValues', () => {
     const pickerValues = fuseValuePickerList.items.map(item => item.dataset.value);
     expect(pickerValues).toContain('3.15');
     expect(fuseValuePickerList.hidden).toBe(true);
+  });
+});
+
+describe('MOSFET option data', () => {
+  it('provides shared artwork for each MOSFET channel type option', () => {
+    expect(mosfetChannelOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'N-Channel Logic-Level', image: 'images/mosfet/mosfet.svg' }),
+        expect.objectContaining({ id: 'P-Channel', image: 'images/mosfet/mosfet.svg' }),
+      ]),
+    );
+  });
+
+  it('includes popular MOSFET part numbers with matching art', () => {
+    const ids = mosfetPartOptions.map(option => option.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['IRLZ44N', 'AO3400A', 'BS170', 'IRF520', 'FQP30N06L']),
+    );
+    mosfetPartOptions.forEach(option => {
+      expect(option.image).toBe('images/mosfet/mosfet.svg');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add MOSFET to the part type picker with channel and part selectors in the UI
- seed data, state management, rendering, and URL sharing with MOSFET metadata
- update controls, events, and tests while fixing a layout preset lint warning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e15a5eee3883298eacd3e71ea022a7