### PR TITLE
Hide standard selector when washer type is selected

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -5264,7 +5264,8 @@ export function onHardwareTypeChange() {
         showComponentFields ||
         showFuseFields ||
         showSwitchFields ||
-        showNutFields,
+        showNutFields ||
+        showWasherFields,
     );
   }
   if (standardLabel) {
@@ -5274,13 +5275,21 @@ export function onHardwareTypeChange() {
       standardLabel.textContent = defaultStandardLabel;
     }
     const hideStandardLabel =
-      showFastenerFields || showFuseFields || showSwitchFields || showNutFields;
+      showFastenerFields ||
+      showFuseFields ||
+      showSwitchFields ||
+      showNutFields ||
+      showWasherFields;
     standardLabel.classList.toggle('d-none', hideStandardLabel);
     standardLabel.setAttribute('for', hideStandardLabel ? 'bolt-head-select' : 'standard-select');
   }
   if (standardSelect) {
     const hideStandardSelect =
-      showFastenerFields || showFuseFields || showSwitchFields || showNutFields;
+      showFastenerFields ||
+      showFuseFields ||
+      showSwitchFields ||
+      showNutFields ||
+      showWasherFields;
     standardSelect.classList.toggle('d-none', hideStandardSelect);
     standardSelect.hidden = hideStandardSelect;
     if (hideStandardSelect) {


### PR DESCRIPTION
## Summary
- update the hardware type change logic so washer-specific UI hides the shared standard field
- keep the standard label and select disabled while the washer picker is active to avoid blank dropdowns

## Testing
- npm run lint
- Manual verification of washer and connector forms in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e1acbd23c88329a31a5bd0a61de395