### PR TITLE
Fix middle baseline offset for main text

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1263,10 +1263,7 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
   zones.main.effectiveWidth = mainWidthForFitPx;
   zones.sub.effectiveWidth = Math.max(0, subtitleWidthPx - horizontalInsetPx);
 
-  let mainBaseline = mainHeight > 0 ? zones.main.y + mainHeight / 2 : zones.main.y;
-  if (mainHeight > 0 && hasMainMetrics) {
-    mainBaseline += (mainAscent - mainDescent) / 2;
-  }
+  const mainBaseline = mainHeight > 0 ? zones.main.y + mainHeight / 2 : zones.main.y;
 
   const subtitle = {
     ...subtitleFit,


### PR DESCRIPTION
## Summary
- remove the extra baseline adjustment so middle-aligned main text stays centered in its block

## Testing
- node --test *(fails: cannot find package '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68e1b969379483298369234c188b7990