### PR TITLE
Adjust row icon layout scaling

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1409,14 +1409,24 @@ function layoutIcons({
     return items;
   }
   // row layout
-  const slotWidth = (innerWidth - gapPx * (count - 1)) / count;
-  let cursorX = rect.x + paddingPx;
-  mediaItems.forEach(item => {
-    const { width, height } = resolveDimensions(item, slotWidth, innerHeight);
-    const x = cursorX + (slotWidth - width) / 2;
-    const y = rect.y + (rect.height - height) / 2;
+  const gapTotal = gapPx * Math.max(0, count - 1);
+  const naturalSizes = mediaItems.map(item =>
+    resolveDimensions(item, Number.POSITIVE_INFINITY, innerHeight),
+  );
+  const naturalTotalWidth = naturalSizes.reduce((sum, size) => sum + size.width, 0);
+  const availableForIcons = Math.max(0, innerWidth - gapTotal);
+  const scale = naturalTotalWidth > 0 ? Math.min(1, availableForIcons / naturalTotalWidth) : 1;
+  const scaledTotalWidth = naturalTotalWidth * scale;
+  const leftoverSpace = Math.max(0, innerWidth - (scaledTotalWidth + gapTotal));
+  let cursorX = rect.x + paddingPx + leftoverSpace / 2;
+  mediaItems.forEach((item, index) => {
+    const natural = naturalSizes[index];
+    const width = natural.width * scale;
+    const height = natural.height * scale;
+    const x = cursorX;
+    const y = rect.y + paddingPx + (innerHeight - height) / 2;
     items.push({ ...item, x, y, width, height });
-    cursorX += slotWidth + gapPx;
+    cursorX += width + gapPx;
   });
   return items;
 }

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -397,6 +397,33 @@ test('37×12 mm labels keep bolt icons side-by-side', async () => {
   assert.ok(Math.abs(left.y - right.y) < 1.5, 'icons should align horizontally');
   assert.ok(right.x > left.x + left.width - 1, 'icons should be side-by-side');
   assert.ok(left.width > 30 && right.width > 30, 'icons should retain visual size');
+
+  const presetKey = resolvePresetHeightKey(geometry);
+  const previousOverride = getPresetOverride(presetKey);
+  try {
+    setPresetOverride(presetKey, { ...(previousOverride || {}), icon_gap_mm: 0 });
+    const flushResult = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines,
+      hardwareInfo,
+      qrContent: '',
+    });
+    const flushImages = extractImages(flushResult.svgMarkup);
+    assert.equal(flushImages.length, 2, 'expected two media images with zero gap');
+    const [flushLeft, flushRight] = flushImages;
+    const leftEdge = flushLeft.x + flushLeft.width;
+    assert.ok(
+      Math.abs(leftEdge - flushRight.x) < 0.5,
+      'icons should touch when icon gap is zero',
+    );
+  } finally {
+    if (previousOverride) {
+      setPresetOverride(presetKey, previousOverride);
+    } else {
+      setPresetOverride(presetKey, null);
+    }
+  }
 });
 
 test('37×24 mm labels stack bolt icons vertically', async () => {


### PR DESCRIPTION
## Summary
- update the row-layout media icon placement to size icons based on their natural width and center the scaled row when needed
- ensure the layout uniformly scales when icons exceed the media zone and spaces them only by the configured gap
- extend the row-layout test to verify icons touch when the configured gap is zero

## Testing
- `node --test test/labelRenderer.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68e1d5a121308329a0224dc5916e0168