### PR TITLE
Add panel mount fuse holder support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1226,6 +1226,9 @@
                         <option value="Glass">Glass Fuse</option>
                         <option value="Ceramic">Ceramic Fuse</option>
                         <option value="Blade">Blade Fuse</option>
+                        <option value="Panel Mount Fuse Holder">
+                          Panel Mount Fuse Holder
+                        </option>
                       </select>
                       <button
                         type="button"

--- a/js/data.js
+++ b/js/data.js
@@ -78,6 +78,11 @@ export const fuseTypeOptions = [
   { id: 'Glass', label: 'Glass Fuse', image: 'images/fuses/glass_fuse.svg' },
   { id: 'Ceramic', label: 'Ceramic Fuse', image: 'images/fuses/ceramic_fuse.svg' },
   { id: 'Blade', label: 'Blade Fuse', image: 'images/fuses/blade_fuse.svg' },
+  {
+    id: 'Panel Mount Fuse Holder',
+    label: 'Panel Mount Fuse Holder',
+    image: 'images/fuses/fuse_holder_panel_mount.svg',
+  },
 ];
 
 export const switchTypeOptions = [

--- a/js/render.js
+++ b/js/render.js
@@ -168,6 +168,11 @@ const fuseIllustrations = {
     alt: 'Blade fuse illustration',
     aspectRatio: 854 / 797,
   },
+  'Panel Mount Fuse Holder': {
+    src: 'images/fuses/fuse_holder_panel_mount.svg',
+    alt: 'Panel mount fuse holder illustration',
+    aspectRatio: 673 / 669,
+  },
 };
 
 function formatMillimeters(value) {
@@ -1285,7 +1290,11 @@ function buildTextLines() {
 
   if (state.hardwareType === 'Fuse') {
     const valueLabel = state.fuseValue ? `${state.fuseValue} A` : 'Fuse';
-    const typeLabel = state.fuseType ? `${state.fuseType} Fuse` : 'Fuse';
+    const fuseTypeLabel = (state.fuseType || '').trim();
+    const needsFuseSuffix = fuseTypeLabel && !/fuse/i.test(fuseTypeLabel);
+    const typeLabel = fuseTypeLabel
+      ? `${fuseTypeLabel}${needsFuseSuffix ? ' Fuse' : ''}`
+      : 'Fuse';
     const typeParts = [typeLabel];
     if (state.glassSize) {
       typeParts.push(state.glassSize);
@@ -1496,6 +1505,11 @@ function buildTextLines() {
   const line2 = state.standard ? state.standard : state.notes || '';
   return applyTextVisibility({ line1, line2, line3: '' });
 }
+
+export function buildTextLinesForTest() {
+  return buildTextLines();
+}
+
 function hidePreviewContent() {
   if (!labelPreviewImage) {
     return;

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,5 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { fuseValues, mosfetChannelOptions, mosfetPartOptions } from '../js/data.js';
+import {
+  fuseTypeOptions,
+  fuseValues,
+  mosfetChannelOptions,
+  mosfetPartOptions,
+} from '../js/data.js';
 
 const createClassListMock = () => ({
   add: jest.fn(),
@@ -8,7 +13,7 @@ const createClassListMock = () => ({
   contains: jest.fn(() => false),
 });
 
-const fuseValueSelect = {
+const mockFuseValueSelect = {
   options: [],
   disabled: false,
   value: '',
@@ -25,7 +30,7 @@ const fuseValueSelect = {
   },
 };
 
-const fuseValuePickerList = {
+const mockFuseValuePickerList = {
   items: [],
   hidden: false,
   appendChild(item) {
@@ -47,7 +52,7 @@ const fuseValuePickerList = {
   },
 };
 
-const fuseValuePickerButton = {
+const mockFuseValuePickerButton = {
   disabled: true,
   attributes: {},
   classList: createClassListMock(),
@@ -60,7 +65,7 @@ const fuseValuePickerButton = {
   querySelector: jest.fn(() => null),
 };
 
-const fuseValuePicker = {
+const mockFuseValuePicker = {
   classList: {
     add: jest.fn(),
     remove: jest.fn(),
@@ -72,10 +77,10 @@ const fuseValuePicker = {
 jest.mock('../js/dom-elements.js', () => ({
   __esModule: true,
   elements: {
-    fuseValueSelect,
-    fuseValuePickerList,
-    fuseValuePickerButton,
-    fuseValuePicker,
+    fuseValueSelect: mockFuseValueSelect,
+    fuseValuePickerList: mockFuseValuePickerList,
+    fuseValuePickerButton: mockFuseValuePickerButton,
+    fuseValuePicker: mockFuseValuePicker,
   },
 }));
 
@@ -142,22 +147,36 @@ beforeAll(async () => {
 
 beforeEach(() => {
   createElementMock.mockClear();
-  fuseValueSelect.options = [];
-  fuseValueSelect.value = '';
-  fuseValuePickerList.items = [];
-  fuseValuePickerList.hidden = false;
-  fuseValuePickerButton.disabled = true;
-  fuseValuePickerButton.attributes = {};
-  fuseValuePickerButton.classList.add.mockClear();
-  fuseValuePickerButton.classList.remove.mockClear();
-  fuseValuePickerButton.classList.toggle.mockClear();
-  fuseValuePickerButton.setAttribute.mockClear();
-  fuseValuePickerButton.removeAttribute.mockClear();
-  fuseValuePickerButton.querySelector.mockClear();
-  fuseValuePicker.classList.contains.mockReturnValue(false);
-  fuseValuePicker.classList.remove.mockClear();
-  fuseValuePicker.classList.toggle.mockClear();
+  mockFuseValueSelect.options = [];
+  mockFuseValueSelect.value = '';
+  mockFuseValuePickerList.items = [];
+  mockFuseValuePickerList.hidden = false;
+  mockFuseValuePickerButton.disabled = true;
+  mockFuseValuePickerButton.attributes = {};
+  mockFuseValuePickerButton.classList.add.mockClear();
+  mockFuseValuePickerButton.classList.remove.mockClear();
+  mockFuseValuePickerButton.classList.toggle.mockClear();
+  mockFuseValuePickerButton.setAttribute.mockClear();
+  mockFuseValuePickerButton.removeAttribute.mockClear();
+  mockFuseValuePickerButton.querySelector.mockClear();
+  mockFuseValuePicker.classList.contains.mockReturnValue(false);
+  mockFuseValuePicker.classList.remove.mockClear();
+  mockFuseValuePicker.classList.toggle.mockClear();
   state.fuseValue = '';
+});
+
+describe('fuse type option data', () => {
+  it('includes the panel mount fuse holder option with artwork', () => {
+    expect(fuseTypeOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'Panel Mount Fuse Holder',
+          label: 'Panel Mount Fuse Holder',
+          image: 'images/fuses/fuse_holder_panel_mount.svg',
+        }),
+      ]),
+    );
+  });
 });
 
 describe('populateFuseValues', () => {
@@ -172,13 +191,13 @@ describe('populateFuseValues', () => {
 
     populateFuseValues();
 
-    const selectValues = fuseValueSelect.options.map(option => option.value);
+    const selectValues = mockFuseValueSelect.options.map(option => option.value);
     expect(selectValues).toContain('3.15');
-    expect(fuseValueSelect.value).toBe('3.15');
+    expect(mockFuseValueSelect.value).toBe('3.15');
 
-    const pickerValues = fuseValuePickerList.items.map(item => item.dataset.value);
+    const pickerValues = mockFuseValuePickerList.items.map(item => item.dataset.value);
     expect(pickerValues).toContain('3.15');
-    expect(fuseValuePickerList.hidden).toBe(true);
+    expect(mockFuseValuePickerList.hidden).toBe(true);
   });
 });
 

--- a/test/renderFuseText.test.js
+++ b/test/renderFuseText.test.js
@@ -1,0 +1,67 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../js/dom-elements.js', () => ({
+  __esModule: true,
+  elements: new Proxy(
+    {},
+    {
+      get: () => null,
+    },
+  ),
+}));
+
+const mockRenderLabelSVG = jest.fn(async () => ({
+  svgMarkup: '',
+  widthPx: 0,
+  heightPx: 0,
+  printableWidthMm: 0,
+  printableHeightMm: 0,
+}));
+
+jest.mock('../js/label/renderLabelSVG.js', () => ({
+  __esModule: true,
+  renderLabelSVG: mockRenderLabelSVG,
+  loadSvgImage: jest.fn(),
+  canvasToBlob: jest.fn(),
+  layoutPresetTools: {
+    subscribePresetChanges: jest.fn(),
+  },
+}));
+
+let buildTextLinesForTest;
+let state;
+
+beforeAll(async () => {
+  ({ buildTextLinesForTest } = await import('../js/render.js'));
+  ({ state } = await import('../js/state.js'));
+});
+
+beforeEach(() => {
+  state.hardwareType = 'Fuse';
+  state.fuseValue = '5';
+  state.fuseType = 'Glass';
+  state.glassSize = '';
+  state.glassSpeed = '';
+  state.notes = '';
+  state.showText = true;
+  state.showTextMain = true;
+  state.showTextInfo = true;
+});
+
+describe('buildTextLinesForTest', () => {
+  it('avoids duplicating the fuse suffix for panel mount holders', () => {
+    state.fuseType = 'Panel Mount Fuse Holder';
+
+    const lines = buildTextLinesForTest();
+
+    expect(lines.line2).toBe('Panel Mount Fuse Holder');
+  });
+
+  it('still appends the suffix when it is missing', () => {
+    state.fuseType = 'Glass';
+
+    const lines = buildTextLinesForTest();
+
+    expect(lines.line2).toBe('Glass Fuse');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the fuse type data and fallback markup with the panel mount fuse holder option and artwork
- wire the new illustration into the render pipeline and guard against duplicating the "Fuse" suffix
- add regression coverage for the new fuse type option and text rendering behavior

## Testing
- NODE_OPTIONS=--experimental-vm-modules npx jest *(fails: repository currently lacks a Jest ESM configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e4e439ec83298ae35f81a06d341e