### PR TITLE
Allow panel-mount fuse holder without amperage selection

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -238,6 +238,8 @@ const switchTypeMap = new Map(switchTypeOptions.map(option => [option.id, option
 const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const DEFAULT_FUSE_TYPE = 'Glass';
 const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
+const PANEL_MOUNT_FUSE_HOLDER_TYPE = 'Panel Mount Fuse Holder';
+const FUSE_TYPES_WITHOUT_AMPS = new Set([PANEL_MOUNT_FUSE_HOLDER_TYPE]);
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
@@ -2315,6 +2317,86 @@ export function syncHardwareTypePicker() {
   }
 }
 
+function fuseTypeRequiresValue(type) {
+  return !FUSE_TYPES_WITHOUT_AMPS.has(type);
+}
+
+function applyFuseValueVisibility({ showFuseFields = state.hardwareType === 'Fuse' } = {}) {
+  const sanitizedType = validFuseTypeIds.has(state.fuseType)
+    ? state.fuseType
+    : DEFAULT_FUSE_TYPE;
+
+  if (sanitizedType !== state.fuseType) {
+    state.fuseType = sanitizedType;
+  }
+
+  const requiresValue = showFuseFields && fuseTypeRequiresValue(sanitizedType);
+  const shouldShowField = requiresValue;
+
+  if (!requiresValue && state.fuseValue) {
+    state.fuseValue = '';
+  }
+
+  if (fuseValueContainer && fuseValueContainer.classList) {
+    fuseValueContainer.classList.toggle('d-none', !shouldShowField);
+  }
+
+  if (fuseValueSelect) {
+    fuseValueSelect.disabled = !shouldShowField;
+    fuseValueSelect.value = shouldShowField ? state.fuseValue || '' : '';
+  }
+
+  if (fuseValuePickerButton) {
+    fuseValuePickerButton.disabled = !shouldShowField;
+    if (!shouldShowField) {
+      if (typeof fuseValuePickerButton.setAttribute === 'function') {
+        fuseValuePickerButton.setAttribute('aria-expanded', 'false');
+      }
+      if (
+        fuseValuePickerButton.classList &&
+        typeof fuseValuePickerButton.classList.remove === 'function'
+      ) {
+        fuseValuePickerButton.classList.remove('is-invalid');
+      }
+      if (typeof fuseValuePickerButton.removeAttribute === 'function') {
+        fuseValuePickerButton.removeAttribute('aria-invalid');
+      }
+    } else {
+      const pickerIsOpen = Boolean(
+        fuseValuePicker &&
+          fuseValuePicker.classList &&
+          typeof fuseValuePicker.classList.contains === 'function' &&
+          fuseValuePicker.classList.contains('is-open'),
+      );
+      if (typeof fuseValuePickerButton.setAttribute === 'function') {
+        fuseValuePickerButton.setAttribute('aria-expanded', pickerIsOpen ? 'true' : 'false');
+      }
+    }
+  }
+
+  if (fuseValuePickerList) {
+    const pickerIsOpen = Boolean(
+      fuseValuePicker &&
+        fuseValuePicker.classList &&
+        typeof fuseValuePicker.classList.contains === 'function' &&
+        fuseValuePicker.classList.contains('is-open'),
+    );
+    const shouldHideList = !shouldShowField || !pickerIsOpen;
+    fuseValuePickerList.hidden = shouldHideList;
+  }
+
+  if (
+    !shouldShowField &&
+    fuseValuePicker &&
+    fuseValuePicker.classList &&
+    typeof fuseValuePicker.classList.remove === 'function'
+  ) {
+    fuseValuePicker.classList.remove('is-open');
+  }
+
+  return { requiresValue };
+}
+
 export function syncFuseTypePicker({ isValid = true } = {}) {
   const currentValue = typeof state.fuseType === 'string' ? state.fuseType : '';
   const sanitizedValue = validFuseTypeIds.has(currentValue) ? currentValue : DEFAULT_FUSE_TYPE;
@@ -2385,6 +2467,10 @@ export function setFuseTypeSelection(nextId, { triggerUpdate = true } = {}) {
 
   state.fuseType = sanitizedValue;
   syncFuseTypePicker({ isValid: true });
+
+  const showFuseFields = state.hardwareType === 'Fuse';
+  applyFuseValueVisibility({ showFuseFields });
+  syncFuseValuePicker({ isValid: true });
 
   const previousWasCartridge = CARTRIDGE_FUSE_TYPES.has(previousValue);
   const nextIsCartridge = CARTRIDGE_FUSE_TYPES.has(sanitizedValue);
@@ -3596,18 +3682,34 @@ export function updateConnectorCategoryUi() {
 export { populateThreadSizes, syncThreadSizePicker, setThreadSizeSelection };
 
 export function syncFuseValuePicker({ isValid = true } = {}) {
-  if (!fuseValueSelect) {
-    return;
+  const sanitizedType = validFuseTypeIds.has(state.fuseType)
+    ? state.fuseType
+    : DEFAULT_FUSE_TYPE;
+
+  if (sanitizedType !== state.fuseType) {
+    state.fuseType = sanitizedType;
   }
 
-  const currentValue = typeof state.fuseValue === 'string' ? state.fuseValue.trim() : '';
-  const sanitizedValue = currentValue && validFuseValuesSet.has(currentValue) ? currentValue : '';
+  const showFuseFields = state.hardwareType === 'Fuse';
+  const requiresValue = showFuseFields && fuseTypeRequiresValue(sanitizedType);
 
-  if (sanitizedValue !== currentValue) {
+  let currentValue = typeof state.fuseValue === 'string' ? state.fuseValue.trim() : '';
+  if (!requiresValue) {
+    currentValue = '';
+  }
+
+  const sanitizedValue =
+    requiresValue && currentValue && validFuseValuesSet.has(currentValue) ? currentValue : '';
+
+  if (sanitizedValue !== state.fuseValue) {
     state.fuseValue = sanitizedValue;
   }
 
-  fuseValueSelect.value = sanitizedValue;
+  if (fuseValueSelect) {
+    fuseValueSelect.value = sanitizedValue;
+  }
+
+  const effectiveValidity = requiresValue ? isValid : true;
 
   if (fuseValuePickerButton) {
     const label = fuseValuePickerButton.querySelector('.bolt-drive-picker__current-label');
@@ -3619,17 +3721,21 @@ export function syncFuseValuePicker({ isValid = true } = {}) {
       iconWrapper.classList.add('is-empty');
     }
 
-    if (isValid) {
+    if (effectiveValidity) {
       fuseValuePickerButton.classList.remove('is-invalid');
-      fuseValuePickerButton.removeAttribute('aria-invalid');
+      if (typeof fuseValuePickerButton.removeAttribute === 'function') {
+        fuseValuePickerButton.removeAttribute('aria-invalid');
+      }
     } else {
       fuseValuePickerButton.classList.add('is-invalid');
-      fuseValuePickerButton.setAttribute('aria-invalid', 'true');
+      if (typeof fuseValuePickerButton.setAttribute === 'function') {
+        fuseValuePickerButton.setAttribute('aria-invalid', 'true');
+      }
     }
   }
 
   if (fuseValuePicker) {
-    fuseValuePicker.classList.toggle('is-invalid', !isValid);
+    fuseValuePicker.classList.toggle('is-invalid', !effectiveValidity);
   }
 
   if (fuseValuePickerList) {
@@ -5210,36 +5316,11 @@ export function onHardwareTypeChange() {
   if (fuseTypeContainer) {
     fuseTypeContainer.classList.toggle('d-none', !showFuseFields);
   }
-  if (fuseValueContainer) {
-    fuseValueContainer.classList.toggle('d-none', !showFuseFields);
-  }
-  if (fuseValueSelect) {
-    fuseValueSelect.disabled = !showFuseFields;
-    if (showFuseFields) {
-      fuseValueSelect.value = state.fuseValue || '';
-    }
-  }
-  if (fuseValuePickerButton) {
-    fuseValuePickerButton.disabled = !showFuseFields;
-    if (!showFuseFields) {
-      fuseValuePickerButton.setAttribute('aria-expanded', 'false');
-    } else {
-      const isOpen = Boolean(fuseValuePicker && fuseValuePicker.classList.contains('is-open'));
-      fuseValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    }
-  }
-  if (fuseValuePickerList) {
-    const shouldHideList =
-      !showFuseFields || !fuseValuePicker || !fuseValuePicker.classList.contains('is-open');
-    fuseValuePickerList.hidden = shouldHideList;
-  }
-  if (!showFuseFields && fuseValuePicker) {
-    fuseValuePicker.classList.remove('is-open');
-  }
+  applyFuseValueVisibility({ showFuseFields });
   if (showFuseFields) {
     syncFuseTypePicker();
-    syncFuseValuePicker({ isValid: true });
   }
+  syncFuseValuePicker({ isValid: true });
   syncSwitchTypePicker({ isValid: true });
   if (connectorNotesHint) {
     connectorNotesHint.classList.toggle('d-none', !showConnectorFields);

--- a/js/render.js
+++ b/js/render.js
@@ -355,7 +355,13 @@ function updateRadioGroupFeedback({ radios, container, messageElement, valid, me
 
 export function isLabelReady() {
   if (state.hardwareType === 'Fuse') {
-    return Boolean(state.fuseType && state.fuseValue);
+    if (!state.fuseType) {
+      return false;
+    }
+    if (state.fuseType === 'Panel Mount Fuse Holder') {
+      return true;
+    }
+    return Boolean(state.fuseValue);
   }
   if (state.hardwareType === 'Connector') {
     return Boolean(state.connectorCategory);
@@ -482,12 +488,14 @@ function applyValidationFeedback() {
       valid: typeValid,
     });
     syncFuseTypePicker({ isValid: typeValid });
-    const valueValid = Boolean(state.fuseValue);
+    const requiresFuseValue = state.fuseType !== 'Panel Mount Fuse Holder';
+    const valueValid = !requiresFuseValue || Boolean(state.fuseValue);
     updateInputFieldState({
       input: fuseValueSelect,
       container: fuseValueContainer,
       messageElement: fuseValueMessage,
       valid: valueValid,
+      message: '',
     });
     syncFuseValuePicker({ isValid: valueValid });
     updateInputFieldState({

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -52,6 +52,10 @@ const mockFuseValuePickerList = {
   },
 };
 
+const mockFuseValueContainer = {
+  classList: createClassListMock(),
+};
+
 const mockFuseValuePickerButton = {
   disabled: true,
   attributes: {},
@@ -77,6 +81,7 @@ const mockFuseValuePicker = {
 jest.mock('../js/dom-elements.js', () => ({
   __esModule: true,
   elements: {
+    fuseValueContainer: mockFuseValueContainer,
     fuseValueSelect: mockFuseValueSelect,
     fuseValuePickerList: mockFuseValuePickerList,
     fuseValuePickerButton: mockFuseValuePickerButton,
@@ -138,10 +143,14 @@ global.document = {
 };
 
 let populateFuseValues;
+let setFuseTypeSelection;
+let syncFuseValuePicker;
 let state;
 
 beforeAll(async () => {
-  ({ populateFuseValues } = await import('../js/forms.js'));
+  ({ populateFuseValues, setFuseTypeSelection, syncFuseValuePicker } = await import(
+    '../js/forms.js',
+  ));
   ({ state } = await import('../js/state.js'));
 });
 
@@ -159,10 +168,17 @@ beforeEach(() => {
   mockFuseValuePickerButton.setAttribute.mockClear();
   mockFuseValuePickerButton.removeAttribute.mockClear();
   mockFuseValuePickerButton.querySelector.mockClear();
+  mockFuseValueContainer.classList.toggle.mockClear();
   mockFuseValuePicker.classList.contains.mockReturnValue(false);
   mockFuseValuePicker.classList.remove.mockClear();
   mockFuseValuePicker.classList.toggle.mockClear();
   state.fuseValue = '';
+  state.fuseType = 'Glass';
+  state.hardwareType = 'Fuse';
+  mockFuseValueSelect.disabled = false;
+  mockFuseValueSelect.value = '';
+  mockFuseValuePickerButton.disabled = true;
+  mockFuseValuePickerButton.attributes = {};
 });
 
 describe('fuse type option data', () => {
@@ -198,6 +214,37 @@ describe('populateFuseValues', () => {
     const pickerValues = mockFuseValuePickerList.items.map(item => item.dataset.value);
     expect(pickerValues).toContain('3.15');
     expect(mockFuseValuePickerList.hidden).toBe(true);
+  });
+});
+
+describe('fuse type selection behaviour', () => {
+  it('hides the amperage controls and clears the value for panel mount holders', () => {
+    state.fuseValue = '5';
+    mockFuseValuePicker.classList.contains.mockReturnValue(true);
+
+    setFuseTypeSelection('Panel Mount Fuse Holder', { triggerUpdate: false });
+
+    expect(state.fuseValue).toBe('');
+    expect(mockFuseValueSelect.disabled).toBe(true);
+    expect(mockFuseValueSelect.value).toBe('');
+    expect(mockFuseValueContainer.classList.toggle).toHaveBeenCalledWith('d-none', true);
+    expect(mockFuseValuePickerButton.disabled).toBe(true);
+    expect(mockFuseValuePickerButton.attributes['aria-expanded']).toBe('false');
+    expect(mockFuseValuePickerButton.classList.remove).toHaveBeenCalledWith('is-invalid');
+    expect(mockFuseValuePickerButton.removeAttribute).toHaveBeenCalledWith('aria-invalid');
+    expect(mockFuseValuePicker.classList.remove).toHaveBeenCalledWith('is-open');
+  });
+
+  it('keeps validation clear when amperage is not required', () => {
+    state.fuseType = 'Panel Mount Fuse Holder';
+    state.fuseValue = '';
+
+    syncFuseValuePicker({ isValid: false });
+
+    expect(mockFuseValuePickerButton.classList.add).not.toHaveBeenCalledWith('is-invalid');
+    expect(mockFuseValuePickerButton.classList.remove).toHaveBeenCalledWith('is-invalid');
+    expect(mockFuseValuePickerButton.removeAttribute).toHaveBeenCalledWith('aria-invalid');
+    expect(mockFuseValuePicker.classList.toggle).toHaveBeenCalledWith('is-invalid', false);
   });
 });
 

--- a/test/renderFuseText.test.js
+++ b/test/renderFuseText.test.js
@@ -29,10 +29,11 @@ jest.mock('../js/label/renderLabelSVG.js', () => ({
 }));
 
 let buildTextLinesForTest;
+let isLabelReady;
 let state;
 
 beforeAll(async () => {
-  ({ buildTextLinesForTest } = await import('../js/render.js'));
+  ({ buildTextLinesForTest, isLabelReady } = await import('../js/render.js'));
   ({ state } = await import('../js/state.js'));
 });
 
@@ -63,5 +64,12 @@ describe('buildTextLinesForTest', () => {
     const lines = buildTextLinesForTest();
 
     expect(lines.line2).toBe('Glass Fuse');
+  });
+
+  it('considers the panel mount holder ready without an amperage', () => {
+    state.fuseType = 'Panel Mount Fuse Holder';
+    state.fuseValue = '';
+
+    expect(isLabelReady()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow the panel-mount fuse holder to count as ready without choosing an amperage
- hide and reset the fuse value controls whenever the holder type is active
- extend fuse-related tests to cover the holder scenario

## Testing
- npx jest --runInBand *(fails: repository lacks Jest ESM configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ee4cb4f483298de8024766be81cb