### PR TITLE
Hide fuse speed controls for panel fuse holders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1311,20 +1311,25 @@
                   </div>
                 </div>
                 <div id="glass-options-container" class="d-none">
-                  <span class="form-label d-block fw-semibold">Glass &amp; Ceramic Fuse Options</span>
-                  <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
-                    <label class="form-check-label" for="glass-slow-blow"
-                      >Slow-blow (time delay)</label
-                    >
-                  </div>
-                  <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="glass-fast-blow" />
-                    <label class="form-check-label" for="glass-fast-blow">Fast-blow</label>
+                  <span class="form-label d-block fw-semibold"
+                    >Glass, Ceramic &amp; Holder Options</span
+                  >
+                  <div id="glass-speed-options">
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
+                      <label class="form-check-label" for="glass-slow-blow"
+                        >Slow-blow (time delay)</label
+                      >
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" id="glass-fast-blow" />
+                      <label class="form-check-label" for="glass-fast-blow">Fast-blow</label>
+                    </div>
+                    <div class="form-text">Select a fuse speed for glass or ceramic fuses.</div>
                   </div>
                   <div class="mt-2">
                     <label for="glass-size-select" class="form-label fw-semibold"
-                      >Glass &amp; Ceramic Fuse Size</label
+                      >Glass Fuse or Holder Size</label
                     >
                     <select id="glass-size-select" class="form-select">
                       <option value="">&nbsp;</option>
@@ -1334,7 +1339,8 @@
                       </option>
                     </select>
                     <div class="form-text">
-                      Standard glass and ceramic fuse sizes: 5 × 20 mm and 6.3 × 32 mm.
+                      Standard glass fuse sizes and matching panel mount holders: 5 × 20 mm and
+                      6.3 × 32 mm. Holders only need the size selection.
                     </div>
                   </div>
                 </div>

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -45,6 +45,7 @@ const fuseTypePickerList = document.getElementById('fuse-type-picker-list');
 const fuseValueContainer = document.getElementById('fuse-value-container');
 const fuseTypeMessage = document.getElementById('fuse-type-message');
 const glassOptionsContainer = document.getElementById('glass-options-container');
+const glassSpeedOptionsContainer = document.getElementById('glass-speed-options');
 const fuseValueSelect = document.getElementById('fuse-value-select');
 const fuseValuePicker = document.getElementById('fuse-value-picker');
 const fuseValuePickerButton = document.getElementById('fuse-value-picker-button');
@@ -263,6 +264,7 @@ export const elements = {
   fuseTypeMessage,
   fuseValueContainer,
   glassOptionsContainer,
+  glassSpeedOptionsContainer,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,

--- a/js/forms.js
+++ b/js/forms.js
@@ -56,6 +56,7 @@ const {
   fuseTypePickerList,
   fuseValueContainer,
   glassOptionsContainer,
+  glassSpeedOptionsContainer,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,
@@ -237,8 +238,8 @@ const validSwitchTypeIds = new Set(switchTypeOptions.map(option => option.id));
 const switchTypeMap = new Map(switchTypeOptions.map(option => [option.id, option]));
 const FUSE_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const DEFAULT_FUSE_TYPE = 'Glass';
-const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic']);
 const PANEL_MOUNT_FUSE_HOLDER_TYPE = 'Panel Mount Fuse Holder';
+const CARTRIDGE_FUSE_TYPES = new Set(['Glass', 'Ceramic', PANEL_MOUNT_FUSE_HOLDER_TYPE]);
 const FUSE_TYPES_WITHOUT_AMPS = new Set([PANEL_MOUNT_FUSE_HOLDER_TYPE]);
 const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -3825,28 +3826,51 @@ export function populateFuseValues() {
 export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
   const shouldShow =
     state.hardwareType === 'Fuse' && CARTRIDGE_FUSE_TYPES.has(state.fuseType);
+  const requiresSpeedOptions =
+    shouldShow && state.fuseType !== PANEL_MOUNT_FUSE_HOLDER_TYPE;
   if (glassOptionsContainer) {
     glassOptionsContainer.classList.toggle('d-none', !shouldShow);
+  }
+  if (glassSpeedOptionsContainer) {
+    glassSpeedOptionsContainer.classList.toggle('d-none', shouldShow ? !requiresSpeedOptions : false);
   }
   if (shouldShow) {
     if (glassSizeSelect) {
       glassSizeSelect.value = state.glassSize || '';
     }
-    if (glassSlowBlowCheckbox && glassFastBlowCheckbox) {
-      glassSlowBlowCheckbox.checked = state.glassSpeed.startsWith('Slow');
-      glassFastBlowCheckbox.checked = state.glassSpeed.startsWith('Fast');
+    if (glassSlowBlowCheckbox) {
+      glassSlowBlowCheckbox.disabled = !requiresSpeedOptions;
+      glassSlowBlowCheckbox.checked =
+        requiresSpeedOptions && state.glassSpeed.startsWith('Slow');
+    }
+    if (glassFastBlowCheckbox) {
+      glassFastBlowCheckbox.disabled = !requiresSpeedOptions;
+      glassFastBlowCheckbox.checked =
+        requiresSpeedOptions && state.glassSpeed.startsWith('Fast');
+    }
+    if (!requiresSpeedOptions) {
+      state.glassSpeed = '';
     }
   } else if (resetIfHidden) {
     state.glassSpeed = '';
     state.glassSize = '';
     if (glassSlowBlowCheckbox) {
       glassSlowBlowCheckbox.checked = false;
+      glassSlowBlowCheckbox.disabled = false;
     }
     if (glassFastBlowCheckbox) {
       glassFastBlowCheckbox.checked = false;
+      glassFastBlowCheckbox.disabled = false;
     }
     if (glassSizeSelect) {
       glassSizeSelect.value = '';
+    }
+  } else {
+    if (glassSlowBlowCheckbox) {
+      glassSlowBlowCheckbox.disabled = false;
+    }
+    if (glassFastBlowCheckbox) {
+      glassFastBlowCheckbox.disabled = false;
     }
   }
 }

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -78,6 +78,28 @@ const mockFuseValuePicker = {
   },
 };
 
+const mockGlassOptionsContainer = {
+  classList: createClassListMock(),
+};
+
+const mockGlassSpeedOptionsContainer = {
+  classList: createClassListMock(),
+};
+
+const mockGlassSizeSelect = {
+  value: '',
+};
+
+const mockGlassSlowBlowCheckbox = {
+  checked: false,
+  disabled: false,
+};
+
+const mockGlassFastBlowCheckbox = {
+  checked: false,
+  disabled: false,
+};
+
 jest.mock('../js/dom-elements.js', () => ({
   __esModule: true,
   elements: {
@@ -86,6 +108,11 @@ jest.mock('../js/dom-elements.js', () => ({
     fuseValuePickerList: mockFuseValuePickerList,
     fuseValuePickerButton: mockFuseValuePickerButton,
     fuseValuePicker: mockFuseValuePicker,
+    glassOptionsContainer: mockGlassOptionsContainer,
+    glassSpeedOptionsContainer: mockGlassSpeedOptionsContainer,
+    glassSizeSelect: mockGlassSizeSelect,
+    glassSlowBlowCheckbox: mockGlassSlowBlowCheckbox,
+    glassFastBlowCheckbox: mockGlassFastBlowCheckbox,
   },
 }));
 
@@ -172,9 +199,18 @@ beforeEach(() => {
   mockFuseValuePicker.classList.contains.mockReturnValue(false);
   mockFuseValuePicker.classList.remove.mockClear();
   mockFuseValuePicker.classList.toggle.mockClear();
+  mockGlassOptionsContainer.classList.toggle.mockClear();
+  mockGlassSpeedOptionsContainer.classList.toggle.mockClear();
+  mockGlassSizeSelect.value = '';
+  mockGlassSlowBlowCheckbox.checked = false;
+  mockGlassSlowBlowCheckbox.disabled = false;
+  mockGlassFastBlowCheckbox.checked = false;
+  mockGlassFastBlowCheckbox.disabled = false;
   state.fuseValue = '';
   state.fuseType = 'Glass';
   state.hardwareType = 'Fuse';
+  state.glassSize = '';
+  state.glassSpeed = '';
   mockFuseValueSelect.disabled = false;
   mockFuseValueSelect.value = '';
   mockFuseValuePickerButton.disabled = true;
@@ -245,6 +281,57 @@ describe('fuse type selection behaviour', () => {
     expect(mockFuseValuePickerButton.classList.remove).toHaveBeenCalledWith('is-invalid');
     expect(mockFuseValuePickerButton.removeAttribute).toHaveBeenCalledWith('aria-invalid');
     expect(mockFuseValuePicker.classList.toggle).toHaveBeenCalledWith('is-invalid', false);
+  });
+
+  it('reveals the glass options for panel mount holders and keeps the selected size', () => {
+    state.glassSize = '5 × 20 mm';
+    state.glassSpeed = 'Fast Blow';
+
+    setFuseTypeSelection('Panel Mount Fuse Holder', { triggerUpdate: false });
+
+    expect(mockGlassOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', false);
+    expect(mockGlassSpeedOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', true);
+    expect(mockGlassSizeSelect.value).toBe('5 × 20 mm');
+    expect(state.glassSpeed).toBe('');
+    expect(mockGlassSlowBlowCheckbox.checked).toBe(false);
+    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
+    expect(mockGlassSlowBlowCheckbox.disabled).toBe(true);
+    expect(mockGlassFastBlowCheckbox.disabled).toBe(true);
+  });
+
+  it('hides and clears the glass options when switching to blade fuses', () => {
+    state.fuseType = 'Panel Mount Fuse Holder';
+    state.glassSize = '6.3 × 32 mm (1/4″ × 1-1/4″)';
+    mockGlassSizeSelect.value = state.glassSize;
+    state.glassSpeed = 'Slow Blow (Time Delay)';
+
+    setFuseTypeSelection('Blade', { triggerUpdate: false });
+
+    expect(mockGlassOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', true);
+    expect(state.glassSize).toBe('');
+    expect(mockGlassSizeSelect.value).toBe('');
+    expect(mockGlassSpeedOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', false);
+    expect(state.glassSpeed).toBe('');
+    expect(mockGlassSlowBlowCheckbox.checked).toBe(false);
+    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
+    expect(mockGlassSlowBlowCheckbox.disabled).toBe(false);
+    expect(mockGlassFastBlowCheckbox.disabled).toBe(false);
+  });
+
+  it('restores fuse speed options when switching back to glass fuses', () => {
+    setFuseTypeSelection('Panel Mount Fuse Holder', { triggerUpdate: false });
+    state.glassSpeed = 'Slow Blow (Time Delay)';
+
+    setFuseTypeSelection('Glass', { triggerUpdate: false });
+
+    expect(mockGlassSpeedOptionsContainer.classList.toggle).toHaveBeenLastCalledWith(
+      'd-none',
+      false,
+    );
+    expect(mockGlassSlowBlowCheckbox.disabled).toBe(false);
+    expect(mockGlassFastBlowCheckbox.disabled).toBe(false);
+    expect(mockGlassSlowBlowCheckbox.checked).toBe(true);
+    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
   });
 });
 

--- a/test/renderFuseText.test.js
+++ b/test/renderFuseText.test.js
@@ -58,6 +58,16 @@ describe('buildTextLinesForTest', () => {
     expect(lines.line2).toBe('Panel Mount Fuse Holder');
   });
 
+  it('includes the selected glass size for panel mount holders', () => {
+    state.fuseType = 'Panel Mount Fuse Holder';
+    state.fuseValue = '';
+    state.glassSize = '6.3 × 32 mm (1/4″ × 1-1/4″)';
+
+    const lines = buildTextLinesForTest();
+
+    expect(lines.line2).toBe('Panel Mount Fuse Holder — 6.3 × 32 mm (1/4″ × 1-1/4″)');
+  });
+
   it('still appends the suffix when it is missing', () => {
     state.fuseType = 'Glass';
 


### PR DESCRIPTION
## Summary
- hide the slow/fast blow checkboxes when selecting a panel mount fuse holder and disable them in the form state
- add a DOM handle for the glass fuse speed group and clarify the holder-only size messaging in the UI copy
- extend the fuse form tests to cover the hidden speed options and re-enabling behaviour when switching back to glass fuses

## Testing
- node --test *(fails: missing @jest/globals package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f298a5148329b924a826d9ead508