### PR TITLE
Update default layout presets

### DIFF
--- a/js/label/layoutPresets.js
+++ b/js/label/layoutPresets.js
@@ -80,6 +80,19 @@ export const defaultLayoutPresets = {
       location: 'top-right',
       max_pct_of_text_zone_width: 32,
     },
+    __parts: {
+      Switch: {
+        __sub_parts: {
+          'switch-type:microswitch-roller': {
+            text_zone: {
+              main: {
+                wrap_mode: 'wrap',
+              },
+            },
+          },
+        },
+      },
+    },
   },
   18: {
     padding_mm: 0,
@@ -121,6 +134,20 @@ export const defaultLayoutPresets = {
       location: 'top-right',
       max_pct_of_text_zone_width: 32,
     },
+    __parts: {
+      Switch: {
+        __sub_parts: {
+          'switch-type:microswitch-roller': {
+            text_zone: {
+              main: {
+                wrap_mode: 'wrap',
+              },
+            },
+            media_zone_width_pct_max_user: 50,
+          },
+        },
+      },
+    },
   },
   24: {
     padding_mm: 0,
@@ -161,6 +188,22 @@ export const defaultLayoutPresets = {
       margin_mm: 0.8,
       location: 'top-right',
       max_pct_of_text_zone_width: 32,
+    },
+    __parts: {
+      Switch: {
+        __sub_parts: {
+          'switch-type:microswitch-roller': {
+            text_zone: {
+              main: {
+                wrap_mode: 'wrap',
+              },
+            },
+            media_zone_width_pct_max_user: 50,
+            media_zone_width_pct_max: 38,
+            icon_padding_mm: 0.4,
+          },
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
## Summary
- add the layout editor export for sizes 12, 18, and 24 to the default layout presets

## Testing
- npm test -- --runTestsByPath test/labelRenderer.test.mjs *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e273dffc3c8329956da8ab908dad9e