### PR TITLE
Add built-in part icon picker for custom graphics

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,6 +371,17 @@
                         <i class="fa-solid fa-icons me-1" aria-hidden="true"></i>
                         Font Awesome icon
                       </label>
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        name="custom-graphic-source"
+                        id="custom-graphic-source-parts"
+                        value="parts"
+                      />
+                      <label class="btn btn-outline-secondary btn-sm" for="custom-graphic-source-parts">
+                        <i class="fa-solid fa-puzzle-piece me-1" aria-hidden="true"></i>
+                        Built-in part icon
+                      </label>
                     </div>
                   </div>
                   <div id="custom-image-fields">
@@ -388,12 +399,6 @@
                     </div>
                   </div>
                   <div id="custom-icon-fields" class="d-none">
-                    <label for="custom-icon-style" class="form-label fw-semibold">Icon style</label>
-                    <select class="form-select" id="custom-icon-style">
-                      <option value="solid" selected>Solid</option>
-                      <option value="regular">Regular</option>
-                      <option value="brands">Brands</option>
-                    </select>
                     <div class="mt-3">
                       <label for="custom-icon-search" class="form-label fw-semibold">Search icons</label>
                       <input
@@ -444,6 +449,45 @@
                       </div>
                     </div>
                     <div class="form-text mt-2" id="custom-icon-status" aria-live="polite"></div>
+                  </div>
+                  <div id="custom-part-fields" class="d-none">
+                    <label for="custom-part-select" class="form-label fw-semibold">Part icon</label>
+                    <div class="bolt-drive-picker" id="custom-part-picker">
+                      <select
+                        id="custom-part-select"
+                        class="visually-hidden"
+                        aria-describedby="custom-part-status"
+                      ></select>
+                      <button
+                        type="button"
+                        class="bolt-drive-picker__button"
+                        id="custom-part-picker-button"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="custom-part-picker-list"
+                      >
+                        <span class="bolt-drive-picker__current">
+                          <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                            <img
+                              class="bolt-drive-picker__current-icon-image"
+                              src=""
+                              alt=""
+                              hidden
+                            />
+                          </span>
+                          <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                        </span>
+                        <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                      </button>
+                      <ul
+                        class="bolt-drive-picker__list"
+                        id="custom-part-picker-list"
+                        role="listbox"
+                        aria-labelledby="custom-part-picker-button"
+                        hidden
+                      ></ul>
+                    </div>
+                    <div class="form-text mt-2" id="custom-part-status" aria-live="polite"></div>
                   </div>
                   <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
                     <button

--- a/js/controls.js
+++ b/js/controls.js
@@ -18,6 +18,7 @@ import {
   populatePotentiometerValues,
   populatePotentiometerTapers,
   populateWasherTypeOptions,
+  populateCustomPartPicker,
   updateCustomImageUi,
   ensureCustomIconAsset,
   onHardwareTypeChange,
@@ -42,6 +43,7 @@ import {
   setPotentiometerTaperSelection,
   syncConnectorSeriesPicker,
   updateComponentValueUi,
+  setCustomPartSelection,
 } from './forms.js';
 import {
   updateDownloadState,
@@ -139,6 +141,7 @@ function applyStateToControls() {
   setNutTypeSelection(state.nutType || '', { triggerUpdate: false });
   setWasherTypeSelection(state.washerType || '', { triggerUpdate: false });
   setSwitchTypeSelection(state.switchType || '', { triggerUpdate: false });
+  setCustomPartSelection(state.customPartId || '', { triggerUpdate: false });
   if (textToggle) {
     textToggle.checked = state.showText;
     textToggle.setAttribute('aria-expanded', state.showText ? 'true' : 'false');
@@ -191,6 +194,7 @@ function init() {
   populatePotentiometerTapers();
   populateWasherTypeOptions();
   populateSwitchTypePicker();
+  populateCustomPartPicker();
   updateCustomImageUi();
   ensureCustomIconAsset();
   onHardwareTypeChange();

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -128,7 +128,6 @@ const customImageInput = document.getElementById('custom-image-input');
 const customImageClearButton = document.getElementById('custom-image-clear');
 const customImageNameDisplay = document.getElementById('custom-image-name');
 const customIconFields = document.getElementById('custom-icon-fields');
-const customIconStyleSelect = document.getElementById('custom-icon-style');
 const customIconSearchInput = document.getElementById('custom-icon-search');
 const customIconSelect = document.getElementById('custom-icon-select');
 const customIconPicker = document.getElementById('custom-icon-picker');
@@ -136,6 +135,12 @@ const customIconPickerButton = document.getElementById('custom-icon-picker-butto
 const customIconPickerList = document.getElementById('custom-icon-picker-list');
 const customIconStatus = document.getElementById('custom-icon-status');
 const customIconPreview = document.getElementById('custom-icon-preview');
+const customPartFields = document.getElementById('custom-part-fields');
+const customPartPicker = document.getElementById('custom-part-picker');
+const customPartPickerButton = document.getElementById('custom-part-picker-button');
+const customPartPickerList = document.getElementById('custom-part-picker-list');
+const customPartSelect = document.getElementById('custom-part-select');
+const customPartStatus = document.getElementById('custom-part-status');
 const customLine1Input = document.getElementById('custom-line1-input');
 const customLine2Input = document.getElementById('custom-line2-input');
 const customLine1Field = document.getElementById('custom-line1-field');
@@ -345,7 +350,6 @@ export const elements = {
   customImageClearButton,
   customImageNameDisplay,
   customIconFields,
-  customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
   customIconPicker,
@@ -353,6 +357,12 @@ export const elements = {
   customIconPickerList,
   customIconStatus,
   customIconPreview,
+  customPartFields,
+  customPartPicker,
+  customPartPickerButton,
+  customPartPickerList,
+  customPartSelect,
+  customPartStatus,
   customLine1Input,
   customLine2Input,
   customLine1Field,

--- a/js/events.js
+++ b/js/events.js
@@ -6,7 +6,6 @@ import {
   handleCustomImageFile,
   clearCustomImage,
   setCustomGraphicSource,
-  setCustomIconStyle,
   setCustomIconSelection,
   refreshCustomIconOptions,
   handleStandardSelectKeydown,
@@ -46,6 +45,8 @@ import {
   updateComponentValueUi,
   setBearingTypeSelection,
   syncBearingTypePicker,
+  setCustomPartSelection,
+  syncCustomPartPicker,
 } from './forms.js';
 import {
   updatePreview,
@@ -126,12 +127,15 @@ const {
   lengthInput,
   notesInput,
   customGraphicSourceRadios,
-  customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
   customIconPicker,
   customIconPickerButton,
   customIconPickerList,
+  customPartSelect,
+  customPartPicker,
+  customPartPickerButton,
+  customPartPickerList,
   customLine1Input,
   customLine2Input,
   customImageInput,
@@ -202,6 +206,7 @@ let potentiometerValuePickerOpen = false;
 let potentiometerTaperPickerOpen = false;
 let bearingTypePickerOpen = false;
 let customIconPickerOpen = false;
+let customPartPickerOpen = false;
 let connectorCategoryPickerOpen = false;
 let connectorSeriesPickerOpen = false;
 
@@ -1618,7 +1623,7 @@ function handleCustomIconListKeydown(event) {
           name: option.dataset.value || '',
           unicode: option.dataset.unicode || '',
           label: option.dataset.label || option.textContent || option.dataset.value || '',
-          style: option.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+          style: option.dataset.style || 'solid',
         });
         closeCustomIconPicker({ focusButton: true });
       }
@@ -1652,7 +1657,7 @@ function handleCustomIconListClick(event) {
     name: option.dataset.value || '',
     unicode: option.dataset.unicode || '',
     label: option.dataset.label || option.textContent || option.dataset.value || '',
-    style: option.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+    style: option.dataset.style || 'solid',
   });
   closeCustomIconPicker({ focusButton: true });
 }
@@ -1672,6 +1677,216 @@ function handleCustomIconListFocusOut() {
     const active = document.activeElement;
     if (!active || !customIconPicker.contains(active)) {
       closeCustomIconPicker();
+    }
+  }, 0);
+}
+
+function getCustomPartOptionElements() {
+  if (!customPartPickerList) {
+    return [];
+  }
+  return Array.from(customPartPickerList.querySelectorAll('[role="option"]'));
+}
+
+function focusCustomPartOption(option) {
+  if (!option) {
+    return;
+  }
+  const options = getCustomPartOptionElements();
+  options.forEach(opt => {
+    opt.tabIndex = opt === option ? 0 : -1;
+  });
+  option.focus();
+  if (typeof option.scrollIntoView === 'function') {
+    option.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function openCustomPartPicker() {
+  if (!customPartPicker || !customPartPickerButton || !customPartPickerList) {
+    return;
+  }
+  if (customPartPickerButton.disabled) {
+    return;
+  }
+  if (customPartPickerOpen) {
+    return;
+  }
+  customPartPickerOpen = true;
+  customPartPicker.classList.add('is-open');
+  customPartPickerList.hidden = false;
+  customPartPickerButton.setAttribute('aria-expanded', 'true');
+  syncCustomPartPicker({ isValid: true });
+
+  const options = getCustomPartOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const currentValue = typeof state.customPartId === 'string' ? state.customPartId : '';
+  const selectedOption = options.find(option => option.dataset.value === currentValue);
+  focusCustomPartOption(selectedOption || options[0]);
+}
+
+function closeCustomPartPicker({ focusButton = false } = {}) {
+  if (!customPartPicker || !customPartPickerButton || !customPartPickerList) {
+    return;
+  }
+  if (!customPartPickerOpen) {
+    if (focusButton && !customPartPickerButton.disabled) {
+      customPartPickerButton.focus();
+    }
+    return;
+  }
+  customPartPickerOpen = false;
+  customPartPicker.classList.remove('is-open');
+  customPartPickerList.hidden = true;
+  customPartPickerButton.setAttribute('aria-expanded', 'false');
+  if (focusButton && !customPartPickerButton.disabled) {
+    customPartPickerButton.focus();
+  }
+}
+
+function toggleCustomPartPicker() {
+  if (customPartPickerOpen) {
+    closeCustomPartPicker({ focusButton: false });
+  } else {
+    openCustomPartPicker();
+  }
+}
+
+function moveCustomPartOption(delta) {
+  if (!customPartPickerList) {
+    return;
+  }
+  const options = getCustomPartOptionElements();
+  if (options.length === 0) {
+    return;
+  }
+  const active = document.activeElement;
+  const activeOption = active && customPartPickerList.contains(active)
+    ? active.closest('[role="option"]')
+    : null;
+  let index = activeOption ? options.indexOf(activeOption) : -1;
+  if (index === -1) {
+    const currentValue = typeof state.customPartId === 'string' ? state.customPartId : '';
+    index = options.findIndex(option => option.dataset.value === currentValue);
+  }
+  let nextIndex = index + delta;
+  if (nextIndex < 0) {
+    nextIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    nextIndex = 0;
+  }
+  const nextOption = options[nextIndex];
+  if (nextOption) {
+    focusCustomPartOption(nextOption);
+  }
+}
+
+function handleCustomPartButtonKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    openCustomPartPicker();
+    moveCustomPartOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    openCustomPartPicker();
+    moveCustomPartOption(-1);
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    toggleCustomPartPicker();
+  }
+}
+
+function handleCustomPartListKeydown(event) {
+  const { key } = event;
+  if (key === 'ArrowDown') {
+    event.preventDefault();
+    moveCustomPartOption(1);
+    return;
+  }
+  if (key === 'ArrowUp') {
+    event.preventDefault();
+    moveCustomPartOption(-1);
+    return;
+  }
+  if (key === 'Home') {
+    event.preventDefault();
+    const options = getCustomPartOptionElements();
+    if (options.length > 0) {
+      focusCustomPartOption(options[0]);
+    }
+    return;
+  }
+  if (key === 'End') {
+    event.preventDefault();
+    const options = getCustomPartOptionElements();
+    if (options.length > 0) {
+      focusCustomPartOption(options[options.length - 1]);
+    }
+    return;
+  }
+  if (key === 'Enter' || key === ' ' || key === 'Spacebar' || key === 'Space') {
+    event.preventDefault();
+    const target = event.target;
+    if (target && target instanceof HTMLElement) {
+      const option = target.closest('[role="option"]');
+      if (option) {
+        setCustomGraphicSource('parts');
+        setCustomPartSelection(option.dataset.value || '');
+        closeCustomPartPicker({ focusButton: true });
+      }
+    }
+    return;
+  }
+  if (key === 'Escape') {
+    event.preventDefault();
+    closeCustomPartPicker({ focusButton: true });
+    return;
+  }
+  if (key === 'Tab') {
+    closeCustomPartPicker();
+  }
+}
+
+function handleCustomPartListClick(event) {
+  if (!customPartPickerList) {
+    return;
+  }
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  const option = target.closest('[role="option"]');
+  if (!option || !customPartPickerList.contains(option)) {
+    return;
+  }
+  event.preventDefault();
+  setCustomGraphicSource('parts');
+  setCustomPartSelection(option.dataset.value || '');
+  closeCustomPartPicker({ focusButton: true });
+}
+
+function handleCustomPartListFocusOut() {
+  if (!customPartPickerOpen) {
+    return;
+  }
+  setTimeout(() => {
+    if (!customPartPickerOpen) {
+      return;
+    }
+    if (!customPartPicker) {
+      closeCustomPartPicker();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || !customPartPicker.contains(active)) {
+      closeCustomPartPicker();
     }
   }, 0);
 }
@@ -4942,6 +5157,11 @@ function handleDocumentPointer(event) {
       closeCustomIconPicker();
     }
   }
+  if (customPartPickerOpen && customPartPicker) {
+    if (!(target instanceof Node) || !customPartPicker.contains(target)) {
+      closeCustomPartPicker();
+    }
+  }
 }
 
 function handleDocumentFocusIn(event) {
@@ -5019,6 +5239,11 @@ function handleDocumentFocusIn(event) {
   if (customIconPickerOpen && customIconPicker) {
     if (!(target instanceof Node) || !customIconPicker.contains(target)) {
       closeCustomIconPicker();
+    }
+  }
+  if (customPartPickerOpen && customPartPicker) {
+    if (!(target instanceof Node) || !customPartPicker.contains(target)) {
+      closeCustomPartPicker();
     }
   }
 }
@@ -5395,12 +5620,6 @@ export function initEventHandlers() {
     });
   }
 
-  if (customIconStyleSelect) {
-    customIconStyleSelect.addEventListener('change', () => {
-      setCustomIconStyle(customIconStyleSelect.value);
-    });
-  }
-
   if (customIconSearchInput) {
     let iconSearchTimeoutId = 0;
     const scheduleIconSearch = () => {
@@ -5422,7 +5641,7 @@ export function initEventHandlers() {
     customIconSelect.addEventListener('change', () => {
       const selected = customIconSelect.selectedOptions[0];
       if (!selected) {
-        setCustomIconSelection({ name: '', unicode: '', label: '', style: customIconStyleSelect ? customIconStyleSelect.value : undefined });
+        setCustomIconSelection({ name: '', unicode: '', label: '', style: 'solid' });
         closeCustomIconPicker();
         return;
       }
@@ -5430,10 +5649,28 @@ export function initEventHandlers() {
         name: selected.value,
         unicode: selected.dataset.unicode || '',
         label: selected.dataset.label || selected.textContent || selected.value,
-        style: selected.dataset.style || (customIconStyleSelect ? customIconStyleSelect.value : undefined),
+        style: selected.dataset.style || 'solid',
       });
       closeCustomIconPicker();
     });
+  }
+
+  if (customPartSelect) {
+    customPartSelect.addEventListener('change', () => {
+      setCustomGraphicSource('parts');
+      setCustomPartSelection(customPartSelect.value);
+    });
+  }
+
+  if (customPartPickerButton && customPartPickerList) {
+    customPartPickerButton.addEventListener('click', event => {
+      event.preventDefault();
+      toggleCustomPartPicker();
+    });
+    customPartPickerButton.addEventListener('keydown', handleCustomPartButtonKeydown);
+    customPartPickerList.addEventListener('click', handleCustomPartListClick);
+    customPartPickerList.addEventListener('keydown', handleCustomPartListKeydown);
+    customPartPickerList.addEventListener('focusout', handleCustomPartListFocusOut);
   }
 
   if (customImageInput) {
@@ -5604,7 +5841,8 @@ export function initEventHandlers() {
     bearingTypePicker ||
     connectorCategoryPicker ||
     connectorSeriesPicker ||
-    customIconPicker
+    customIconPicker ||
+    customPartPicker
   ) {
     document.addEventListener('pointerdown', handleDocumentPointer);
     document.addEventListener('focusin', handleDocumentFocusIn);

--- a/js/forms.js
+++ b/js/forms.js
@@ -142,7 +142,6 @@ const {
   customImageClearButton,
   customImageNameDisplay,
   customIconFields,
-  customIconStyleSelect,
   customIconSearchInput,
   customIconSelect,
   customIconPicker,
@@ -150,6 +149,12 @@ const {
   customIconPickerList,
   customIconStatus,
   customIconPreview,
+  customPartFields,
+  customPartPicker,
+  customPartPickerButton,
+  customPartPickerList,
+  customPartSelect,
+  customPartStatus,
   notesField,
   standardField,
   boltStandardGroup,
@@ -220,7 +225,7 @@ const validBoltHeadIds = new Set(
 );
 const NUT_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validNutTypeIds = new Set(nutTypeOptions.map(option => option.id));
-const CUSTOM_GRAPHIC_SOURCES = new Set(['image', 'icon']);
+const CUSTOM_GRAPHIC_SOURCES = new Set(['image', 'icon', 'parts']);
 const DEFAULT_CUSTOM_GRAPHIC_SOURCE = 'image';
 const DEFAULT_ICON_STYLE = 'solid';
 const CUSTOM_ICON_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -231,6 +236,11 @@ const FONT_AWESOME_STYLE_CLASSES = {
 };
 let customIconRequestId = 0;
 let lastIconCollection = { style: '', total: 0 };
+const CUSTOM_PART_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
+const partGraphicOptions = Object.entries(hardwareTypeImageMap)
+  .map(([id, src]) => ({ id, label: id, image: src }))
+  .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+const validCustomPartIds = new Set(partGraphicOptions.map(option => option.id));
 const WASHER_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validWasherTypeIds = new Set(washerTypeOptions.map(option => option.id));
 const SWITCH_TYPE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -690,6 +700,170 @@ export function populateHardwareTypePicker() {
   }
 
   syncHardwareTypePicker();
+}
+
+function getCustomPartOption(partId) {
+  if (!partId) {
+    return null;
+  }
+  return partGraphicOptions.find(option => option.id === partId) || null;
+}
+
+export function populateCustomPartPicker() {
+  if (!customPartSelect) {
+    return;
+  }
+
+  customPartSelect.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = CUSTOM_PART_PLACEHOLDER_TEXT;
+  customPartSelect.appendChild(placeholder);
+
+  partGraphicOptions.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    opt.dataset.image = option.image || '';
+    customPartSelect.appendChild(opt);
+  });
+
+  if (customPartPickerList) {
+    customPartPickerList.innerHTML = '';
+    partGraphicOptions.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.id;
+      item.dataset.label = option.label;
+      item.dataset.image = option.image || '';
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
+
+      const iconWrapper = document.createElement('span');
+      iconWrapper.className = option.image
+        ? 'bolt-drive-picker__option-icon'
+        : 'bolt-drive-picker__option-icon is-empty';
+      iconWrapper.setAttribute('aria-hidden', 'true');
+
+      if (option.image) {
+        const img = document.createElement('img');
+        img.className = 'bolt-drive-picker__option-icon-image';
+        img.src = option.image;
+        img.alt = '';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        iconWrapper.appendChild(img);
+      }
+
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+
+      item.appendChild(iconWrapper);
+      item.appendChild(label);
+      customPartPickerList.appendChild(item);
+    });
+  }
+
+  if (customPartPickerButton) {
+    customPartPickerButton.disabled = partGraphicOptions.length === 0;
+    customPartPickerButton.setAttribute('aria-expanded', 'false');
+  }
+
+  syncCustomPartPicker({ isValid: true });
+}
+
+export function syncCustomPartPicker({ isValid = true } = {}) {
+  if (!customPartSelect) {
+    return;
+  }
+
+  const currentValue = typeof state.customPartId === 'string' ? state.customPartId : '';
+  const sanitizedValue = validCustomPartIds.has(currentValue) ? currentValue : '';
+  if (sanitizedValue !== currentValue) {
+    state.customPartId = sanitizedValue;
+  }
+
+  customPartSelect.value = sanitizedValue;
+  if (!sanitizedValue && customPartSelect.options.length > 0) {
+    customPartSelect.selectedIndex = 0;
+  }
+
+  const selectedOption = getCustomPartOption(sanitizedValue);
+
+  if (customPartPickerButton) {
+    const label = customPartPickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = customPartPickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = customPartPickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+
+    if (label) {
+      label.textContent = selectedOption ? selectedOption.label : CUSTOM_PART_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (selectedOption && selectedOption.image) {
+        iconImage.src = selectedOption.image;
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+      }
+    }
+
+    if (isValid) {
+      customPartPickerButton.classList.remove('is-invalid');
+      customPartPickerButton.removeAttribute('aria-invalid');
+    } else {
+      customPartPickerButton.classList.add('is-invalid');
+      customPartPickerButton.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  if (customPartPicker) {
+    customPartPicker.classList.toggle('is-invalid', !isValid);
+  }
+
+  if (customPartPickerList) {
+    const items = Array.from(customPartPickerList.querySelectorAll('[role="option"]'));
+    items.forEach(item => {
+      const isSelected = item.dataset.value === sanitizedValue;
+      item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      item.classList.toggle('is-selected', isSelected);
+      item.tabIndex = -1;
+    });
+  }
+
+  if (customPartStatus) {
+    if (selectedOption) {
+      customPartStatus.textContent = `${selectedOption.label} icon selected.`;
+      customPartStatus.classList.remove('text-danger');
+    } else {
+      customPartStatus.textContent = 'No built-in part icon selected.';
+      customPartStatus.classList.remove('text-danger');
+    }
+  }
+}
+
+export function setCustomPartSelection(nextId, { triggerUpdate = true } = {}) {
+  const desiredValue = typeof nextId === 'string' ? nextId.trim() : '';
+  const sanitizedValue = validCustomPartIds.has(desiredValue) ? desiredValue : '';
+  const previousValue = typeof state.customPartId === 'string' ? state.customPartId : '';
+
+  state.customPartId = sanitizedValue;
+  if (sanitizedValue) {
+    state.customGraphicSource = 'parts';
+  }
+  syncCustomPartPicker({ isValid: true });
+  applyCustomGraphicInfoDisplay();
+  updateCustomImageUi();
+
+  if (triggerUpdate && previousValue !== sanitizedValue) {
+    updatePreview();
+    updateDownloadState();
+  }
 }
 
 function resolveComponentMountImage(mountId) {
@@ -3884,9 +4058,8 @@ function normalizeCustomGraphicSource(value) {
 }
 
 function getCurrentIconStyle() {
-  const normalized = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
-  state.customIconStyle = normalized;
-  return normalized;
+  state.customIconStyle = DEFAULT_ICON_STYLE;
+  return DEFAULT_ICON_STYLE;
 }
 
 function setIconSelectEnabled(enabled) {
@@ -3989,7 +4162,7 @@ function resetCustomIconSvgData() {
 }
 
 function refreshSelectedCustomIconAsset() {
-  const style = normalizeIconStyle(state.customIconStyle || DEFAULT_ICON_STYLE);
+  const style = DEFAULT_ICON_STYLE;
   const name = typeof state.customIconName === 'string' ? state.customIconName.trim() : '';
   resetCustomIconSvgData();
   if (!name) {
@@ -4142,17 +4315,16 @@ function setCustomIconStatus(message, { isError = false, isLoading = false } = {
 function applyCustomGraphicInfoDisplay() {
   const source = normalizeCustomGraphicSource(state.customGraphicSource);
   const style = getCurrentIconStyle();
-  if (customIconStyleSelect) {
-    customIconStyleSelect.value = style;
-  }
   if (customImageNameDisplay) {
     let displayText = '';
     if (source === 'image' && state.customImageName) {
       displayText = state.customImageName;
     } else if (source === 'icon' && state.customIconName) {
       const label = state.customIconLabel || state.customIconName;
-      const styleLabel = style.charAt(0).toUpperCase() + style.slice(1);
-      displayText = `${label} · ${styleLabel}`;
+      displayText = label;
+    } else if (source === 'parts' && state.customPartId) {
+      const partOption = getCustomPartOption(state.customPartId);
+      displayText = partOption ? partOption.label : state.customPartId;
     }
     if (displayText) {
       customImageNameDisplay.textContent = displayText;
@@ -4167,8 +4339,11 @@ function applyCustomGraphicInfoDisplay() {
   } else {
     clearCustomIconPreview();
   }
+  if (source === 'parts') {
+    syncCustomPartPicker({ isValid: true });
+  }
   if (customIconSelect) {
-    if (source === 'icon' && state.customIconName && state.customIconStyle === style) {
+    if (source === 'icon' && state.customIconName) {
       customIconSelect.value = state.customIconName;
     } else if (source !== 'icon') {
       customIconSelect.value = '';
@@ -4290,7 +4465,7 @@ export async function refreshCustomIconOptions({ preserveSelection = true } = {}
           ? `Showing ${filtered.length.toLocaleString()} icons.`
           : `Showing ${filtered.length.toLocaleString()} of ${total.toLocaleString()} icons.`;
       setCustomIconStatus(message);
-      if (preserveSelection && state.customIconName && state.customIconStyle === style) {
+      if (preserveSelection && state.customIconName) {
         customIconSelect.value = state.customIconName;
         if (customIconSelect.selectedIndex === -1) {
           state.customIconName = '';
@@ -4347,30 +4522,8 @@ export function setCustomGraphicSource(source, options = {}) {
   }
 }
 
-export function setCustomIconStyle(style, { preserveSelection = true } = {}) {
-  const normalized = normalizeIconStyle(style || DEFAULT_ICON_STYLE);
-  if (state.customIconStyle === normalized) {
-    refreshCustomIconOptions({ preserveSelection });
-    applyCustomGraphicInfoDisplay();
-    return;
-  }
-  state.customIconStyle = normalized;
-  if (!preserveSelection) {
-    state.customIconName = '';
-    state.customIconUnicode = '';
-    state.customIconLabel = '';
-    resetCustomIconSvgData();
-  } else {
-    refreshSelectedCustomIconAsset();
-  }
-  refreshCustomIconOptions({ preserveSelection });
-  applyCustomGraphicInfoDisplay();
-  updateDownloadState();
-  updatePreview();
-}
-
 export function setCustomIconSelection(icon = {}) {
-  const style = normalizeIconStyle(icon.style || state.customIconStyle || DEFAULT_ICON_STYLE);
+  const style = DEFAULT_ICON_STYLE;
   const name = typeof icon.name === 'string' ? icon.name : '';
   const unicode = typeof icon.unicode === 'string' ? icon.unicode : '';
   const label = typeof icon.label === 'string' && icon.label.trim().length > 0 ? icon.label : name;
@@ -4387,7 +4540,7 @@ export function setCustomIconSelection(icon = {}) {
         if (!record) {
           return;
         }
-        if (state.customIconName !== record.name || state.customIconStyle !== record.style) {
+        if (state.customIconName !== record.name) {
           return;
         }
         state.customIconUnicode = record.unicode;
@@ -4436,12 +4589,23 @@ export function updateCustomImageUi() {
   if (customIconFields) {
     customIconFields.classList.toggle('d-none', source !== 'icon');
   }
+  if (customPartFields) {
+    customPartFields.classList.toggle('d-none', source !== 'parts');
+  }
   const hasImage = source === 'image' && Boolean(state.customImageData);
   const hasIcon =
     source === 'icon' && Boolean(state.customIconUnicode || state.customIconSvgData);
+  const hasPart = source === 'parts' && Boolean(state.customPartId);
   if (customImageClearButton) {
-    const label = source === 'icon' ? 'Remove icon' : 'Remove image';
-    customImageClearButton.disabled = !(hasImage || hasIcon);
+    let label = 'Clear selection';
+    if (source === 'icon') {
+      label = 'Remove icon';
+    } else if (source === 'parts') {
+      label = 'Remove part icon';
+    } else {
+      label = 'Remove image';
+    }
+    customImageClearButton.disabled = !(hasImage || hasIcon || hasPart);
     customImageClearButton.textContent = label;
     customImageClearButton.setAttribute('aria-label', label);
   }
@@ -4461,6 +4625,12 @@ export function updateCustomImageUi() {
       setIconSelectEnabled(enableSelect);
       setIconSearchEnabled(true);
     }
+  } else if (source === 'parts') {
+    setIconControlsBusy(false);
+    setIconSelectEnabled(false);
+    setIconSearchEnabled(false);
+    setCustomIconStatus('');
+    syncCustomPartPicker({ isValid: true });
   } else {
     setIconControlsBusy(false);
     setIconSelectEnabled(false);
@@ -4489,6 +4659,9 @@ export function clearCustomImage({ resetInput = true } = {}) {
       customIconSelect.value = '';
       customIconSelect.selectedIndex = -1;
     }
+  } else if (source === 'parts') {
+    state.customPartId = '';
+    syncCustomPartPicker({ isValid: true });
   } else {
     state.customImageData = '';
     state.customImageName = '';

--- a/js/render.js
+++ b/js/render.js
@@ -939,7 +939,11 @@ function resolveHardwareImageInfo() {
     return null;
   }
   if (state.hardwareType === 'Custom') {
-    const source = state.customGraphicSource === 'icon' ? 'icon' : 'image';
+    const source = state.customGraphicSource === 'icon'
+      ? 'icon'
+      : state.customGraphicSource === 'parts'
+        ? 'parts'
+        : 'image';
     if (source === 'icon') {
       const hasIcon = Boolean(
         state.customIconName && (state.customIconSvgData || state.customIconUnicode),
@@ -949,9 +953,22 @@ function resolveHardwareImageInfo() {
         hasIcon,
         iconName: state.customIconName || '',
         iconUnicode: state.customIconUnicode || '',
-        iconStyle: state.customIconStyle || 'solid',
+        iconStyle: 'solid',
         iconLabel: state.customIconLabel || state.customIconName || 'Custom icon',
         iconSvgData: state.customIconSvgData || '',
+      };
+    }
+    if (source === 'parts') {
+      const partId = typeof state.customPartId === 'string' ? state.customPartId.trim() : '';
+      const imageSrc = partId ? hardwareTypeImageMap[partId] || '' : '';
+      if (!imageSrc) {
+        return null;
+      }
+      const altLabel = partId || 'Custom part icon';
+      return {
+        type: 'photo',
+        src: imageSrc,
+        alt: `${altLabel} illustration`,
       };
     }
     const hasImage = Boolean(state.customImageData);
@@ -1661,7 +1678,7 @@ function resolveComponentPartType(hardwareType) {
   return { partType, partLabel: label };
 }
 
-function resolveSubPartEntries(hardwareType, partType, partLabel) {
+function resolveSubPartEntries(hardwareType, partType) {
   const entries = [];
   let activeEntry = null;
 
@@ -1728,7 +1745,7 @@ function resolveLayoutPartContext() {
   let activeScope = hierarchy[0];
 
   if (partType) {
-    const { entries, activeEntry } = resolveSubPartEntries(hardwareType, partType, partLabel);
+    const { entries, activeEntry } = resolveSubPartEntries(hardwareType, partType);
     const partEntry = { label: partLabel || partType, partType, subPartType: null };
     if (entries.length > 0) {
       partEntry.children = entries.map(entry => ({ ...entry }));

--- a/js/state.js
+++ b/js/state.js
@@ -45,6 +45,7 @@ export const state = {
   customIconSvgData: '',
   customImageData: '',
   customImageName: '',
+  customPartId: '',
 };
 
 export const standardFilterState = {

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -19,6 +19,7 @@ import {
   mosfetPartOptions,
   potentiometerValueOptions,
   potentiometerTaperOptions,
+  hardwareTypeImageMap,
 } from './data.js';
 
 export const SHARE_QUERY_PARAM = 'label';
@@ -67,6 +68,7 @@ const FIELD_MAP = {
   customIconLabel: 'cil',
   customImageData: 'cid',
   customImageName: 'cin',
+  customPartId: 'cpi',
 };
 
 const REVERSE_FIELD_MAP = Object.entries(FIELD_MAP).reduce((acc, [key, code]) => {
@@ -122,7 +124,7 @@ const boltHeadIds = new Set(
   boltHeadOptions.concat(screwTypeOptions).map(option => option.id),
 );
 const boltDriveIds = new Set(boltDriveOptions.map(option => option.id));
-const iconStyleOptions = new Set(['solid', 'regular', 'brands']);
+const customPartOptionSet = new Set(Object.keys(hardwareTypeImageMap));
 
 function encodeToBase64Url(input) {
   const encoder = new TextEncoder();
@@ -267,15 +269,22 @@ function sanitizeCustomGraphicSource(value) {
     return 'image';
   }
   const normalized = value.trim().toLowerCase();
-  return normalized === 'icon' ? 'icon' : 'image';
+  if (normalized === 'icon' || normalized === 'parts') {
+    return normalized;
+  }
+  return 'image';
 }
 
-function sanitizeIconStyle(value) {
+function sanitizeIconStyle() {
+  return 'solid';
+}
+
+function sanitizeCustomPartId(value) {
   if (typeof value !== 'string') {
-    return 'solid';
+    return '';
   }
-  const normalized = value.trim().toLowerCase();
-  return iconStyleOptions.has(normalized) ? normalized : 'solid';
+  const trimmed = value.trim();
+  return customPartOptionSet.has(trimmed) ? trimmed : '';
 }
 
 function sanitizeWidth(value) {
@@ -550,6 +559,9 @@ function applyExpandedPayload(expanded) {
   }
   if (typeof expanded.customImageName === 'string') {
     state.customImageName = sanitizeCustomImageName(expanded.customImageName);
+  }
+  if (typeof expanded.customPartId === 'string') {
+    state.customPartId = sanitizeCustomPartId(expanded.customPartId);
   }
 }
 


### PR DESCRIPTION
## Summary
- add the new "parts" source option and bolt-drive style picker for reusing built-in artwork in the custom graphics panel
- register the picker in the DOM registry, hydrate it from state, and persist selections through rendering and share URLs while fixing icon style handling
- wire up events for the parts picker and ensure icon selections always force the solid Font Awesome set

## Testing
- npm run lint *(fails: existing unused-variable errors in js/label/layoutPresets.js and js/label/renderLabelSVG.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2eb5f037c8329861b9cdd4a770c06