### PR TITLE
Allow custom labels when either line is filled

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,11 +513,8 @@
                       id="custom-line1-input"
                       placeholder="e.g., 5 mm Drill Bits"
                       maxlength="60"
-                      aria-describedby="custom-line1-hint custom-line1-message"
+                      aria-describedby="custom-line1-message"
                     />
-                    <div class="form-text" id="custom-line1-hint">
-                      Shown as the large title on the label.
-                    </div>
                     <div
                       id="custom-line1-message"
                       class="validation-message text-danger small mt-2 d-none"

--- a/js/events.js
+++ b/js/events.js
@@ -5603,6 +5603,7 @@ export function initEventHandlers() {
   if (customLine2Input) {
     customLine2Input.addEventListener('input', () => {
       state.customLine2 = customLine2Input.value;
+      updateDownloadState();
       updatePreview();
     });
   }

--- a/js/render.js
+++ b/js/render.js
@@ -367,7 +367,9 @@ export function isLabelReady() {
     return Boolean(state.connectorCategory);
   }
   if (state.hardwareType === 'Custom') {
-    return Boolean(state.customLine1 && state.customLine1.trim());
+    const hasLine1 = Boolean((state.customLine1 || '').trim());
+    const hasLine2 = Boolean((state.customLine2 || '').trim());
+    return hasLine1 || hasLine2;
   }
   if (state.hardwareType === 'Bearing') {
     return Boolean(state.bearingType);
@@ -815,8 +817,9 @@ function applyValidationFeedback() {
   }
 
   if (hardwareType === 'Custom') {
-    const title = (state.customLine1 || '').trim();
-    const valid = title.length > 0;
+    const line1 = (state.customLine1 || '').trim();
+    const line2 = (state.customLine2 || '').trim();
+    const valid = line1.length > 0 || line2.length > 0;
     updateInputFieldState({
       input: customLine1Input,
       container: customLine1Field,
@@ -1308,8 +1311,11 @@ function buildTextLines() {
   };
 
   if (state.hardwareType === 'Custom') {
-    const line1 = (state.customLine1 || '').trim() || 'Custom Label';
-    const line2 = (state.customLine2 || '').trim();
+    const line1Value = (state.customLine1 || '').trim();
+    const line2Value = (state.customLine2 || '').trim();
+    const hasAnyCustomText = line1Value.length > 0 || line2Value.length > 0;
+    const line1 = hasAnyCustomText ? line1Value : 'Custom Label';
+    const line2 = line2Value;
     return applyTextVisibility({ line1, line2, line3: '' });
   }
 


### PR DESCRIPTION
## Summary
- remove the custom top-line hint so the UI no longer implies it is required
- allow custom labels to validate when either line has text and only fall back to the default when both are empty
- refresh the download button state when the second custom line is edited

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f25275788329badeeb7ba1b53bd1