### PR TITLE
Remove switch type helper text

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -531,7 +531,6 @@ function applyValidationFeedback() {
         container: switchTypeContainer,
         messageElement: switchTypeMessage,
         valid: switchValid,
-        message: switchValid ? '' : 'Select a switch type',
       });
       syncSwitchTypePicker({ isValid: switchValid });
     } else {


### PR DESCRIPTION
## Summary
- stop rendering the switch type validation helper text while still toggling invalid styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f4b13f4c83298fd495d13c9a5ce9