### PR TITLE
Update MOSFET SMD asset reference

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -138,7 +138,7 @@ export const componentImageMap = {
   },
   MOSFET: {
     'Through-Hole': 'images/mosfet/mosfet.svg',
-    SMD: 'images/mosfet/mosfet.svg',
+    SMD: 'images/mosfet/mosfet_smd.svg',
     default: 'images/mosfet/mosfet.svg',
   },
 };

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
+  componentImageMap,
   fuseTypeOptions,
   fuseValues,
   mosfetChannelOptions,
@@ -336,6 +337,10 @@ describe('fuse type selection behaviour', () => {
 });
 
 describe('MOSFET option data', () => {
+  it('uses dedicated artwork for the MOSFET SMD mount', () => {
+    expect(componentImageMap.MOSFET.SMD).toBe('images/mosfet/mosfet_smd.svg');
+  });
+
   it('provides shared artwork for each MOSFET channel type option', () => {
     expect(mosfetChannelOptions).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- update the MOSFET SMD image reference to use the dedicated mosfet_smd.svg asset
- extend the MOSFET option data tests to cover the SMD artwork mapping

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e300da7d888329a0d4d1d45c73140f