### PR TITLE
Fix MOSFET SMD artwork reference

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -336,7 +336,7 @@ export const mosfetPartOptions = [
     label: 'IRLZ44N Logic-Level MOSFET',
     image: 'images/mosfet/mosfet.svg',
   },
-  { id: 'AO3400A', label: 'AO3400A MOSFET', image: 'images/mosfet/mosfet.svg' },
+  { id: 'AO3400A', label: 'AO3400A MOSFET', image: 'images/mosfet/mosfet_smd.svg' },
   { id: 'BS170', label: 'BS170 MOSFET', image: 'images/mosfet/mosfet.svg' },
   { id: 'IRF520', label: 'IRF520 MOSFET', image: 'images/mosfet/mosfet.svg' },
   { id: 'FQP30N06L', label: 'FQP30N06L MOSFET', image: 'images/mosfet/mosfet.svg' },

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -351,12 +351,19 @@ describe('MOSFET option data', () => {
   });
 
   it('includes popular MOSFET part numbers with matching art', () => {
-    const ids = mosfetPartOptions.map(option => option.id);
-    expect(ids).toEqual(
-      expect.arrayContaining(['IRLZ44N', 'AO3400A', 'BS170', 'IRF520', 'FQP30N06L']),
-    );
+    const expectedImages = {
+      IRLZ44N: 'images/mosfet/mosfet.svg',
+      AO3400A: 'images/mosfet/mosfet_smd.svg',
+      BS170: 'images/mosfet/mosfet.svg',
+      IRF520: 'images/mosfet/mosfet.svg',
+      FQP30N06L: 'images/mosfet/mosfet.svg',
+    };
+
+    const ids = mosfetPartOptions.map(option => option.id).sort();
+    expect(ids).toEqual(Object.keys(expectedImages).sort());
+
     mosfetPartOptions.forEach(option => {
-      expect(option.image).toBe('images/mosfet/mosfet.svg');
+      expect(option.image).toBe(expectedImages[option.id]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- update the AO3400A MOSFET preset to use the dedicated SMD artwork
- refresh the MOSFET part option test to assert the specific art per device, including the SMD variant

## Testing
- `npx --node-options=--experimental-vm-modules jest test/forms.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68e302daf67c83298c2e1edd9cdde7a7