### PR TITLE
Refine MOSFET label rendering

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -334,12 +334,33 @@ export const mosfetPartOptions = [
   {
     id: 'IRLZ44N',
     label: 'IRLZ44N Logic-Level MOSFET',
+    shortLabel: 'IRLZ44N',
     image: 'images/mosfet/mosfet.svg',
   },
-  { id: 'AO3400A', label: 'AO3400A MOSFET', image: 'images/mosfet/mosfet_smd.svg' },
-  { id: 'BS170', label: 'BS170 MOSFET', image: 'images/mosfet/mosfet.svg' },
-  { id: 'IRF520', label: 'IRF520 MOSFET', image: 'images/mosfet/mosfet.svg' },
-  { id: 'FQP30N06L', label: 'FQP30N06L MOSFET', image: 'images/mosfet/mosfet.svg' },
+  {
+    id: 'AO3400A',
+    label: 'AO3400A MOSFET',
+    shortLabel: 'AO3400A',
+    image: 'images/mosfet/mosfet_smd.svg',
+  },
+  {
+    id: 'BS170',
+    label: 'BS170 MOSFET',
+    shortLabel: 'BS170',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  {
+    id: 'IRF520',
+    label: 'IRF520 MOSFET',
+    shortLabel: 'IRF520',
+    image: 'images/mosfet/mosfet.svg',
+  },
+  {
+    id: 'FQP30N06L',
+    label: 'FQP30N06L MOSFET',
+    shortLabel: 'FQP30N06L',
+    image: 'images/mosfet/mosfet.svg',
+  },
 ];
 
 export const mosfetChannelLabelMap = mosfetChannelOptions.reduce((map, option) => {
@@ -349,6 +370,11 @@ export const mosfetChannelLabelMap = mosfetChannelOptions.reduce((map, option) =
 
 export const mosfetPartLabelMap = mosfetPartOptions.reduce((map, option) => {
   map[option.id] = option.label;
+  return map;
+}, {});
+
+export const mosfetPartShortLabelMap = mosfetPartOptions.reduce((map, option) => {
+  map[option.id] = option.shortLabel || option.id;
   return map;
 }, {});
 

--- a/js/render.js
+++ b/js/render.js
@@ -38,7 +38,7 @@ import {
   componentImageMap,
   diodeValueLabelMap,
   mosfetChannelLabelMap,
-  mosfetPartLabelMap,
+  mosfetPartShortLabelMap,
 } from './data.js';
 import {
   renderLabelSVG,
@@ -1383,8 +1383,8 @@ function buildTextLines() {
       const channelId = state.mosfetChannel || '';
       const partId = state.mosfetPart || '';
       const channelLabel = channelId ? mosfetChannelLabelMap[channelId] || channelId : '';
-      const partLabel = partId ? mosfetPartLabelMap[partId] || partId : '';
-      const line1 = partLabel || 'MOSFET';
+      const partNumber = partId ? mosfetPartShortLabelMap[partId] || partId : '';
+      const line1 = partNumber || 'MOSFET';
       const line2Parts = [];
       if (channelLabel) {
         line2Parts.push(channelLabel);


### PR DESCRIPTION
## Summary
- add short MOSFET part metadata so dropdowns retain descriptive labels while previews can show plain part numbers
- update MOSFET label rendering to reference the short label map and remove the redundant “MOSFET” suffix from the preview

## Testing
- npm run lint *(fails: existing no-unused-vars violations in layoutPresets.js and renderLabelSVG.js)*
- node --input-type=module <<'NODE'
import { mosfetPartOptions, mosfetPartShortLabelMap } from './js/data.js';

const results = mosfetPartOptions.map(option => ({
  id: option.id,
  label: option.label,
  shortLabel: mosfetPartShortLabelMap[option.id],
}));

console.table(results);
NODE


------
https://chatgpt.com/codex/tasks/task_e_68e305fbccfc8329ad82396e8138a7b7