### PR TITLE
Reorder MOSFET part and channel fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,53 +770,6 @@
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>
-                    <div class="col-12 col-lg-6 d-none" id="mosfet-channel-field" aria-hidden="true">
-                      <label class="form-label fw-semibold" for="mosfet-channel-picker-button"
-                        >MOSFET Channel Type</label
-                      >
-                      <div class="bolt-drive-picker" id="mosfet-channel-picker">
-                        <select
-                          id="mosfet-channel-select"
-                          class="visually-hidden"
-                          aria-labelledby="mosfet-channel-picker-button"
-                        >
-                          <option value="">&nbsp;</option>
-                        </select>
-                        <button
-                          type="button"
-                          class="bolt-drive-picker__button"
-                          id="mosfet-channel-picker-button"
-                          aria-haspopup="listbox"
-                          aria-expanded="false"
-                          aria-controls="mosfet-channel-picker-list"
-                          disabled
-                        >
-                          <span class="bolt-drive-picker__current">
-                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
-                              <img
-                                class="bolt-drive-picker__current-icon-image"
-                                src=""
-                                alt=""
-                                hidden
-                              />
-                            </span>
-                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
-                          </span>
-                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
-                        </button>
-                        <ul
-                          class="bolt-drive-picker__list"
-                          id="mosfet-channel-picker-list"
-                          role="listbox"
-                          aria-labelledby="mosfet-channel-picker-button"
-                          hidden
-                        ></ul>
-                      </div>
-                      <div
-                        id="mosfet-channel-message"
-                        class="validation-message text-danger small mt-2 d-none"
-                      ></div>
-                    </div>
                     <div class="col-12 col-lg-6 d-none" id="mosfet-part-field" aria-hidden="true">
                       <label class="form-label fw-semibold" for="mosfet-part-picker-button"
                         >MOSFET Part Number</label
@@ -861,6 +814,53 @@
                       </div>
                       <div
                         id="mosfet-part-message"
+                        class="validation-message text-danger small mt-2 d-none"
+                      ></div>
+                    </div>
+                    <div class="col-12 col-lg-6 d-none" id="mosfet-channel-field" aria-hidden="true">
+                      <label class="form-label fw-semibold" for="mosfet-channel-picker-button"
+                        >MOSFET Channel Type</label
+                      >
+                      <div class="bolt-drive-picker" id="mosfet-channel-picker">
+                        <select
+                          id="mosfet-channel-select"
+                          class="visually-hidden"
+                          aria-labelledby="mosfet-channel-picker-button"
+                        >
+                          <option value="">&nbsp;</option>
+                        </select>
+                        <button
+                          type="button"
+                          class="bolt-drive-picker__button"
+                          id="mosfet-channel-picker-button"
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="mosfet-channel-picker-list"
+                          disabled
+                        >
+                          <span class="bolt-drive-picker__current">
+                            <span class="bolt-drive-picker__current-icon is-empty" aria-hidden="true">
+                              <img
+                                class="bolt-drive-picker__current-icon-image"
+                                src=""
+                                alt=""
+                                hidden
+                              />
+                            </span>
+                            <span class="bolt-drive-picker__current-label">&nbsp;</span>
+                          </span>
+                          <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>
+                        </button>
+                        <ul
+                          class="bolt-drive-picker__list"
+                          id="mosfet-channel-picker-list"
+                          role="listbox"
+                          aria-labelledby="mosfet-channel-picker-button"
+                          hidden
+                        ></ul>
+                      </div>
+                      <div
+                        id="mosfet-channel-message"
                         class="validation-message text-danger small mt-2 d-none"
                       ></div>
                     </div>


### PR DESCRIPTION
## Summary
- move the MOSFET part number field before the channel type field within the part details grid so the part picker appears first

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30d4476e88329b34da665e3183037