### PR TITLE
Remove icons from text toggle labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1599,7 +1599,6 @@
                         class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
                         for="text-main-toggle"
                       >
-                        <i class="fa-solid fa-heading text-secondary" aria-hidden="true"></i>
                         <span>Primary Text</span>
                       </label>
                       <div class="form-check form-switch m-0 ps-0">
@@ -1619,7 +1618,6 @@
                         class="d-flex align-items-center gap-2 fw-semibold text-body mb-0"
                         for="text-info-toggle"
                       >
-                        <i class="fa-solid fa-circle-info text-secondary" aria-hidden="true"></i>
                         <span>Additional Info</span>
                       </label>
                       <div class="form-check form-switch m-0 ps-0">


### PR DESCRIPTION
## Summary
- remove the font awesome icons from the primary and additional text toggle labels so the switches show text only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3193972ec832984e778a2a2f8c033