### PR TITLE
Allow bolt label subtitles to include notes

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1064,6 +1064,40 @@ function buildSubtitleCandidates(textLines, preset) {
   if (baseCandidate.length > 0) {
     candidates.push(baseCandidate);
   }
+  const expandedCandidate = [];
+  let hasExpansion = false;
+  const splitSeparators = [' • ', ' · ', ' \u00b7 '];
+  for (const entry of baseCandidate) {
+    if (!entry || !entry.text) {
+      continue;
+    }
+    const separator = splitSeparators.find(token => entry.text.includes(token));
+    if (!separator) {
+      expandedCandidate.push(entry);
+      continue;
+    }
+    const parts = entry.text
+      .split(separator)
+      .map(part => part.trim())
+      .filter(Boolean);
+    if (parts.length < 2) {
+      expandedCandidate.push(entry);
+      continue;
+    }
+    hasExpansion = true;
+    for (const part of parts) {
+      const expanded = normalizeLineEntry(
+        { text: part, wrapMode: entry.wrapMode },
+        { defaultWrapMode: entry.wrapMode },
+      );
+      if (expanded) {
+        expandedCandidate.push(expanded);
+      }
+    }
+  }
+  if (hasExpansion && expandedCandidate.length > 0) {
+    candidates.push(expandedCandidate);
+  }
   if (
     textPreset.compact_join_subtitles &&
     line2Entry &&

--- a/js/render.js
+++ b/js/render.js
@@ -1490,8 +1490,25 @@ function buildTextLines() {
     const driveEntry = boltDriveMap.get((state.boltDrive || '').trim());
     const headLabel = headEntry ? headEntry.label : '';
     const driveLabel = driveEntry ? driveEntry.label : '';
+    const notes = (state.notes || '').trim();
+    const subtitleParts = [];
+    if (headLabel) {
+      subtitleParts.push(headLabel);
+    }
+    if (driveLabel) {
+      subtitleParts.push(driveLabel);
+    }
+    let line2 = subtitleParts.join(' • ');
+    let line3 = '';
+    if (notes) {
+      if (line2) {
+        line3 = notes;
+      } else {
+        line2 = notes;
+      }
+    }
     const line1 = pieces.join(' ') || 'Bolt';
-    return applyTextVisibility({ line1, line2: headLabel || '', line3: driveLabel || '' });
+    return applyTextVisibility({ line1, line2, line3 });
   }
 
   if (state.hardwareType === 'Nut') {

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -634,6 +634,78 @@ test('part-specific overrides take precedence over shared height overrides', () 
   }
 });
 
+test('bolt subtitles include head, drive, and notes information', async () => {
+  const stubDocument = {
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    documentElement: { style: { setProperty: () => {} } },
+    createElement: tag => {
+      if (tag === 'canvas') {
+        return {
+          getContext: () => ({
+            drawImage: () => {},
+            clearRect: () => {},
+            scale: () => {},
+          }),
+          toBlob: callback => callback(null),
+        };
+      }
+      return { style: {}, classList: { add: () => {}, remove: () => {}, contains: () => false } };
+    },
+    fonts: {
+      ready: Promise.resolve(),
+      load: () => Promise.resolve(),
+    },
+  };
+  const originalDocument = global.document;
+  try {
+    global.document = stubDocument;
+    const [{ state }, { buildTextLinesForTest }] = await Promise.all([
+      import('../js/state.js'),
+      import('../js/render.js'),
+    ]);
+    const originalState = { ...state };
+    try {
+      Object.assign(state, {
+        hardwareType: 'Bolt',
+        threadSize: 'M6',
+        length: '20 mm',
+        boltHead: 'cap_head',
+        boltDrive: 'hex',
+        notes: 'Use threadlocker',
+        showText: true,
+        showTextMain: true,
+        showTextInfo: true,
+      });
+      const textLines = buildTextLinesForTest();
+      assert.equal(textLines.line1, 'M6 × 20 mm', 'bolt size should appear on the main line');
+      assert.equal(
+        textLines.line2,
+        'Socket Cap • Hex',
+        'head and drive should be combined in the first subtitle line',
+      );
+      assert.equal(textLines.line3, 'Use threadlocker', 'notes should use the remaining subtitle slot');
+      assert.ok(
+        textLines.line2.includes('Socket Cap') && textLines.line2.includes('Hex'),
+        'expected head and drive labels to remain visible after formatting',
+      );
+      assert.ok(
+        [textLines.line2, textLines.line3].some(line => line.includes('Use threadlocker')),
+        'notes should be surfaced in the subtitle lines',
+      );
+    } finally {
+      Object.assign(state, originalState);
+    }
+  } finally {
+    if (originalDocument === undefined) {
+      delete global.document;
+    } else {
+      global.document = originalDocument;
+    }
+  }
+});
+
 test('sub-part overrides merge with part and global overrides', () => {
   clearPresetOverrides();
   try {


### PR DESCRIPTION
## Summary
- combine bolt head and drive subtitles so bolt notes can occupy the remaining slot
- expand subtitle layout candidate generation to split joined entries when needed for wrapping
- add a regression test that stubs DOM access and confirms bolt notes appear in the generated subtitles

## Testing
- node --test test/labelRenderer.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e3202ad16c8329a9aa35f03a9f0112