### PR TITLE
Update thread size picker icon handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1076,7 +1076,14 @@
                           <span
                             class="bolt-drive-picker__current-icon is-empty"
                             aria-hidden="true"
-                          ></span>
+                          >
+                            <img
+                              class="bolt-drive-picker__current-icon-image"
+                              src=""
+                              alt=""
+                              hidden
+                            />
+                          </span>
                           <span class="bolt-drive-picker__current-label">&nbsp;</span>
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>

--- a/js/threadSizes.js
+++ b/js/threadSizes.js
@@ -4,6 +4,7 @@ import {
   metricThreadSizes,
   imperialThreadSizes,
   electricalComponentTypes,
+  hardwareImageFolders,
 } from './data.js';
 import { updatePreview, updateDownloadState } from './render.js';
 
@@ -21,6 +22,30 @@ const THREAD_SIZE_NOT_APPLICABLE_TEXT = 'Not applicable';
 let validThreadSizes = new Set();
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
 
+function updateThreadSizePickerIcon() {
+  if (!threadSizePickerButton) {
+    return;
+  }
+  const iconWrapper = threadSizePickerButton.querySelector('.bolt-drive-picker__current-icon');
+  const iconImage = threadSizePickerButton.querySelector('.bolt-drive-picker__current-icon-image');
+  if (!iconWrapper || !iconImage) {
+    return;
+  }
+
+  const folder = hardwareImageFolders[state.hardwareType];
+  const shouldShowIcon = Boolean(folder) && !threadSizePickerButton.disabled;
+
+  if (shouldShowIcon) {
+    iconImage.src = `images/${folder}/thread_size.svg`;
+    iconImage.hidden = false;
+    iconWrapper.classList.remove('is-empty');
+  } else {
+    iconImage.hidden = true;
+    iconImage.src = '';
+    iconWrapper.classList.add('is-empty');
+  }
+}
+
 function updateThreadSizePickerLabel(text) {
   if (!threadSizePickerButton) {
     return;
@@ -29,10 +54,7 @@ function updateThreadSizePickerLabel(text) {
   if (label) {
     label.textContent = text;
   }
-  const iconWrapper = threadSizePickerButton.querySelector('.bolt-drive-picker__current-icon');
-  if (iconWrapper) {
-    iconWrapper.classList.add('is-empty');
-  }
+  updateThreadSizePickerIcon();
 }
 
 function buildThreadSizeOptionItem(value) {


### PR DESCRIPTION
## Summary
- add an icon image element to the thread size picker button so it matches the other picker structures
- drive the thread size picker icon from the hardware type folder when the control is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3266436d08329a60906883ce87d77