### PR TITLE
Rotate thread size picker icon 90 degrees

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,7 +1078,7 @@
                             aria-hidden="true"
                           >
                             <img
-                              class="bolt-drive-picker__current-icon-image"
+                              class="bolt-drive-picker__current-icon-image is-rotated-90"
                               src=""
                               alt=""
                               hidden


### PR DESCRIPTION
## Summary
- rotate the thread size picker icon by 90 degrees so it displays in the expected orientation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e329dc3a788329a8e6c1cd29c6ad84