### PR TITLE
Fix QR content overflow handling

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -871,6 +871,7 @@ export function updateQrContentVisibility(options = {}) {
   const restoreTransition = animate ? null : temporarilyDisableTransition(qrContentWrapper);
 
   if (!shouldShow) {
+    qrContentWrapper.style.overflow = 'hidden';
     const measuredHeight = qrContentWrapper.scrollHeight;
     if (measuredHeight > 0) {
       qrContentWrapper.style.maxHeight = `${measuredHeight}px`;
@@ -883,6 +884,7 @@ export function updateQrContentVisibility(options = {}) {
   qrContentWrapper.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
 
   if (shouldShow) {
+    qrContentWrapper.style.overflow = 'visible';
     qrContentWrapper.style.removeProperty('max-height');
     qrContentInput.disabled = false;
     qrContentInput.value = state.qrContent || '';

--- a/style.css
+++ b/style.css
@@ -267,7 +267,7 @@ main {
   gap: 0.75rem;
   padding-left: 1rem;
   border-left: 2px solid var(--bs-border-color, rgba(148, 163, 184, 0.35));
-  overflow: hidden;
+  overflow: visible;
   max-height: 400px;
   transition:
     max-height 0.25s ease,
@@ -283,6 +283,7 @@ main {
   border-left-color: transparent;
   max-height: 0;
   padding-left: 0;
+  overflow: hidden;
 }
 
 .label-suboptions.is-collapsed .label-suboption {


### PR DESCRIPTION
## Summary
- let expanded QR content panels use visible overflow while keeping collapsed states clipped
- explicitly toggle the QR content wrapper overflow style when opening and closing the section to protect the close animation

## Testing
- npm run lint *(fails: pre-existing no-unused-vars errors in js/label/layoutPresets.js and js/label/renderLabelSVG.js)*
- python - <<'PY' ... *(verifies desktop and mobile overflow states for QR toggle)*

------
https://chatgpt.com/codex/tasks/task_e_68e33227571c8329b5f5a65bb8dd36f6