### PR TITLE
Fix QR text width calculations

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1166,18 +1166,10 @@ export function layoutText({ textLines, textRect, preset, pxPerMm, qrBounds }) {
   const horizontalInsetPx = Math.abs(horizontalOffsetPx);
   const blockOffsetRawPx = mmToPx(textPreset.block_offset_mm || 0, pxPerMm);
   const blockOffsetPx = Number.isFinite(blockOffsetRawPx) ? blockOffsetRawPx : 0;
-  const qrSizePx =
-    qrBounds && Number.isFinite(qrBounds.size)
-      ? qrBounds.size
-      : qrBounds && Number.isFinite(qrBounds.width)
-      ? qrBounds.width
-      : 0;
-  const qrMarginPx = qrBounds ? mmToPx(preset.qr?.margin_mm || 0, pxPerMm) : 0;
-  const qrReservedWidthPx = Math.max(0, qrSizePx + qrMarginPx);
-  const baseMainWidthPx = Math.max(0, zones.main.width - qrReservedWidthPx);
+  const baseMainWidthPx = Math.max(0, zones.main.width);
   const mainWidthForFitPx = Math.max(0, baseMainWidthPx - horizontalInsetPx);
   const subtitleCandidates = buildSubtitleCandidates(textLines, preset);
-  const baseSubWidthPx = Math.max(0, zones.sub.width - qrReservedWidthPx);
+  const baseSubWidthPx = Math.max(0, zones.sub.width);
   const subWidthForFitPx = Math.max(0, baseSubWidthPx - horizontalInsetPx);
   const subtitleWidthPx = baseSubWidthPx;
   const subtitleX = computeAlignedX(zones.sub.x, subtitleWidthPx, alignment) + horizontalOffsetPx;

--- a/test/labelRenderer.test.mjs
+++ b/test/labelRenderer.test.mjs
@@ -1222,6 +1222,49 @@ test('QR generator hook places QR image alongside text', async () => {
   assert.ok(images[0].x > Number(textMatches[0][1]), 'QR should appear to the right of text content');
 });
 
+test('textRect width shrinks by a single QR clearance when QR content is present', async () => {
+  clearPresetOverrides();
+  try {
+    const geometry = {
+      labelWidthMm: 37,
+      labelHeightMm: 12,
+      printableWidthMm: 33,
+      printableHeightMm: 10,
+      marginX: 2,
+      marginY: 1,
+    };
+    const preset = getActiveLayoutPreset(geometry.labelHeightMm);
+    const textLines = { line1: 'QR Width Check', line2: '', line3: '' };
+    const baseResult = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines,
+      hardwareInfo: null,
+      qrContent: '',
+    });
+    const qrDataUrl = 'data:image/png;base64,AAAAC';
+    const qrResult = await renderLabelSVG({
+      geometry,
+      pxPerMm,
+      textLines,
+      hardwareInfo: null,
+      qrContent: 'https://example.com',
+      qrGenerator: async (_, size) => ({ dataUrl: qrDataUrl, sizePx: size }),
+    });
+    const expectedDropPx = mmToPx(
+      (preset.qr?.side_mm || 0) + (preset.qr?.margin_mm || 0),
+      pxPerMm,
+    );
+    const actualDropPx = baseResult.textRect.width - qrResult.textRect.width;
+    assert.ok(
+      Math.abs(actualDropPx - expectedDropPx) < 0.51,
+      `expected textRect width drop of ${expectedDropPx.toFixed(2)}px but got ${actualDropPx.toFixed(2)}px`,
+    );
+  } finally {
+    clearPresetOverrides();
+  }
+});
+
 test('end text alignment anchors text to the right edge when QR is absent', async () => {
   clearPresetOverrides();
   try {


### PR DESCRIPTION
## Summary
- rely on the computed text zone widths when fitting main and subtitle text so QR clearance is only applied once
- adjust dependent layout calculations to match the updated widths
- add a regression test that verifies QR content reduces the text rectangle width by only a single QR clearance

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e33d0e11e083298c3ee8795b040952