### PR TITLE
Balance media and text width when reserving QR space

### DIFF
--- a/js/label/renderLabelSVG.js
+++ b/js/label/renderLabelSVG.js
@@ -1915,6 +1915,19 @@ export async function renderLabelSVG({
           ...contentRect,
           width: Math.max(0, contentRect.width - qrReservedWidthPx),
         };
+        const widthReductionPx = Math.max(0, contentRect.width - qrAwareContentRect.width);
+        if (widthReductionPx > 0) {
+          const baselineMediaWidthPx = Math.max(0, mediaWidthPx);
+          const baselineTextWidthPx = Math.max(0, textRect.width);
+          const flexibleWidthPx = baselineMediaWidthPx + baselineTextWidthPx;
+          if (flexibleWidthPx > 0) {
+            const mediaShare = baselineMediaWidthPx / flexibleWidthPx;
+            const targetMediaWidthPx = baselineMediaWidthPx - widthReductionPx * mediaShare;
+            mediaWidthPx = clamp(targetMediaWidthPx, 0, qrAwareContentRect.width);
+          } else {
+            mediaWidthPx = Math.min(mediaWidthPx, qrAwareContentRect.width);
+          }
+        }
         ensureResult = ensureTextFits({
           preset,
           mediaZoneWidthPx: mediaWidthPx,


### PR DESCRIPTION
## Summary
- update the QR layout pass to shrink the media and text zones proportionally when space is reserved for the code
- ensure additional QR width no longer comes entirely from the text zone so larger percentages can be applied

## Testing
- npm run lint *(fails: pre-existing lint errors in js/label/layoutPresets.js and js/label/renderLabelSVG.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e340653c3483298d9b6e67a4241c45