### PR TITLE
Style thread length input with icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,15 +1193,26 @@
                   </div>
                   <div class="col-12 col-sm-6 thread-length-field" id="length-container">
                     <label for="length-input" class="form-label fw-semibold">Length</label>
-                    <input
-                      type="number"
-                      id="length-input"
-                      class="form-control picker-input"
-                      placeholder="e.g., 10"
-                      min="1"
-                      inputmode="decimal"
-                      aria-describedby="length-message"
-                    />
+                    <div class="picker-input-with-icon" id="length-input-wrapper">
+                      <span class="picker-input-with-icon__icon" aria-hidden="true">
+                        <img
+                          id="length-input-icon"
+                          class="picker-input-with-icon__icon-image"
+                          src=""
+                          alt=""
+                          hidden
+                        />
+                      </span>
+                      <input
+                        type="number"
+                        id="length-input"
+                        class="form-control picker-input picker-input-with-icon__input"
+                        placeholder="e.g., 10"
+                        min="1"
+                        inputmode="decimal"
+                        aria-describedby="length-message"
+                      />
+                    </div>
                     <div
                       id="length-message"
                       class="validation-message text-danger small mt-2 d-none"

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -15,6 +15,8 @@ const threadSizePickerList = document.getElementById('thread-size-picker-list');
 const threadLengthRow = document.getElementById('thread-length-row');
 const lengthContainer = document.getElementById('length-container');
 const lengthInput = document.getElementById('length-input');
+const lengthInputWrapper = document.getElementById('length-input-wrapper');
+const lengthInputIcon = document.getElementById('length-input-icon');
 const threadSizeMessage = document.getElementById('thread-size-message');
 const lengthMessage = document.getElementById('length-message');
 const nutTypeContainer = document.getElementById('nut-type-container');
@@ -239,6 +241,8 @@ export const elements = {
   threadLengthRow,
   lengthContainer,
   lengthInput,
+  lengthInputWrapper,
+  lengthInputIcon,
   threadSizeMessage,
   lengthMessage,
   nutTypeContainer,

--- a/js/forms.js
+++ b/js/forms.js
@@ -11,6 +11,7 @@ import {
   nutTypeOptions,
   washerTypeOptions,
   hardwareCatalog,
+  hardwareImageFolders,
   hardwareTypeImageMap,
   connectorCatalog,
   STANDARD_PLACEHOLDER_TEXT,
@@ -48,6 +49,8 @@ const {
   threadLengthRow,
   lengthContainer,
   lengthInput,
+  lengthInputWrapper,
+  lengthInputIcon,
   fuseSelectionRow,
   fuseTypeContainer,
   fuseTypeSelect,
@@ -255,6 +258,39 @@ const validFuseTypeIds = new Set(fuseTypeOptions.map(option => option.id));
 const FUSE_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validFuseValuesSet = new Set(fuseValues.map(value => String(value)));
 const ELECTRICAL_COMPONENT_TYPES = new Set(electricalComponentTypes);
+
+function syncThreadLengthInputIcon(nextType) {
+  if (!lengthInputWrapper || !lengthInputIcon) {
+    return;
+  }
+  const type = typeof nextType === 'string' ? nextType.trim() : state.hardwareType;
+  const shouldShowIcon = type === 'Bolt' || type === 'Screw';
+  if (!shouldShowIcon) {
+    lengthInputIcon.hidden = true;
+    lengthInputIcon.removeAttribute('src');
+    lengthInputIcon.removeAttribute('data-hardware-type');
+    lengthInputWrapper.classList.remove('has-icon');
+    return;
+  }
+
+  const folder = hardwareImageFolders[type];
+  if (!folder) {
+    lengthInputIcon.hidden = true;
+    lengthInputIcon.removeAttribute('src');
+    lengthInputIcon.removeAttribute('data-hardware-type');
+    lengthInputWrapper.classList.remove('has-icon');
+    return;
+  }
+
+  const currentType = lengthInputIcon.dataset.hardwareType || '';
+  if (currentType !== type) {
+    lengthInputIcon.src = `images/${folder}/thread_length.svg`;
+    lengthInputIcon.dataset.hardwareType = type;
+  }
+
+  lengthInputIcon.hidden = false;
+  lengthInputWrapper.classList.add('has-icon');
+}
 const COMPONENT_MOUNT_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
 const validComponentMounts = new Set(componentMountOptions.map(option => option.id));
 const RESISTOR_VALUE_PLACEHOLDER_TEXT = PLACEHOLDER_BLANK;
@@ -5262,6 +5298,8 @@ export function onHardwareTypeChange() {
   if (lengthContainer) {
     lengthContainer.style.display = requiresThreadDetails ? '' : 'none';
   }
+
+  syncThreadLengthInputIcon(type);
 
   if (switchSelectionRow) {
     switchSelectionRow.classList.toggle('d-none', !showSwitchFields);

--- a/style.css
+++ b/style.css
@@ -526,6 +526,47 @@ main {
   box-shadow: 0 0 0 0.25rem var(--field-invalid-ring);
 }
 
+.picker-input-with-icon {
+  position: relative;
+}
+
+.picker-input-with-icon__icon {
+  position: absolute;
+  top: 50%;
+  left: 0.875rem;
+  transform: translateY(-50%);
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.picker-input-with-icon.has-icon .picker-input-with-icon__icon {
+  display: inline-flex;
+}
+
+.picker-input-with-icon__icon-image {
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  filter: var(--form-icon-filter);
+  transition: filter 0.2s ease;
+}
+
+.picker-input-with-icon__input {
+  padding-left: 0.875rem;
+}
+
+.picker-input-with-icon.has-icon .picker-input-with-icon__input {
+  padding-left: calc(0.875rem + 2.25rem + 0.75rem);
+}
+
 .bolt-drive-picker__current {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- wrap the thread length input in a picker-style container that can display the new thread_length.svg artwork
- add CSS and DOM bindings so the input mirrors the thread size picker appearance
- update hardware type handling to swap the length icon between bolt and screw imagery when appropriate

## Testing
- npm run lint *(fails: existing unused-variable warnings in js/label files)*
- npx eslint js/forms.js js/dom-elements.js

------
https://chatgpt.com/codex/tasks/task_e_68e35bb694fc8329a9e74d8bcad3d0d8