### PR TITLE
Wrap label dimension controls with styled container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1727,92 +1727,90 @@
                     </div>
                   </div>
                 </div>
-                <div>
-                  <label
-                    for="width-range"
-                    class="form-label fw-semibold d-flex align-items-center gap-2"
-                  >
+                <div class="p-3 rounded-4 border bg-body-secondary">
+                  <div class="d-flex align-items-center gap-2 fw-semibold text-body mb-3">
                     <i
-                      class="fa-solid fa-ruler-horizontal text-muted"
+                      class="fa-solid fa-ruler-combined text-secondary fs-5"
                       aria-hidden="true"
                     ></i>
-                    <span>Label Width <span id="width-value">37</span> mm</span>
-                  </label>
-                  <input
-                    type="range"
-                    class="form-range"
-                    id="width-range"
-                    min="37"
-                    max="100"
-                    value="37"
-                  />
-                  <div class="d-flex justify-content-between text-muted small">
-                    <span>37&nbsp;mm</span><span>100&nbsp;mm</span>
+                    <span>Dimensions</span>
                   </div>
-                </div>
-                <div>
-                  <span
-                    class="form-label d-block fw-semibold d-flex align-items-center gap-2"
-                  >
-                    <i
-                      class="fa-solid fa-ruler-vertical text-muted"
-                      aria-hidden="true"
-                    ></i>
-                    <span>Label Height</span>
-                  </span>
-                  <div class="row row-cols-2 g-2 height-options">
-                    <div class="col">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="label-height"
-                        id="height-9"
-                        value="9"
-                        autocomplete="off"
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="height-9"
-                        >9&nbsp;mm</label
-                      >
+                  <div class="mb-3">
+                    <label
+                      for="width-range"
+                      class="form-label fw-semibold d-flex align-items-center justify-content-between mb-2"
+                    >
+                      <span>Width</span>
+                      <span><span id="width-value">37</span>&nbsp;mm</span>
+                    </label>
+                    <input
+                      type="range"
+                      class="form-range"
+                      id="width-range"
+                      min="37"
+                      max="100"
+                      value="37"
+                    />
+                    <div class="d-flex justify-content-between text-muted small">
+                      <span>37&nbsp;mm</span><span>100&nbsp;mm</span>
                     </div>
-                    <div class="col">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="label-height"
-                        id="height-12"
-                        value="12"
-                        autocomplete="off"
-                        checked
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="height-12"
-                        >12&nbsp;mm</label
-                      >
-                    </div>
-                    <div class="col">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="label-height"
-                        id="height-18"
-                        value="18"
-                        autocomplete="off"
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="height-18"
-                        >18&nbsp;mm</label
-                      >
-                    </div>
-                    <div class="col">
-                      <input
-                        type="radio"
-                        class="btn-check"
-                        name="label-height"
-                        id="height-24"
-                        value="24"
-                        autocomplete="off"
-                      />
-                      <label class="btn btn-outline-secondary w-100" for="height-24"
-                        >24&nbsp;mm</label
-                      >
+                  </div>
+                  <div>
+                    <span class="form-label d-block fw-semibold mb-2">Height</span>
+                    <div class="row row-cols-2 g-2 height-options">
+                      <div class="col">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="label-height"
+                          id="height-9"
+                          value="9"
+                          autocomplete="off"
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="height-9"
+                          >9&nbsp;mm</label
+                        >
+                      </div>
+                      <div class="col">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="label-height"
+                          id="height-12"
+                          value="12"
+                          autocomplete="off"
+                          checked
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="height-12"
+                          >12&nbsp;mm</label
+                        >
+                      </div>
+                      <div class="col">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="label-height"
+                          id="height-18"
+                          value="18"
+                          autocomplete="off"
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="height-18"
+                          >18&nbsp;mm</label
+                        >
+                      </div>
+                      <div class="col">
+                        <input
+                          type="radio"
+                          class="btn-check"
+                          name="label-height"
+                          id="height-24"
+                          value="24"
+                          autocomplete="off"
+                        />
+                        <label class="btn btn-outline-secondary w-100" for="height-24"
+                          >24&nbsp;mm</label
+                        >
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- group the label width and height controls into a styled card matching other label setting sections
- add a dimensions header with icon and update width/height labels for improved clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3610f70e88329a1b04f5cef93906b