### PR TITLE
Keep height buttons on a single line

### DIFF
--- a/index.html
+++ b/index.html
@@ -1757,8 +1757,8 @@
                   </div>
                   <div>
                     <span class="form-label d-block fw-semibold mb-2">Height</span>
-                    <div class="row row-cols-2 g-2 height-options">
-                      <div class="col">
+                    <div class="d-flex gap-2 flex-nowrap height-options">
+                      <div class="flex-fill">
                         <input
                           type="radio"
                           class="btn-check"
@@ -1771,7 +1771,7 @@
                           >9&nbsp;mm</label
                         >
                       </div>
-                      <div class="col">
+                      <div class="flex-fill">
                         <input
                           type="radio"
                           class="btn-check"
@@ -1785,7 +1785,7 @@
                           >12&nbsp;mm</label
                         >
                       </div>
-                      <div class="col">
+                      <div class="flex-fill">
                         <input
                           type="radio"
                           class="btn-check"


### PR DESCRIPTION
## Summary
- replace the responsive column grid with a no-wrap flex row for the height option buttons
- ensure each height button flexes evenly so they stay on a single line across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36b712eac8329b2303f9ea0dcea48