### PR TITLE
Keep fuse picker glyph visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -1350,7 +1350,12 @@
                           <span
                             class="bolt-drive-picker__current-icon is-empty"
                             aria-hidden="true"
-                          ></span>
+                          >
+                            <i
+                              class="fuse-value-picker__glyph"
+                              aria-hidden="true"
+                            ></i>
+                          </span>
                           <span class="bolt-drive-picker__current-label">&nbsp;</span>
                         </span>
                         <span class="bolt-drive-picker__chevron" aria-hidden="true"></span>

--- a/js/forms.js
+++ b/js/forms.js
@@ -3929,7 +3929,18 @@ export function syncFuseValuePicker({ isValid = true } = {}) {
     }
     const iconWrapper = fuseValuePickerButton.querySelector('.bolt-drive-picker__current-icon');
     if (iconWrapper) {
-      iconWrapper.classList.add('is-empty');
+      const iconGlyph = iconWrapper.querySelector('.fuse-value-picker__glyph');
+      if (requiresValue) {
+        iconWrapper.classList.remove('is-empty');
+        if (iconGlyph) {
+          iconGlyph.classList.add('fa-solid', 'fa-a');
+        }
+      } else {
+        iconWrapper.classList.add('is-empty');
+        if (iconGlyph) {
+          iconGlyph.classList.remove('fa-solid', 'fa-a');
+        }
+      }
     }
 
     if (effectiveValidity) {


### PR DESCRIPTION
## Summary
- add a dedicated glyph element inside the fuse value picker button for the Font Awesome "A" icon
- update the fuse value sync logic to toggle the glyph visibility and Font Awesome classes when the picker is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38ce837a0832999bd081a791bbbb6