### PR TITLE
Ensure resistor omega icon renders without background

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1206,6 +1206,26 @@ export function updateComponentValueUi({ resetIfHidden = true } = {}) {
         resistorValuePicker.classList.contains('is-open'),
     );
     resistorValuePickerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+
+    const iconWrapper = resistorValuePickerButton.querySelector(
+      '.bolt-drive-picker__current-icon',
+    );
+    const iconImage = resistorValuePickerButton.querySelector(
+      '.bolt-drive-picker__current-icon-image',
+    );
+    if (iconWrapper && iconImage) {
+      if (showResistorValues) {
+        iconImage.src = 'images/resistors/omega.svg';
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+        iconWrapper.classList.add('bolt-drive-picker__current-icon--no-background');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+        iconWrapper.classList.remove('bolt-drive-picker__current-icon--no-background');
+      }
+    }
   }
 
   if (resistorValuePickerList) {
@@ -1481,8 +1501,26 @@ export function syncResistorValuePicker({ isValid = true } = {}) {
 
   if (resistorValuePickerButton) {
     const label = resistorValuePickerButton.querySelector('.bolt-drive-picker__current-label');
+    const iconWrapper = resistorValuePickerButton.querySelector('.bolt-drive-picker__current-icon');
+    const iconImage = resistorValuePickerButton.querySelector(
+      '.bolt-drive-picker__current-icon-image',
+    );
     if (label) {
       label.textContent = sanitizedValue ? sanitizedValue : RESISTOR_VALUE_PLACEHOLDER_TEXT;
+    }
+
+    if (iconWrapper && iconImage) {
+      if (!resistorValuePickerButton.disabled) {
+        iconImage.src = 'images/resistors/omega.svg';
+        iconImage.hidden = false;
+        iconWrapper.classList.remove('is-empty');
+        iconWrapper.classList.add('bolt-drive-picker__current-icon--no-background');
+      } else {
+        iconImage.hidden = true;
+        iconImage.removeAttribute('src');
+        iconWrapper.classList.add('is-empty');
+        iconWrapper.classList.remove('bolt-drive-picker__current-icon--no-background');
+      }
     }
 
     if (isValid) {

--- a/style.css
+++ b/style.css
@@ -602,6 +602,12 @@ main {
   transition: background-color 0.2s ease;
 }
 
+.bolt-drive-picker__current-icon--no-background {
+  background: none !important;
+  border-radius: 0;
+  overflow: visible;
+}
+
 .bolt-drive-picker__current-icon.is-empty {
   visibility: hidden;
 }


### PR DESCRIPTION
## Summary
- keep the resistor value picker button wiring toggled so the omega icon uses a transparent wrapper
- add a no-background icon style to prevent the resistor omega image from being cropped by the circular mask

## Testing
- npm run lint *(fails: layoutPresets.js and renderLabelSVG.js have existing unused variable errors)*
- manual: selected the Resistor part type in the UI and verified the omega icon appears without a circular background

------
https://chatgpt.com/codex/tasks/task_e_68e38e52cc688329b659717d064b0608