### PR TITLE
Switch glass fuse speed controls to dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -1375,25 +1375,17 @@
                   </div>
                 </div>
                 <div id="glass-options-container" class="d-none">
-                  <span class="form-label d-block fw-semibold"
-                    >Glass, Ceramic &amp; Holder Options</span
-                  >
+                  <span class="form-label d-block fw-semibold">Time</span>
                   <div id="glass-speed-options">
-                    <div class="form-check">
-                      <input class="form-check-input" type="checkbox" id="glass-slow-blow" />
-                      <label class="form-check-label" for="glass-slow-blow"
-                        >Slow-blow (time delay)</label
-                      >
-                    </div>
-                    <div class="form-check">
-                      <input class="form-check-input" type="checkbox" id="glass-fast-blow" />
-                      <label class="form-check-label" for="glass-fast-blow">Fast-blow</label>
-                    </div>
-                    <div class="form-text">Select a fuse speed for glass or ceramic fuses.</div>
+                    <select id="glass-speed-select" class="form-select">
+                      <option value="">&nbsp;</option>
+                      <option value="Slow-blow">Slow-blow</option>
+                      <option value="Fast-blow">Fast-blow</option>
+                    </select>
                   </div>
                   <div class="mt-2">
                     <label for="glass-size-select" class="form-label fw-semibold"
-                      >Glass Fuse or Holder Size</label
+                      >Size</label
                     >
                     <select id="glass-size-select" class="form-select">
                       <option value="">&nbsp;</option>
@@ -1402,10 +1394,6 @@
                         6.3 × 32 mm (1/4″ × 1-1/4″)
                       </option>
                     </select>
-                    <div class="form-text">
-                      Standard glass fuse sizes and matching panel mount holders: 5 × 20 mm and
-                      6.3 × 32 mm. Holders only need the size selection.
-                    </div>
                   </div>
                 </div>
                 <div id="standard-field" class="d-none">

--- a/js/controls.js
+++ b/js/controls.js
@@ -60,8 +60,7 @@ function applyStateToControls() {
   const {
     systemTypeRadios,
     glassSizeSelect,
-    glassSlowBlowCheckbox,
-    glassFastBlowCheckbox,
+    glassSpeedSelect,
     lengthInput,
     notesInput,
     customLine1Input,
@@ -90,11 +89,8 @@ function applyStateToControls() {
   if (glassSizeSelect) {
     glassSizeSelect.value = state.glassSize || '';
   }
-  if (glassSlowBlowCheckbox) {
-    glassSlowBlowCheckbox.checked = state.glassSpeed.startsWith('Slow');
-  }
-  if (glassFastBlowCheckbox) {
-    glassFastBlowCheckbox.checked = state.glassSpeed.startsWith('Fast');
+  if (glassSpeedSelect) {
+    glassSpeedSelect.value = state.glassSpeed || '';
   }
 
   setConnectorCategorySelection(state.connectorCategory || '', { triggerUpdate: false });

--- a/js/dom-elements.js
+++ b/js/dom-elements.js
@@ -48,13 +48,12 @@ const fuseValueContainer = document.getElementById('fuse-value-container');
 const fuseTypeMessage = document.getElementById('fuse-type-message');
 const glassOptionsContainer = document.getElementById('glass-options-container');
 const glassSpeedOptionsContainer = document.getElementById('glass-speed-options');
+const glassSpeedSelect = document.getElementById('glass-speed-select');
 const fuseValueSelect = document.getElementById('fuse-value-select');
 const fuseValuePicker = document.getElementById('fuse-value-picker');
 const fuseValuePickerButton = document.getElementById('fuse-value-picker-button');
 const fuseValuePickerList = document.getElementById('fuse-value-picker-list');
 const glassSizeSelect = document.getElementById('glass-size-select');
-const glassSlowBlowCheckbox = document.getElementById('glass-slow-blow');
-const glassFastBlowCheckbox = document.getElementById('glass-fast-blow');
 const fuseValueMessage = document.getElementById('fuse-value-message');
 const notesInput = document.getElementById('notes-input');
 const measurementSystemContainer = document.getElementById('measurement-system-container');
@@ -274,13 +273,12 @@ export const elements = {
   fuseValueContainer,
   glassOptionsContainer,
   glassSpeedOptionsContainer,
+  glassSpeedSelect,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,
   fuseValuePickerList,
   glassSizeSelect,
-  glassSlowBlowCheckbox,
-  glassFastBlowCheckbox,
   fuseValueMessage,
   notesInput,
   measurementSystemContainer,

--- a/js/events.js
+++ b/js/events.js
@@ -121,8 +121,7 @@ const {
   fuseValuePicker,
   fuseValuePickerButton,
   fuseValuePickerList,
-  glassSlowBlowCheckbox,
-  glassFastBlowCheckbox,
+  glassSpeedSelect,
   glassSizeSelect,
   lengthInput,
   notesInput,
@@ -5536,34 +5535,9 @@ export function initEventHandlers() {
     });
   }
 
-  if (glassSlowBlowCheckbox) {
-    glassSlowBlowCheckbox.addEventListener('change', () => {
-      if (!glassSlowBlowCheckbox.checked) {
-        if (!glassFastBlowCheckbox || !glassFastBlowCheckbox.checked) {
-          state.glassSpeed = '';
-        }
-      } else {
-        state.glassSpeed = 'Slow Blow (Time Delay)';
-        if (glassFastBlowCheckbox) {
-          glassFastBlowCheckbox.checked = false;
-        }
-      }
-      updatePreview();
-    });
-  }
-
-  if (glassFastBlowCheckbox) {
-    glassFastBlowCheckbox.addEventListener('change', () => {
-      if (!glassFastBlowCheckbox.checked) {
-        if (!glassSlowBlowCheckbox || !glassSlowBlowCheckbox.checked) {
-          state.glassSpeed = '';
-        }
-      } else {
-        state.glassSpeed = 'Fast Blow';
-        if (glassSlowBlowCheckbox) {
-          glassSlowBlowCheckbox.checked = false;
-        }
-      }
+  if (glassSpeedSelect) {
+    glassSpeedSelect.addEventListener('change', () => {
+      state.glassSpeed = glassSpeedSelect.value;
       updatePreview();
     });
   }

--- a/js/forms.js
+++ b/js/forms.js
@@ -60,13 +60,12 @@ const {
   fuseValueContainer,
   glassOptionsContainer,
   glassSpeedOptionsContainer,
+  glassSpeedSelect,
   fuseValueSelect,
   fuseValuePicker,
   fuseValuePickerButton,
   fuseValuePickerList,
   glassSizeSelect,
-  glassSlowBlowCheckbox,
-  glassFastBlowCheckbox,
   notesInput,
   nutTypeContainer,
   nutTypePicker,
@@ -4097,39 +4096,35 @@ export function updateGlassOptionVisibility({ resetIfHidden = false } = {}) {
     if (glassSizeSelect) {
       glassSizeSelect.value = state.glassSize || '';
     }
-    if (glassSlowBlowCheckbox) {
-      glassSlowBlowCheckbox.disabled = !requiresSpeedOptions;
-      glassSlowBlowCheckbox.checked =
-        requiresSpeedOptions && state.glassSpeed.startsWith('Slow');
-    }
-    if (glassFastBlowCheckbox) {
-      glassFastBlowCheckbox.disabled = !requiresSpeedOptions;
-      glassFastBlowCheckbox.checked =
-        requiresSpeedOptions && state.glassSpeed.startsWith('Fast');
-    }
-    if (!requiresSpeedOptions) {
-      state.glassSpeed = '';
+    if (glassSpeedSelect) {
+      if (requiresSpeedOptions) {
+        const validOptionExists = Array.from(glassSpeedSelect.options || []).some(
+          option => option.value === state.glassSpeed,
+        );
+        if (!validOptionExists) {
+          state.glassSpeed = '';
+        }
+        glassSpeedSelect.disabled = false;
+        glassSpeedSelect.value = state.glassSpeed || '';
+      } else {
+        state.glassSpeed = '';
+        glassSpeedSelect.value = '';
+        glassSpeedSelect.disabled = true;
+      }
     }
   } else if (resetIfHidden) {
     state.glassSpeed = '';
     state.glassSize = '';
-    if (glassSlowBlowCheckbox) {
-      glassSlowBlowCheckbox.checked = false;
-      glassSlowBlowCheckbox.disabled = false;
-    }
-    if (glassFastBlowCheckbox) {
-      glassFastBlowCheckbox.checked = false;
-      glassFastBlowCheckbox.disabled = false;
+    if (glassSpeedSelect) {
+      glassSpeedSelect.value = '';
+      glassSpeedSelect.disabled = false;
     }
     if (glassSizeSelect) {
       glassSizeSelect.value = '';
     }
   } else {
-    if (glassSlowBlowCheckbox) {
-      glassSlowBlowCheckbox.disabled = false;
-    }
-    if (glassFastBlowCheckbox) {
-      glassFastBlowCheckbox.disabled = false;
+    if (glassSpeedSelect) {
+      glassSpeedSelect.disabled = false;
     }
   }
 }

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -112,7 +112,17 @@ const glassSizeOptions = new Set(
         .filter(value => value && value.trim().length > 0)
     : [],
 );
-const glassSpeedOptions = new Set(['Slow Blow (Time Delay)', 'Fast Blow']);
+const glassSpeedOptions = new Set(
+  elements.glassSpeedSelect
+    ? Array.from(elements.glassSpeedSelect.options, option => option.value)
+        .map(value => value.trim())
+        .filter(value => value.length > 0)
+    : ['Slow-blow', 'Fast-blow'],
+);
+const legacyGlassSpeedMap = new Map([
+  ['Slow Blow (Time Delay)', 'Slow-blow'],
+  ['Fast Blow', 'Fast-blow'],
+]);
 const metricThreadSet = new Set(metricThreadSizes);
 const imperialThreadSet = new Set(imperialThreadSizes);
 const allThreadSizes = new Set([...metricThreadSet, ...imperialThreadSet]);
@@ -222,7 +232,8 @@ function sanitizeGlassSpeed(value) {
   if (!trimmed) {
     return '';
   }
-  return glassSpeedOptions.has(trimmed) ? trimmed : '';
+  const normalized = legacyGlassSpeedMap.get(trimmed) || trimmed;
+  return glassSpeedOptions.has(normalized) ? normalized : '';
 }
 
 function sanitizeGlassSize(value) {

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -87,18 +87,14 @@ const mockGlassSpeedOptionsContainer = {
   classList: createClassListMock(),
 };
 
+const mockGlassSpeedSelect = {
+  value: '',
+  disabled: false,
+  options: [{ value: '' }, { value: 'Slow-blow' }, { value: 'Fast-blow' }],
+};
+
 const mockGlassSizeSelect = {
   value: '',
-};
-
-const mockGlassSlowBlowCheckbox = {
-  checked: false,
-  disabled: false,
-};
-
-const mockGlassFastBlowCheckbox = {
-  checked: false,
-  disabled: false,
 };
 
 jest.mock('../js/dom-elements.js', () => ({
@@ -111,9 +107,8 @@ jest.mock('../js/dom-elements.js', () => ({
     fuseValuePicker: mockFuseValuePicker,
     glassOptionsContainer: mockGlassOptionsContainer,
     glassSpeedOptionsContainer: mockGlassSpeedOptionsContainer,
+    glassSpeedSelect: mockGlassSpeedSelect,
     glassSizeSelect: mockGlassSizeSelect,
-    glassSlowBlowCheckbox: mockGlassSlowBlowCheckbox,
-    glassFastBlowCheckbox: mockGlassFastBlowCheckbox,
   },
 }));
 
@@ -202,11 +197,9 @@ beforeEach(() => {
   mockFuseValuePicker.classList.toggle.mockClear();
   mockGlassOptionsContainer.classList.toggle.mockClear();
   mockGlassSpeedOptionsContainer.classList.toggle.mockClear();
+  mockGlassSpeedSelect.value = '';
+  mockGlassSpeedSelect.disabled = false;
   mockGlassSizeSelect.value = '';
-  mockGlassSlowBlowCheckbox.checked = false;
-  mockGlassSlowBlowCheckbox.disabled = false;
-  mockGlassFastBlowCheckbox.checked = false;
-  mockGlassFastBlowCheckbox.disabled = false;
   state.fuseValue = '';
   state.fuseType = 'Glass';
   state.hardwareType = 'Fuse';
@@ -286,7 +279,7 @@ describe('fuse type selection behaviour', () => {
 
   it('reveals the glass options for panel mount holders and keeps the selected size', () => {
     state.glassSize = '5 × 20 mm';
-    state.glassSpeed = 'Fast Blow';
+    state.glassSpeed = 'Fast-blow';
 
     setFuseTypeSelection('Panel Mount Fuse Holder', { triggerUpdate: false });
 
@@ -294,17 +287,15 @@ describe('fuse type selection behaviour', () => {
     expect(mockGlassSpeedOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', true);
     expect(mockGlassSizeSelect.value).toBe('5 × 20 mm');
     expect(state.glassSpeed).toBe('');
-    expect(mockGlassSlowBlowCheckbox.checked).toBe(false);
-    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
-    expect(mockGlassSlowBlowCheckbox.disabled).toBe(true);
-    expect(mockGlassFastBlowCheckbox.disabled).toBe(true);
+    expect(mockGlassSpeedSelect.value).toBe('');
+    expect(mockGlassSpeedSelect.disabled).toBe(true);
   });
 
   it('hides and clears the glass options when switching to blade fuses', () => {
     state.fuseType = 'Panel Mount Fuse Holder';
     state.glassSize = '6.3 × 32 mm (1/4″ × 1-1/4″)';
     mockGlassSizeSelect.value = state.glassSize;
-    state.glassSpeed = 'Slow Blow (Time Delay)';
+    state.glassSpeed = 'Slow-blow';
 
     setFuseTypeSelection('Blade', { triggerUpdate: false });
 
@@ -313,15 +304,13 @@ describe('fuse type selection behaviour', () => {
     expect(mockGlassSizeSelect.value).toBe('');
     expect(mockGlassSpeedOptionsContainer.classList.toggle).toHaveBeenCalledWith('d-none', false);
     expect(state.glassSpeed).toBe('');
-    expect(mockGlassSlowBlowCheckbox.checked).toBe(false);
-    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
-    expect(mockGlassSlowBlowCheckbox.disabled).toBe(false);
-    expect(mockGlassFastBlowCheckbox.disabled).toBe(false);
+    expect(mockGlassSpeedSelect.value).toBe('');
+    expect(mockGlassSpeedSelect.disabled).toBe(false);
   });
 
   it('restores fuse speed options when switching back to glass fuses', () => {
     setFuseTypeSelection('Panel Mount Fuse Holder', { triggerUpdate: false });
-    state.glassSpeed = 'Slow Blow (Time Delay)';
+    state.glassSpeed = 'Slow-blow';
 
     setFuseTypeSelection('Glass', { triggerUpdate: false });
 
@@ -329,10 +318,8 @@ describe('fuse type selection behaviour', () => {
       'd-none',
       false,
     );
-    expect(mockGlassSlowBlowCheckbox.disabled).toBe(false);
-    expect(mockGlassFastBlowCheckbox.disabled).toBe(false);
-    expect(mockGlassSlowBlowCheckbox.checked).toBe(true);
-    expect(mockGlassFastBlowCheckbox.checked).toBe(false);
+    expect(mockGlassSpeedSelect.disabled).toBe(false);
+    expect(mockGlassSpeedSelect.value).toBe('Slow-blow');
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the glass fuse speed checkboxes with a select control and streamline the helper text
- expose the new glass speed select in shared DOM references and update events, forms, controls, and URL state handling
- adjust tests to reflect the new control and supported glass speed values

## Testing
- npm run lint *(fails: pre-existing unused variable warnings in label layout code)*

------
https://chatgpt.com/codex/tasks/task_e_68e3920c06088329bb47cc5c08f3e4ce