### PR TITLE
Arrange fuse time and size controls side by side

### DIFF
--- a/index.html
+++ b/index.html
@@ -1375,25 +1375,27 @@
                   </div>
                 </div>
                 <div id="glass-options-container" class="d-none">
-                  <span class="form-label d-block fw-semibold">Time</span>
-                  <div id="glass-speed-options">
-                    <select id="glass-speed-select" class="form-select">
-                      <option value="">&nbsp;</option>
-                      <option value="Slow-blow">Slow-blow</option>
-                      <option value="Fast-blow">Fast-blow</option>
-                    </select>
-                  </div>
-                  <div class="mt-2">
-                    <label for="glass-size-select" class="form-label fw-semibold"
-                      >Size</label
-                    >
-                    <select id="glass-size-select" class="form-select">
-                      <option value="">&nbsp;</option>
-                      <option value="5 × 20 mm">5 × 20 mm</option>
-                      <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
-                        6.3 × 32 mm (1/4″ × 1-1/4″)
-                      </option>
-                    </select>
+                  <div class="row g-3">
+                    <div class="col-12 col-md-6">
+                      <label for="glass-speed-select" class="form-label fw-semibold">Time</label>
+                      <div id="glass-speed-options">
+                        <select id="glass-speed-select" class="form-select">
+                          <option value="">&nbsp;</option>
+                          <option value="Slow-blow">Slow-blow</option>
+                          <option value="Fast-blow">Fast-blow</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                      <label for="glass-size-select" class="form-label fw-semibold">Size</label>
+                      <select id="glass-size-select" class="form-select">
+                        <option value="">&nbsp;</option>
+                        <option value="5 × 20 mm">5 × 20 mm</option>
+                        <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
+                          6.3 × 32 mm (1/4″ × 1-1/4″)
+                        </option>
+                      </select>
+                    </div>
                   </div>
                 </div>
                 <div id="standard-field" class="d-none">


### PR DESCRIPTION
## Summary
- restructure the fuse glass options markup so time and size fields share a responsive row with two columns
- add an explicit label for the time dropdown and remove the extra margin utility to tighten spacing

## Testing
- Manual verification in the Fuse part-type view on desktop and mobile widths

------
https://chatgpt.com/codex/tasks/task_e_68e398b99c3083298dcd7fd2446064c6