### PR TITLE
Use omega icon for potentiometer values

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -255,10 +255,10 @@ export const capacitorValueOptions = Array.from(capacitorValueSet)
   });
 
 export const potentiometerValueOptions = [
-  { id: '1 kΩ', label: '1 kΩ', image: 'images/potentiometer/potentiometer.svg' },
-  { id: '10 kΩ', label: '10 kΩ', image: 'images/potentiometer/potentiometer.svg' },
-  { id: '100 kΩ', label: '100 kΩ', image: 'images/potentiometer/potentiometer.svg' },
-  { id: '1 MΩ', label: '1 MΩ', image: 'images/potentiometer/potentiometer.svg' },
+  { id: '1 kΩ', label: '1 kΩ', image: 'images/resistors/omega.svg' },
+  { id: '10 kΩ', label: '10 kΩ', image: 'images/resistors/omega.svg' },
+  { id: '100 kΩ', label: '100 kΩ', image: 'images/resistors/omega.svg' },
+  { id: '1 MΩ', label: '1 MΩ', image: 'images/resistors/omega.svg' },
 ];
 
 export const potentiometerTaperOptions = [

--- a/js/forms.js
+++ b/js/forms.js
@@ -2282,7 +2282,7 @@ export function syncPotentiometerValuePicker({ isValid = true } = {}) {
     potentiometerValueSelect.selectedIndex = 0;
   }
 
-  const imageSrc = sanitizedValue ? 'images/potentiometer/potentiometer.svg' : '';
+  const imageSrc = sanitizedValue ? 'images/resistors/omega.svg' : '';
 
   if (potentiometerValuePickerButton) {
     const label =
@@ -2312,10 +2312,12 @@ export function syncPotentiometerValuePicker({ isValid = true } = {}) {
         iconWrapper.classList.remove('is-empty');
         iconImage.src = imageSrc;
         iconImage.hidden = false;
+        iconImage.classList.add('bolt-drive-picker__current-icon-image--omega');
       } else {
         if (iconImage) {
           iconImage.hidden = true;
           iconImage.removeAttribute('src');
+          iconImage.classList.remove('bolt-drive-picker__current-icon-image--omega');
         }
         iconWrapper.classList.add('is-empty');
       }


### PR DESCRIPTION
## Summary
- point potentiometer value options at the shared omega icon asset
- update the potentiometer value picker to display the omega icon with the resistor sizing class

## Testing
- npm run lint *(fails: existing unused variable warnings in js/label files)*

------
https://chatgpt.com/codex/tasks/task_e_68e39b5151688329af0f662aa9fcf9e5