### PR TITLE
Keep glass picker icons visible

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -4357,11 +4357,7 @@ export function syncGlassSpeedPicker({
     }
     const iconWrapper = glassSpeedPickerButton.querySelector('.bolt-drive-picker__current-icon');
     if (iconWrapper) {
-      if (selectedOption) {
-        iconWrapper.classList.remove('is-empty');
-      } else {
-        iconWrapper.classList.add('is-empty');
-      }
+      iconWrapper.classList.remove('is-empty');
     }
     if (glassSpeedPickerButton.disabled) {
       glassSpeedPickerButton.setAttribute('aria-expanded', 'false');
@@ -4439,11 +4435,7 @@ export function syncGlassSizePicker({
     }
     const iconWrapper = glassSizePickerButton.querySelector('.bolt-drive-picker__current-icon');
     if (iconWrapper) {
-      if (selectedOption) {
-        iconWrapper.classList.remove('is-empty');
-      } else {
-        iconWrapper.classList.add('is-empty');
-      }
+      iconWrapper.classList.remove('is-empty');
     }
     if (glassSizePickerButton.disabled) {
       glassSizePickerButton.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
## Summary
- ensure the glass speed picker icon wrapper never receives the `is-empty` class so the stopwatch icon stays visible
- ensure the glass size picker icon wrapper never receives the `is-empty` class so the arrow icons remain visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3bbf05af883298f9fdd866cbb640a