### PR TITLE
Fix height option alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1841,7 +1841,7 @@
                           >18&nbsp;mm</label
                         >
                       </div>
-                      <div class="col">
+                      <div class="flex-fill">
                         <input
                           type="radio"
                           class="btn-check"


### PR DESCRIPTION
## Summary
- update the 24 mm height option wrapper to use the same flex layout as the other buttons so they share equal widths

## Testing
- Manually verified in the browser that the height buttons align evenly in both light and dark themes


------
https://chatgpt.com/codex/tasks/task_e_68e43a01a9fc83298552301869b074a4