### PR TITLE
Adjust mobile action layout to stack buttons on narrow screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -399,12 +399,14 @@ main {
   }
 
   .actions {
-    flex-wrap: nowrap !important;
+    flex-direction: column;
+    align-items: stretch;
     gap: 0.75rem;
   }
 
   .actions .btn {
-    flex: 1 1 0;
+    flex: 1 1 auto;
+    width: 100%;
     min-width: 0;
     padding-inline: 0.75rem;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- update the mobile actions layout to stack buttons vertically for narrow screens
- ensure each action button stretches to the container width for better wrapping

## Testing
- Manual: Viewed index.html at a 320px viewport to confirm action buttons remain within the container

------
https://chatgpt.com/codex/tasks/task_e_68e43e8a7c2c83299d7c033cb5beb644