### PR TITLE
Add placeholder entries for glass fuse pickers

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -4209,28 +4209,26 @@ export function populateGlassSpeedOptions() {
 
   if (glassSpeedPickerList) {
     glassSpeedPickerList.innerHTML = '';
-    glassSpeedOptionData
-      .filter(option => option.value)
-      .forEach(option => {
-        const item = document.createElement('li');
-        item.className = 'bolt-drive-picker__option';
-        item.dataset.value = option.value;
-        item.setAttribute('role', 'option');
-        item.setAttribute('aria-selected', 'false');
-        item.tabIndex = -1;
+    glassSpeedOptionData.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.value;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
 
-        const icon = document.createElement('span');
-        icon.className = 'bolt-drive-picker__option-icon is-empty';
-        icon.setAttribute('aria-hidden', 'true');
-        item.appendChild(icon);
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon is-empty';
+      icon.setAttribute('aria-hidden', 'true');
+      item.appendChild(icon);
 
-        const label = document.createElement('span');
-        label.className = 'bolt-drive-picker__option-label';
-        label.textContent = option.label;
-        item.appendChild(label);
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
 
-        glassSpeedPickerList.appendChild(item);
-      });
+      glassSpeedPickerList.appendChild(item);
+    });
     glassSpeedPickerList.hidden = true;
   }
 
@@ -4275,28 +4273,26 @@ export function populateGlassSizeOptions() {
 
   if (glassSizePickerList) {
     glassSizePickerList.innerHTML = '';
-    glassSizeOptionData
-      .filter(option => option.value)
-      .forEach(option => {
-        const item = document.createElement('li');
-        item.className = 'bolt-drive-picker__option';
-        item.dataset.value = option.value;
-        item.setAttribute('role', 'option');
-        item.setAttribute('aria-selected', 'false');
-        item.tabIndex = -1;
+    glassSizeOptionData.forEach(option => {
+      const item = document.createElement('li');
+      item.className = 'bolt-drive-picker__option';
+      item.dataset.value = option.value;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', 'false');
+      item.tabIndex = -1;
 
-        const icon = document.createElement('span');
-        icon.className = 'bolt-drive-picker__option-icon is-empty';
-        icon.setAttribute('aria-hidden', 'true');
-        item.appendChild(icon);
+      const icon = document.createElement('span');
+      icon.className = 'bolt-drive-picker__option-icon is-empty';
+      icon.setAttribute('aria-hidden', 'true');
+      item.appendChild(icon);
 
-        const label = document.createElement('span');
-        label.className = 'bolt-drive-picker__option-label';
-        label.textContent = option.label;
-        item.appendChild(label);
+      const label = document.createElement('span');
+      label.className = 'bolt-drive-picker__option-label';
+      label.textContent = option.label;
+      item.appendChild(label);
 
-        glassSizePickerList.appendChild(item);
-      });
+      glassSizePickerList.appendChild(item);
+    });
     glassSizePickerList.hidden = true;
   }
 
@@ -4357,7 +4353,16 @@ export function syncGlassSpeedPicker({
     }
     const iconWrapper = glassSpeedPickerButton.querySelector('.bolt-drive-picker__current-icon');
     if (iconWrapper) {
-      iconWrapper.classList.remove('is-empty');
+      const classList = iconWrapper.classList;
+      if (classList && typeof classList.toggle === 'function') {
+        classList.toggle('is-empty', !selectedOption);
+      } else if (classList && typeof classList.remove === 'function' && typeof classList.add === 'function') {
+        if (selectedOption) {
+          classList.remove('is-empty');
+        } else {
+          classList.add('is-empty');
+        }
+      }
     }
     if (glassSpeedPickerButton.disabled) {
       glassSpeedPickerButton.setAttribute('aria-expanded', 'false');
@@ -4435,7 +4440,16 @@ export function syncGlassSizePicker({
     }
     const iconWrapper = glassSizePickerButton.querySelector('.bolt-drive-picker__current-icon');
     if (iconWrapper) {
-      iconWrapper.classList.remove('is-empty');
+      const classList = iconWrapper.classList;
+      if (classList && typeof classList.toggle === 'function') {
+        classList.toggle('is-empty', !selectedOption);
+      } else if (classList && typeof classList.remove === 'function' && typeof classList.add === 'function') {
+        if (selectedOption) {
+          classList.remove('is-empty');
+        } else {
+          classList.add('is-empty');
+        }
+      }
     }
     if (glassSizePickerButton.disabled) {
       glassSizePickerButton.setAttribute('aria-expanded', 'false');

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -83,19 +83,53 @@ const mockGlassOptionsContainer = {
   classList: createClassListMock(),
 };
 
+const NBSP = '\u00a0';
+
+const baseGlassSpeedOptions = [
+  { value: '', textContent: NBSP },
+  { value: 'Slow-blow', textContent: 'Slow-blow' },
+  { value: 'Fast-blow', textContent: 'Fast-blow' },
+];
+
+const baseGlassSizeOptions = [
+  { value: '', textContent: NBSP },
+  { value: '5 × 20 mm', textContent: '5 × 20 mm' },
+  { value: '6.3 × 32 mm (1/4″ × 1-1/4″)', textContent: '6.3 × 32 mm (1/4″ × 1-1/4″)' },
+];
+
+const cloneOptions = options => options.map(option => ({ ...option }));
+
 const mockGlassSpeedSelect = {
   value: '',
   disabled: false,
-  options: [{ value: '' }, { value: 'Slow-blow' }, { value: 'Fast-blow' }],
+  options: cloneOptions(baseGlassSpeedOptions),
+  appendChild(option) {
+    this.options.push(option);
+    return option;
+  },
+  set innerHTML(value) {
+    if (value === '') {
+      this.options = [];
+      return;
+    }
+    throw new Error(`Unexpected innerHTML assignment: ${value}`);
+  },
 };
 
 const mockGlassSizeSelect = {
   value: '',
-  options: [
-    { value: '' },
-    { value: '5 × 20 mm' },
-    { value: '6.3 × 32 mm (1/4″ × 1-1/4″)' },
-  ],
+  options: cloneOptions(baseGlassSizeOptions),
+  appendChild(option) {
+    this.options.push(option);
+    return option;
+  },
+  set innerHTML(value) {
+    if (value === '') {
+      this.options = [];
+      return;
+    }
+    throw new Error(`Unexpected innerHTML assignment: ${value}`);
+  },
 };
 
 const mockGlassSpeedPicker = {
@@ -277,14 +311,24 @@ global.document = {
 };
 
 let populateFuseValues;
+let populateGlassSpeedOptions;
+let populateGlassSizeOptions;
 let setFuseTypeSelection;
+let setGlassSpeedSelection;
+let setGlassSizeSelection;
 let syncFuseValuePicker;
 let state;
 
 beforeAll(async () => {
-  ({ populateFuseValues, setFuseTypeSelection, syncFuseValuePicker } = await import(
-    '../js/forms.js',
-  ));
+  ({
+    populateFuseValues,
+    populateGlassSpeedOptions,
+    populateGlassSizeOptions,
+    setFuseTypeSelection,
+    setGlassSpeedSelection,
+    setGlassSizeSelection,
+    syncFuseValuePicker,
+  } = await import('../js/forms.js'));
   ({ state } = await import('../js/state.js'));
 });
 
@@ -311,7 +355,9 @@ beforeEach(() => {
   mockGlassSizeField.classList.toggle.mockClear();
   mockGlassSpeedSelect.value = '';
   mockGlassSpeedSelect.disabled = false;
+  mockGlassSpeedSelect.options = cloneOptions(baseGlassSpeedOptions);
   mockGlassSizeSelect.value = '';
+  mockGlassSizeSelect.options = cloneOptions(baseGlassSizeOptions);
   mockGlassSpeedPicker.classList.toggle.mockClear();
   mockGlassSizePicker.classList.toggle.mockClear();
   mockGlassSpeedPickerButton.disabled = false;
@@ -465,6 +511,78 @@ describe('fuse type selection behaviour', () => {
     expect(mockGlassSpeedSelect.disabled).toBe(false);
     expect(mockGlassSpeedSelect.value).toBe('Slow-blow');
     expect(mockGlassSpeedPickerButton.disabled).toBe(false);
+  });
+});
+
+describe('glass fuse pickers', () => {
+  it('includes the placeholder entry in the glass speed picker list', () => {
+    populateGlassSpeedOptions();
+
+    expect(mockGlassSpeedPickerList.items).toHaveLength(baseGlassSpeedOptions.length);
+    const placeholderItem = mockGlassSpeedPickerList.items[0];
+    expect(placeholderItem.dataset.value).toBe('');
+    const labelSpan = placeholderItem.children.find(
+      child => child.className === 'bolt-drive-picker__option-label',
+    );
+    expect(labelSpan && labelSpan.textContent).toBe(NBSP);
+  });
+
+  it('includes the placeholder entry in the glass size picker list', () => {
+    populateGlassSizeOptions();
+
+    expect(mockGlassSizePickerList.items).toHaveLength(baseGlassSizeOptions.length);
+    const placeholderItem = mockGlassSizePickerList.items[0];
+    expect(placeholderItem.dataset.value).toBe('');
+    const labelSpan = placeholderItem.children.find(
+      child => child.className === 'bolt-drive-picker__option-label',
+    );
+    expect(labelSpan && labelSpan.textContent).toBe(NBSP);
+  });
+
+  it('allows clearing the glass speed selection using the placeholder option', () => {
+    populateGlassSpeedOptions();
+
+    setGlassSpeedSelection('Slow-blow', { triggerUpdate: false });
+    expect(state.glassSpeed).toBe('Slow-blow');
+    expect(mockGlassSpeedPickerLabel.textContent).toBe('Slow-blow');
+
+    const placeholderItem = mockGlassSpeedPickerList.items.find(item => item.dataset.value === '');
+    expect(placeholderItem).toBeDefined();
+    const placeholder = placeholderItem;
+
+    mockGlassSpeedPickerIcon.classList.toggle.mockClear();
+    placeholder.classList.toggle.mockClear();
+
+    setGlassSpeedSelection('', { triggerUpdate: false });
+
+    expect(state.glassSpeed).toBe('');
+    expect(mockGlassSpeedPickerLabel.textContent).toBe(NBSP);
+    expect(mockGlassSpeedPickerIcon.classList.toggle).toHaveBeenCalledWith('is-empty', true);
+    expect(placeholder.attributes['aria-selected']).toBe('true');
+    expect(placeholder.classList.toggle).toHaveBeenCalledWith('is-selected', true);
+  });
+
+  it('allows clearing the glass size selection using the placeholder option', () => {
+    populateGlassSizeOptions();
+
+    setGlassSizeSelection('5 × 20 mm', { triggerUpdate: false });
+    expect(state.glassSize).toBe('5 × 20 mm');
+    expect(mockGlassSizePickerLabel.textContent).toBe('5 × 20 mm');
+
+    const placeholderItem = mockGlassSizePickerList.items.find(item => item.dataset.value === '');
+    expect(placeholderItem).toBeDefined();
+    const placeholder = placeholderItem;
+
+    mockGlassSizePickerIcon.classList.toggle.mockClear();
+    placeholder.classList.toggle.mockClear();
+
+    setGlassSizeSelection('', { triggerUpdate: false });
+
+    expect(state.glassSize).toBe('');
+    expect(mockGlassSizePickerLabel.textContent).toBe(NBSP);
+    expect(mockGlassSizePickerIcon.classList.toggle).toHaveBeenCalledWith('is-empty', true);
+    expect(placeholder.attributes['aria-selected']).toBe('true');
+    expect(placeholder.classList.toggle).toHaveBeenCalledWith('is-selected', true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add placeholder options to the glass fuse pickers so the blank entry appears in the listbox
- keep the picker button label/icon in sync when the placeholder is selected
- expand the forms test suite to cover clearing the glass speed and size selections

## Testing
- node --test test/forms.test.js *(fails: Cannot find package '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68e4efa372d48329911fc1b4641e21e6