### PR TITLE
Update glass fuse size label to new measurement format

### DIFF
--- a/index.html
+++ b/index.html
@@ -1415,8 +1415,8 @@
                         <select id="glass-size-select" class="visually-hidden">
                           <option value="">&nbsp;</option>
                           <option value="5 × 20 mm">5 × 20 mm</option>
-                          <option value="6.3 × 32 mm (1/4″ × 1-1/4″)">
-                            6.3 × 32 mm (1/4″ × 1-1/4″)
+                          <option value="6.3 × 32 mm">
+                            6.3 × 32 mm
                           </option>
                         </select>
                         <button

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -94,7 +94,7 @@ const baseGlassSpeedOptions = [
 const baseGlassSizeOptions = [
   { value: '', textContent: NBSP },
   { value: '5 × 20 mm', textContent: '5 × 20 mm' },
-  { value: '6.3 × 32 mm (1/4″ × 1-1/4″)', textContent: '6.3 × 32 mm (1/4″ × 1-1/4″)' },
+  { value: '6.3 × 32 mm', textContent: '6.3 × 32 mm' },
 ];
 
 const cloneOptions = options => options.map(option => ({ ...option }));
@@ -484,7 +484,7 @@ describe('fuse type selection behaviour', () => {
 
   it('hides and clears the glass options when switching to blade fuses', () => {
     state.fuseType = 'Panel Mount Fuse Holder';
-    state.glassSize = '6.3 × 32 mm (1/4″ × 1-1/4″)';
+    state.glassSize = '6.3 × 32 mm';
     mockGlassSizeSelect.value = state.glassSize;
     state.glassSpeed = 'Slow-blow';
 

--- a/test/renderFuseText.test.js
+++ b/test/renderFuseText.test.js
@@ -61,11 +61,11 @@ describe('buildTextLinesForTest', () => {
   it('includes the selected glass size for panel mount holders', () => {
     state.fuseType = 'Panel Mount Fuse Holder';
     state.fuseValue = '';
-    state.glassSize = '6.3 × 32 mm (1/4″ × 1-1/4″)';
+    state.glassSize = '6.3 × 32 mm';
 
     const lines = buildTextLinesForTest();
 
-    expect(lines.line2).toBe('Panel Mount Fuse Holder — 6.3 × 32 mm (1/4″ × 1-1/4″)');
+    expect(lines.line2).toBe('Panel Mount Fuse Holder — 6.3 × 32 mm');
   });
 
   it('still appends the suffix when it is missing', () => {


### PR DESCRIPTION
## Summary
- update the glass fuse size picker option text to read 6.3 × 32 mm
- align test fixtures and expectations with the new size label
- confirm fuse text rendering continues to concatenate the updated size cleanly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4f635a7a4832995a9dcb03709116e